### PR TITLE
fix(pm): .include uses chai value semantics, not substring matching

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4398,6 +4398,112 @@ mod tests {
     }
 
     #[test]
+    fn test_eql_typed_and_circular_values_compare_by_value() {
+        // Backlog line 85: Date/Set/Map/RegExp collapsed to Object.keys() = []
+        // so ANY two instances compared equal (pm.expect(new Date(1))
+        // .to.eql(new Date(2)) passed). They now compare by value; circular
+        // structures no longer overflow the stack. The same fix landed in all
+        // three deep-equal implementations (pm.js deepEqual, chai-shim
+        // jsDeepEqual, lodash-shim isEqualDeep) — this test locks all three.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
+                .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/lodash/lodash-shim.js"))
+                .expect("lodash shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__r = {};
+                function trial(key, fn) {
+                    globalThis.__r[key] = String((function () {
+                        try { fn(); return true; }
+                        catch (e) { return e.name === 'RangeError' ? 'stack-overflow' : 'threw'; }
+                    })());
+                }
+                trial('pm_date_same', function () { pm.expect(new Date(1700000000000)).to.eql(new Date(1700000000000)); });
+                trial('pm_date_diff', function () { pm.expect(new Date(1700000000000)).to.eql(new Date(1)); });
+                trial('pm_re_same', function () { pm.expect(/a+b/i).to.eql(/a+b/i); });
+                trial('pm_re_flags', function () { pm.expect(/a+b/i).to.eql(/a+b/g); });
+                trial('pm_set_order', function () { pm.expect(new Set([1, 2, 3])).to.eql(new Set([3, 1, 2])); });
+                trial('pm_set_diff', function () { pm.expect(new Set([1, 2])).to.eql(new Set([1, 3])); });
+                trial('pm_map_same', function () { pm.expect(new Map([['a', 1]])).to.eql(new Map([['a', 1]])); });
+                trial('pm_map_diff', function () { pm.expect(new Map([['a', 1]])).to.eql(new Map([['a', 2]])); });
+                trial('pm_cycle_same', function () {
+                    var a = { x: 1 }; a.self = a;
+                    var b = { x: 1 }; b.self = b;
+                    pm.expect(a).to.eql(b);
+                });
+                trial('pm_cycle_diff', function () {
+                    var a = { x: 1 }; a.self = a;
+                    var b = { x: 1 }; b.self = {};
+                    pm.expect(a).to.eql(b);
+                });
+                trial('chai_set_same', function () { chai.expect(new Set([1])).to.eql(new Set([1])); });
+                trial('chai_set_diff', function () { chai.expect(new Set([1])).to.eql(new Set([9])); });
+                trial('lodash_date_same', function () {
+                    if (!_.isEqual(new Date(1700000000000), new Date(1700000000000))) throw new Error('not equal');
+                });
+                trial('lodash_date_diff', function () {
+                    if (_.isEqual(new Date(1), new Date(2))) throw new Error('equal');
+                });
+                trial('lodash_cycle', function () {
+                    var a = { x: 1 }; a.self = a;
+                    if (!_.isEqual(a, a)) throw new Error('not equal');
+                });
+                trial('pm_map_self', function () {
+                    var m = new Map(); m.set('self', m);
+                    var m2 = new Map(); m2.set('self', m2);
+                    pm.expect(m).to.eql(m2);
+                });
+                trial('pm_map_self_diff', function () {
+                    var m = new Map(); m.set('self', m);
+                    var m2 = new Map(); m2.set('self', {});
+                    pm.expect(m).to.eql(m2);
+                });
+                trial('pm_set_self', function () {
+                    var s = new Set(); s.add(s);
+                    var s2 = new Set(); s2.add(s2);
+                    pm.expect(s).to.eql(s2);
+                });
+                trial('pm_map_key_diff', function () {
+                    // Same-size self-referential Maps with different keys: must
+                    // exercise the guarded mate-matching failure pop (not the
+                    // instanceof type-check short-circuit).
+                    var m = new Map(); m.set('a', m);
+                    var m2 = new Map(); m2.set('b', m2);
+                    pm.expect(m).to.eql(m2);
+                });
+                "#,
+            )
+            .expect("script should eval");
+
+            let r = |k: &str| ctx.eval::<String, _>(format!("__r['{}']", k)).unwrap();
+            assert_eq!(r("pm_date_same"), "true", "equal Dates must eql");
+            assert_eq!(r("pm_date_diff"), "threw", "different Dates must NOT eql");
+            assert_eq!(r("pm_re_same"), "true", "same RegExp source+flags must eql");
+            assert_eq!(r("pm_re_flags"), "threw", "differing RegExp flags must NOT eql");
+            assert_eq!(r("pm_set_order"), "true", "Sets are order-insensitive");
+            assert_eq!(r("pm_set_diff"), "threw", "differing Set members must NOT eql");
+            assert_eq!(r("pm_map_same"), "true", "Maps with equal entries must eql");
+            assert_eq!(r("pm_map_diff"), "threw", "differing Map values must NOT eql");
+            assert_eq!(r("pm_cycle_same"), "true", "circular equal structures must eql");
+            assert_eq!(r("pm_cycle_diff"), "threw", "circular differing structures must throw, not overflow");
+            assert_eq!(r("chai_set_same"), "true", "chai: equal Sets must eql");
+            assert_eq!(r("chai_set_diff"), "threw", "chai: differing Sets must NOT eql");
+            assert_eq!(r("lodash_date_same"), "true", "lodash: equal Dates are isEqual");
+            assert_eq!(r("lodash_date_diff"), "true", "lodash: differing Dates are not isEqual");
+            assert_eq!(r("lodash_cycle"), "true", "lodash: circular self-equality must not overflow");
+            assert_eq!(r("pm_map_self"), "true", "self-referential Maps must eql without stack overflow");
+            assert_eq!(r("pm_map_self_diff"), "threw", "differing self-referential Map values must NOT eql");
+            assert_eq!(r("pm_set_self"), "true", "self-referential Sets must eql without stack overflow");
+            assert_eq!(r("pm_map_key_diff"), "threw", "same-size self-referential Maps with different keys must NOT eql");
+        });
+    }
+
+    #[test]
     fn test_unimplemented_assertion_properties_fail_closed() {
         // Backlog §1 P0: unimplemented assertion PROPERTIES (pm.expect(false)
         // .to.be.true, .to.be.null/.undefined/.ok/.empty, pm.expect(null)

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4504,6 +4504,77 @@ mod tests {
     }
 
     #[test]
+    fn test_to_not_chain_matches_not_to() {
+        // Backlog line 87: Postman snippets emit `pm.expect(x).to.not.*`
+        // (negation AFTER .to), but only `.not.to.*` existed — the to.not
+        // spelling read as `unknown assertion property 'not'` and recorded
+        // FAIL while chai.expect handled it fine. Both spellings now share
+        // one negated chain.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__r = {};
+                function trial(key, fn) {
+                    globalThis.__r[key] = String((function () {
+                        try { fn(); return true; }
+                        catch (e) { return e.name === 'RangeError' ? 'stack-overflow' : 'threw'; }
+                    })());
+                }
+                // .to.not.* (Postman's spelling) — pass when values differ.
+                trial('to_not_equal_diff', function () { pm.expect(1).to.not.equal(2); });
+                trial('to_not_equal_same', function () { pm.expect(1).to.not.equal(1); });
+                trial('to_not_eql_diff', function () { pm.expect({ a: 1 }).to.not.eql({ b: 2 }); });
+                trial('to_not_eql_same', function () { pm.expect({ a: 1 }).to.not.eql({ a: 1 }); });
+                trial('to_not_be_true_neg', function () { pm.expect(false).to.not.be.true; });
+                trial('to_not_be_true_pos', function () { pm.expect(true).to.not.be.true; });
+                trial('to_not_be_an_neg', function () { pm.expect('x').to.not.be.an('number'); });
+                trial('to_not_be_an_pos', function () { pm.expect(1).to.not.be.an('number'); });
+                trial('to_not_be_a_neg', function () { pm.expect(1).to.not.be.a('string'); });
+                // Negated include/match/have (Postman's "must not contain").
+                trial('to_not_include_absent', function () { pm.expect('abcdef').to.not.include('zzz'); });
+                trial('to_not_include_present', function () { pm.expect('abcdef').to.not.include('bcd'); });
+                trial('to_not_match_no', function () { pm.expect('abcdef').to.not.match(/zzz/); });
+                trial('to_not_match_yes', function () { pm.expect('abcdef').to.not.match(/bcd/); });
+                trial('to_not_have_prop_absent', function () { pm.expect({ a: 1 }).to.not.have.property('b'); });
+                trial('to_not_have_prop_present', function () { pm.expect({ a: 1 }).to.not.have.property('a'); });
+                // Old spelling must still work.
+                trial('not_to_equal_same', function () { pm.expect(1).not.to.equal(1); });
+                trial('not_to_be_true_pos', function () { pm.expect(true).not.to.be.true; });
+                // Guard still applies on the negated chains.
+                trial('to_not_unknown', function () { pm.expect(1).to.not.bogus; });
+                trial('not_to_unknown', function () { pm.expect(1).not.to.bogus; });
+                "#,
+            )
+            .expect("script should eval");
+
+            let r = |k: &str| ctx.eval::<String, _>(format!("__r['{}']", k)).unwrap();
+            assert_eq!(r("to_not_equal_diff"), "true", "to.not.equal passes when values differ");
+            assert_eq!(r("to_not_equal_same"), "threw", "to.not.equal throws when values match");
+            assert_eq!(r("to_not_eql_diff"), "true", "to.not.eql passes when values differ");
+            assert_eq!(r("to_not_eql_same"), "threw", "to.not.eql throws when values deep-match");
+            assert_eq!(r("to_not_be_true_neg"), "true", "to.not.be.true passes for false");
+            assert_eq!(r("to_not_be_true_pos"), "threw", "to.not.be.true throws for true");
+            assert_eq!(r("to_not_be_an_neg"), "true", "to.not.be.an passes on wrong type");
+            assert_eq!(r("to_not_be_an_pos"), "threw", "to.not.be.an throws on matching type");
+            assert_eq!(r("to_not_be_a_neg"), "true", "to.not.be.a passes on wrong type");
+            assert_eq!(r("to_not_include_absent"), "true", "to.not.include passes when value absent");
+            assert_eq!(r("to_not_include_present"), "threw", "to.not.include throws when value present");
+            assert_eq!(r("to_not_match_no"), "true", "to.not.match passes when no match");
+            assert_eq!(r("to_not_match_yes"), "threw", "to.not.match throws when matched");
+            assert_eq!(r("to_not_have_prop_absent"), "true", "to.not.have.property passes when absent");
+            assert_eq!(r("to_not_have_prop_present"), "threw", "to.not.have.property throws when present");
+            assert_eq!(r("not_to_equal_same"), "threw", "not.to.equal still throws when values match");
+            assert_eq!(r("not_to_be_true_pos"), "threw", "not.to.be.true still throws for true");
+            assert_eq!(r("to_not_unknown"), "threw", "unknown property on to.not throws");
+            assert_eq!(r("not_to_unknown"), "threw", "unknown property on not.to throws");
+        });
+    }
+
+    #[test]
     fn test_unimplemented_assertion_properties_fail_closed() {
         // Backlog §1 P0: unimplemented assertion PROPERTIES (pm.expect(false)
         // .to.be.true, .to.be.null/.undefined/.ok/.empty, pm.expect(null)

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4575,6 +4575,72 @@ mod tests {
     }
 
     #[test]
+    fn test_include_uses_chai_value_semantics() {
+        // Backlog line 88: pm.expect(arr).to.include(v) was a SUBSTRING test
+        // (String(arr).indexOf) — [11,22].include(1) passed and
+        // {a:1}.include('object') passed. chai-shim implements it correctly
+        // (array indexOf for arrays, `key in obj` for objects). pm now
+        // mirrors chai: substring for strings, element membership for
+        // arrays, key membership for objects — on BOTH the positive chain
+        // and the negated chain.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
+                .expect("chai shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__r = {};
+                function trial(key, fn) {
+                    globalThis.__r[key] = String((function () {
+                        try { fn(); return true; }
+                        catch (e) { return e.name === 'RangeError' ? 'stack-overflow' : 'threw'; }
+                    })());
+                }
+                // Arrays: element membership, not substring.
+                trial('pm_arr_include_yes', function () { pm.expect([11, 22]).to.include(22); });
+                trial('pm_arr_include_no', function () { pm.expect([11, 22]).to.include(1); });
+                trial('pm_arr_include_str', function () { pm.expect(['a', 'b']).to.include('b'); });
+                trial('pm_arr_include_str_no', function () { pm.expect(['a', 'b']).to.include('ab'); });
+                // Objects: key membership.
+                trial('pm_obj_include_key', function () { pm.expect({ a: 1 }).to.include('a'); });
+                trial('pm_obj_include_nokey', function () { pm.expect({ a: 1 }).to.include('object'); });
+                // Strings stay substring.
+                trial('pm_str_include_yes', function () { pm.expect('abcdef').to.include('bcd'); });
+                trial('pm_str_include_no', function () { pm.expect('abcdef').to.include('zzz'); });
+                // Negated chain mirrors the same semantics.
+                trial('pm_arr_not_include_yes', function () { pm.expect([11, 22]).to.not.include(1); });
+                trial('pm_arr_not_include_no', function () { pm.expect([11, 22]).to.not.include(22); });
+                // chai parity: both expect()s must agree.
+                trial('chai_arr_include_yes', function () { chai.expect([11, 22]).to.include(22); });
+                trial('chai_arr_include_no', function () { chai.expect([11, 22]).to.include(1); });
+                trial('chai_obj_include_key', function () { chai.expect({ a: 1 }).to.include('a'); });
+                trial('chai_obj_include_nokey', function () { chai.expect({ a: 1 }).to.include('object'); });
+                "#,
+            )
+            .expect("script should eval");
+
+            let r = |k: &str| ctx.eval::<String, _>(format!("__r['{}']", k)).unwrap();
+            assert_eq!(r("pm_arr_include_yes"), "true", "array include passes for a present element");
+            assert_eq!(r("pm_arr_include_no"), "threw", "array include must NOT match substrings (11.include(1) was the bug)");
+            assert_eq!(r("pm_arr_include_str"), "true", "string-array include passes for a present member");
+            assert_eq!(r("pm_arr_include_str_no"), "threw", "string-array include must not substring-match ('ab' not in ['a','b'])");
+            assert_eq!(r("pm_obj_include_key"), "true", "object include passes for a present key");
+            assert_eq!(r("pm_obj_include_nokey"), "threw", "object include must test keys, not type names ('object' was the bug)");
+            assert_eq!(r("pm_str_include_yes"), "true", "string include still substring-tests");
+            assert_eq!(r("pm_str_include_no"), "threw", "string include throws when absent");
+            assert_eq!(r("pm_arr_not_include_yes"), "true", "negated array include passes for an absent element");
+            assert_eq!(r("pm_arr_not_include_no"), "threw", "negated array include throws for a present element");
+            assert_eq!(r("chai_arr_include_yes"), "true", "chai array include agrees (element present)");
+            assert_eq!(r("chai_arr_include_no"), "threw", "chai array include agrees (substring must not match)");
+            assert_eq!(r("chai_obj_include_key"), "true", "chai object include agrees (key present)");
+            assert_eq!(r("chai_obj_include_nokey"), "threw", "chai object include agrees (key test)");
+        });
+    }
+
+    #[test]
     fn test_unimplemented_assertion_properties_fail_closed() {
         // Backlog §1 P0: unimplemented assertion PROPERTIES (pm.expect(false)
         // .to.be.true, .to.be.null/.undefined/.ok/.empty, pm.expect(null)

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -7,27 +7,124 @@ var chai = chai || {};
 
 (function () {
     // Proper JS deep-equal (handles NaN, undefined, key-order)
-    function jsDeepEqual(a, b) {
+    // Backlog line 85: Date/Set/Map/RegExp used to collapse to
+    // Object.keys() = [] — ANY two instances compared equal
+    // (chai.expect(new Set([1])).to.eql(new Set([9])) passed). They now
+    // compare by VALUE (time for Date, source+flags for RegExp, size +
+    // order-insensitive entries for Map/Set). Circular structures no longer
+    // overflow the stack (seen-pair guard: revisiting the exact (a,b) pair
+    // mid-compare is assumed equal).
+    function jsDeepEqual(a, b, seen) {
         if (a === b) return true;
         if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
         if (a === null || b === null || a === undefined || b === undefined) return a === b;
         if (typeof a !== typeof b) return false;
+        // Date: compare by epoch time; two invalid dates compare equal.
+        if (a instanceof Date || b instanceof Date) {
+            if (!(b instanceof Date)) return false;
+            var ta = a.getTime(), tb = b.getTime();
+            return (isNaN(ta) && isNaN(tb)) || ta === tb;
+        }
+        // RegExp: source + flags.
+        if (a instanceof RegExp || b instanceof RegExp) {
+            if (!(b instanceof RegExp)) return false;
+            return a.source === b.source && a.flags === b.flags;
+        }
         if (Array.isArray(a)) {
             if (!Array.isArray(b) || a.length !== b.length) return false;
-            for (var i = 0; i < a.length; i++) {
-                if (!jsDeepEqual(a[i], b[i])) return false;
+            seen = seen || [];
+            for (var s = 0; s < seen.length; s++) {
+                if (seen[s][0] === a && seen[s][1] === b) return true;
             }
+            seen.push([a, b]);
+            for (var i = 0; i < a.length; i++) {
+                if (!jsDeepEqual(a[i], b[i], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
             return true;
         }
         if (typeof a === 'object') {
             if (Array.isArray(b) || b === null || b === undefined) return false;
+            // Map: same size, each entry's key+value finds a deep-equal mate
+            // (order-insensitive).
+            if (a instanceof Map || b instanceof Map) {
+                if (!(b instanceof Map) || a.size !== b.size) return false;
+                // Cycle guard: Map nodes can be self-referential; revisiting the
+                // exact (a, b) pair mid-compare is assumed equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aEntries = Array.from(a.entries());
+                var bEntries = Array.from(b.entries());
+                var usedB = [];
+                outer:
+                for (var mi = 0; mi < aEntries.length; mi++) {
+                    for (var mj = 0; mj < bEntries.length; mj++) {
+                        if (usedB[mj]) continue;
+                        if (jsDeepEqual(aEntries[mi][0], bEntries[mj][0], seen) &&
+                            jsDeepEqual(aEntries[mi][1], bEntries[mj][1], seen)) {
+                            usedB[mj] = true;
+                            continue outer;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Set: same size, each member finds a deep-equal mate.
+            if (a instanceof Set || b instanceof Set) {
+                if (!(b instanceof Set) || a.size !== b.size) return false;
+                // Cycle guard: Set nodes can be self-referential; revisiting the
+                // exact (a, b) pair mid-compare is assumed equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aMembers = Array.from(a);
+                var bMembers = Array.from(b);
+                var usedS = [];
+                outer2:
+                for (var si = 0; si < aMembers.length; si++) {
+                    for (var sj = 0; sj < bMembers.length; sj++) {
+                        if (usedS[sj]) continue;
+                        if (jsDeepEqual(aMembers[si], bMembers[sj], seen)) {
+                            usedS[sj] = true;
+                            continue outer2;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Plain object: key-set comparison with a cycle guard.
+            seen = seen || [];
+            for (var k = 0; k < seen.length; k++) {
+                if (seen[k][0] === a && seen[k][1] === b) return true;
+            }
+            seen.push([a, b]);
             var keysA = Object.keys(a).sort();
             var keysB = Object.keys(b).sort();
-            if (keysA.length !== keysB.length) return false;
-            for (var i = 0; i < keysA.length; i++) {
-                if (keysA[i] !== keysB[i]) return false;
-                if (!jsDeepEqual(a[keysA[i]], b[keysB[i]])) return false;
+            if (keysA.length !== keysB.length) {
+                seen.pop();
+                return false;
             }
+            for (var j = 0; j < keysA.length; j++) {
+                if (keysA[j] !== keysB[j] || !jsDeepEqual(a[keysA[j]], b[keysB[j]], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
             return true;
         }
         return a === b;
@@ -40,6 +137,14 @@ var chai = chai || {};
             if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
             if (a === b) return true;
             if (a === null || a === undefined || b === null || b === undefined) return a === b;
+            // Backlog line 85: JSON.stringify collapses Date/Set/Map/RegExp
+            // (Date → ISO string, others → "{}") so typed values must never
+            // go through the string bridge — the JS impl compares them by
+            // value.
+            if (a instanceof Date || a instanceof RegExp || a instanceof Set || a instanceof Map ||
+                b instanceof Date || b instanceof RegExp || b instanceof Set || b instanceof Map) {
+                return jsDeepEqual(a, b);
+            }
             return __tropel_native_deep_equal(JSON.stringify(a), JSON.stringify(b));
         }
         : jsDeepEqual;

--- a/js/lodash/lodash-shim.js
+++ b/js/lodash/lodash-shim.js
@@ -470,27 +470,123 @@ var _ = _ || {};
         return deep(value);
     };
 
-    function isEqualDeep(a, b) {
+    // Backlog line 85: Date/Set/Map/RegExp used to collapse to
+    // Object.keys() = [] — ANY two instances compared equal. They now
+    // compare by VALUE (time for Date, source+flags for RegExp, size +
+    // order-insensitive entries for Map/Set). Circular structures no longer
+    // overflow the stack (seen-pair guard: revisiting the exact (a,b) pair
+    // mid-compare is assumed equal).
+    function isEqualDeep(a, b, seen) {
         if (a === b) return true;
         if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
         if (a === null || b === null || a === undefined || b === undefined) return a === b;
         if (typeof a !== typeof b) return false;
+        // Date: compare by epoch time; two invalid dates compare equal.
+        if (a instanceof Date || b instanceof Date) {
+            if (!(b instanceof Date)) return false;
+            var ta = a.getTime(), tb = b.getTime();
+            return (isNaN(ta) && isNaN(tb)) || ta === tb;
+        }
+        // RegExp: source + flags.
+        if (a instanceof RegExp || b instanceof RegExp) {
+            if (!(b instanceof RegExp)) return false;
+            return a.source === b.source && a.flags === b.flags;
+        }
         if (Array.isArray(a)) {
             if (!Array.isArray(b) || a.length !== b.length) return false;
-            for (var i = 0; i < a.length; i++) {
-                if (!isEqualDeep(a[i], b[i])) return false;
+            seen = seen || [];
+            for (var s = 0; s < seen.length; s++) {
+                if (seen[s][0] === a && seen[s][1] === b) return true;
             }
+            seen.push([a, b]);
+            for (var i = 0; i < a.length; i++) {
+                if (!isEqualDeep(a[i], b[i], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
             return true;
         }
         if (typeof a === 'object') {
             if (Array.isArray(b) || b === null || b === undefined) return false;
+            // Map: same size, each entry's key+value finds a deep-equal mate
+            // (order-insensitive).
+            if (a instanceof Map || b instanceof Map) {
+                if (!(b instanceof Map) || a.size !== b.size) return false;
+                // Cycle guard: Map nodes can be self-referential; revisiting the
+                // exact (a, b) pair mid-compare is assumed equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aEntries = Array.from(a.entries());
+                var bEntries = Array.from(b.entries());
+                var usedB = [];
+                outer:
+                for (var mi = 0; mi < aEntries.length; mi++) {
+                    for (var mj = 0; mj < bEntries.length; mj++) {
+                        if (usedB[mj]) continue;
+                        if (isEqualDeep(aEntries[mi][0], bEntries[mj][0], seen) &&
+                            isEqualDeep(aEntries[mi][1], bEntries[mj][1], seen)) {
+                            usedB[mj] = true;
+                            continue outer;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Set: same size, each member finds a deep-equal mate.
+            if (a instanceof Set || b instanceof Set) {
+                if (!(b instanceof Set) || a.size !== b.size) return false;
+                // Cycle guard: Set nodes can be self-referential; revisiting the
+                // exact (a, b) pair mid-compare is assumed equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aMembers = Array.from(a);
+                var bMembers = Array.from(b);
+                var usedS = [];
+                outer2:
+                for (var si = 0; si < aMembers.length; si++) {
+                    for (var sj = 0; sj < bMembers.length; sj++) {
+                        if (usedS[sj]) continue;
+                        if (isEqualDeep(aMembers[si], bMembers[sj], seen)) {
+                            usedS[sj] = true;
+                            continue outer2;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Plain object: key-set comparison with a cycle guard.
+            seen = seen || [];
+            for (var k = 0; k < seen.length; k++) {
+                if (seen[k][0] === a && seen[k][1] === b) return true;
+            }
+            seen.push([a, b]);
             var keysA = Object.keys(a).sort();
             var keysB = Object.keys(b).sort();
-            if (keysA.length !== keysB.length) return false;
-            for (var i = 0; i < keysA.length; i++) {
-                if (keysA[i] !== keysB[i]) return false;
-                if (!isEqualDeep(a[keysA[i]], b[keysB[i]])) return false;
+            if (keysA.length !== keysB.length) {
+                seen.pop();
+                return false;
             }
+            for (var j = 0; j < keysA.length; j++) {
+                if (keysA[j] !== keysB[j] || !isEqualDeep(a[keysA[j]], b[keysB[j]], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
             return true;
         }
         return a === b;
@@ -502,6 +598,14 @@ var _ = _ || {};
             if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
             if (a === b) return true;
             if (a === null || a === undefined || b === null || b === undefined) return a === b;
+            // Backlog line 85: JSON.stringify collapses Date/Set/Map/RegExp
+            // (Date → ISO string, others → "{}") so typed values must never
+            // go through the string bridge — the JS impl compares them by
+            // value.
+            if (a instanceof Date || a instanceof RegExp || a instanceof Set || a instanceof Map ||
+                b instanceof Date || b instanceof RegExp || b instanceof Set || b instanceof Map) {
+                return isEqualDeep(a, b);
+            }
             return __tropel_native_deep_equal(JSON.stringify(a), JSON.stringify(b));
         }
         return isEqualDeep(a, b);

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -821,27 +821,126 @@ function shortJson(v) {
 // key order, nested arrays/objects. Mirrors the jsDeepEqual in
 // js/chai/chai-shim.js — the backlog fix for .eql must not depend on chai
 // being loaded first (pm.js is bundled standalone).
-function deepEqual(a, b) {
+//
+// Backlog line 85: Date/Set/Map/RegExp used to collapse to Object.keys()
+// = [] — ANY two instances compared equal (pm.expect(new Date(1))
+// .to.eql(new Date(999999)) passed). They now compare by VALUE (time for
+// Date, source+flags for RegExp, size + order-insensitive entries for
+// Map/Set). Circular structures no longer overflow the stack (a seen-pair
+// guard: revisiting the exact (a,b) pair mid-compare is assumed equal).
+function deepEqual(a, b, seen) {
     if (a === b) return true;
     if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
     if (a === null || b === null || a === undefined || b === undefined) return a === b;
     if (typeof a !== typeof b) return false;
+    // Date: compare by epoch time; two invalid dates compare equal.
+    if (a instanceof Date || b instanceof Date) {
+        if (!(b instanceof Date)) return false;
+        var ta = a.getTime(), tb = b.getTime();
+        return (isNaN(ta) && isNaN(tb)) || ta === tb;
+    }
+    // RegExp: source + flags.
+    if (a instanceof RegExp || b instanceof RegExp) {
+        if (!(b instanceof RegExp)) return false;
+        return a.source === b.source && a.flags === b.flags;
+    }
     if (Array.isArray(a)) {
         if (!Array.isArray(b) || a.length !== b.length) return false;
-        for (var i = 0; i < a.length; i++) {
-            if (!deepEqual(a[i], b[i])) return false;
+        seen = seen || [];
+        for (var s = 0; s < seen.length; s++) {
+            if (seen[s][0] === a && seen[s][1] === b) return true;
         }
+        seen.push([a, b]);
+        for (var i = 0; i < a.length; i++) {
+            if (!deepEqual(a[i], b[i], seen)) {
+                seen.pop();
+                return false;
+            }
+        }
+        seen.pop();
         return true;
     }
     if (typeof a === 'object') {
         if (Array.isArray(b) || b === null || b === undefined) return false;
+        // Map: same size, each entry's key+value finds a deep-equal mate
+        // (order-insensitive).
+        if (a instanceof Map || b instanceof Map) {
+            if (!(b instanceof Map) || a.size !== b.size) return false;
+            // Cycle guard: Map nodes can be self-referential (a Map whose value
+            // is itself); revisiting the exact (a, b) pair mid-compare is
+            // assumed equal.
+            seen = seen || [];
+            for (var s = 0; s < seen.length; s++) {
+                if (seen[s][0] === a && seen[s][1] === b) return true;
+            }
+            seen.push([a, b]);
+            var aEntries = Array.from(a.entries());
+            var bEntries = Array.from(b.entries());
+            var usedB = [];
+            outer:
+            for (var mi = 0; mi < aEntries.length; mi++) {
+                for (var mj = 0; mj < bEntries.length; mj++) {
+                    if (usedB[mj]) continue;
+                    if (deepEqual(aEntries[mi][0], bEntries[mj][0], seen) &&
+                        deepEqual(aEntries[mi][1], bEntries[mj][1], seen)) {
+                        usedB[mj] = true;
+                        continue outer;
+                    }
+                }
+                seen.pop();
+                return false;
+            }
+            seen.pop();
+            return true;
+        }
+        // Set: same size, each member finds a deep-equal mate.
+        if (a instanceof Set || b instanceof Set) {
+            if (!(b instanceof Set) || a.size !== b.size) return false;
+            // Cycle guard: Set nodes can be self-referential (a Set containing
+            // itself); revisiting the exact (a, b) pair mid-compare is assumed
+            // equal.
+            seen = seen || [];
+            for (var s = 0; s < seen.length; s++) {
+                if (seen[s][0] === a && seen[s][1] === b) return true;
+            }
+            seen.push([a, b]);
+            var aMembers = Array.from(a);
+            var bMembers = Array.from(b);
+            var usedS = [];
+            outer2:
+            for (var si = 0; si < aMembers.length; si++) {
+                for (var sj = 0; sj < bMembers.length; sj++) {
+                    if (usedS[sj]) continue;
+                    if (deepEqual(aMembers[si], bMembers[sj], seen)) {
+                        usedS[sj] = true;
+                        continue outer2;
+                    }
+                }
+                seen.pop();
+                return false;
+            }
+            seen.pop();
+            return true;
+        }
+        // Plain object: key-set comparison with a cycle guard.
+        seen = seen || [];
+        for (var k = 0; k < seen.length; k++) {
+            if (seen[k][0] === a && seen[k][1] === b) return true;
+        }
+        seen.push([a, b]);
         var keysA = Object.keys(a).sort();
         var keysB = Object.keys(b).sort();
-        if (keysA.length !== keysB.length) return false;
-        for (var j = 0; j < keysA.length; j++) {
-            if (keysA[j] !== keysB[j]) return false;
-            if (!deepEqual(a[keysA[j]], b[keysB[j]])) return false;
+        if (keysA.length !== keysB.length) {
+            seen.pop();
+            return false;
         }
+        for (var j = 0; j < keysA.length; j++) {
+            if (keysA[j] !== keysB[j] || !deepEqual(a[keysA[j]], b[keysB[j]], seen)) {
+                seen.pop();
+                return false;
+            }
+        }
+        seen.pop();
         return true;
     }
     return a === b;

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -503,6 +503,67 @@ function addPropAssertions(chain, actual, negated) {
 }
 
 pm.expect = function (actual) {
+    // Negated chain body, shared by both spellings Postman emits
+    // (`not.to.*` and `to.not.*`). Each member THROWS when the positive
+    // holds. Property assertions are installed negated on the chain and its
+    // `be` sub-chain so `to.not.be.true` is guarded too.
+    function buildNegated() {
+        var negated = {
+            eql: function (expected) {
+                if (deepEqual(actual, expected)) {
+                    throw new Error(
+                        'expected ' + shortJson(actual) + ' not to eql ' + shortJson(expected)
+                    );
+                }
+            },
+            equal: function (expected) {
+                if (actual === expected) {
+                    throw new Error(
+                        'expected ' + shortJson(actual) + ' not to equal ' + shortJson(expected)
+                    );
+                }
+            },
+            // Postman emits `to.not.include(...)` for "must not contain".
+            // Mirrored from the positive include (line 88 fixes the positive
+            // path on both chains).
+            include: function (expected) {
+                if (String(actual).indexOf(String(expected)) !== -1) {
+                    throw new Error('expected value not to include ' + shortJson(expected));
+                }
+            },
+            match: function (regex) {
+                if (regex.test(String(actual))) {
+                    throw new Error('expected value not to match ' + regex);
+                }
+            },
+            have: {
+                property: function (prop, value) {
+                    var obj = actual;
+                    var has = obj && (prop in obj);
+                    var passed = has && (value === undefined || obj[prop] === value);
+                    if (passed) {
+                        throw new Error('expected value not to have property ' + prop);
+                    }
+                }
+            },
+            be: {
+                // `pm.expect(x).to.not.be.true` must THROW when the positive
+                // holds (the guard applies here too).
+                an: function (type) {
+                    if (typeOf(actual) === type) {
+                        throw new Error('expected value not to be an ' + type);
+                    }
+                },
+                a: function (type) {
+                    return this.an(type);
+                }
+            }
+        };
+        addPropAssertions(negated, actual, true);
+        addPropAssertions(negated.be, actual, true);
+        return negated;
+    }
+
     var chain = {
         to: {
             // Backlog line 144: chai semantics — .eql is DEEP equality,
@@ -584,49 +645,20 @@ pm.expect = function (actual) {
                 if (!regex.test(String(actual))) {
                     throw new Error('expected value to match ' + regex);
                 }
-            }
+            },
+            // Backlog line 87: Postman snippets emit `to.not.*` — the negated
+            // chain must be reachable from `.to` as well as `.not.to`.
+            not: buildNegated()
         },
         not: {
-            to: {
-                eql: function (expected) {
-                    if (deepEqual(actual, expected)) {
-                        throw new Error(
-                            'expected ' + shortJson(actual) + ' not to eql ' + shortJson(expected)
-                        );
-                    }
-                },
-                equal: function (expected) {
-                    if (actual === expected) {
-                        throw new Error(
-                            'expected ' + shortJson(actual) + ' not to equal ' + shortJson(expected)
-                        );
-                    }
-                },
-                be: {
-                    // Negated property/type assertions:
-                    // `pm.expect(x).not.to.be.true` must THROW when the
-                    // positive holds (the guard applies here too).
-                    an: function (type) {
-                        if (typeOf(actual) === type) {
-                            throw new Error('expected value not to be an ' + type);
-                        }
-                    },
-                    a: function (type) {
-                        return this.an(type);
-                    }
-                }
-            }
+            to: buildNegated()
         }
     };
+
     // Install the property assertions on the chain levels where chai-postman
     // exposes them, then guard the whole chain so ANY unknown name throws.
     addPropAssertions(chain.to, actual);
     addPropAssertions(chain.to.be, actual);
-    // Negated chain: both `not.to.true` and the canonical `not.to.be.true`
-    // must be guarded (the getters live on the `be` object, which is a
-    // SEPARATE literal from `not.to`).
-    addPropAssertions(chain.not.to, actual, true);
-    addPropAssertions(chain.not.to.be, actual, true);
     return guardChain(chain);
 };
 

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -524,10 +524,9 @@ pm.expect = function (actual) {
                 }
             },
             // Postman emits `to.not.include(...)` for "must not contain".
-            // Mirrored from the positive include (line 88 fixes the positive
-            // path on both chains).
+            // Same value-based semantics as the positive include (line 88).
             include: function (expected) {
-                if (String(actual).indexOf(String(expected)) !== -1) {
+                if (includesValue(actual, expected)) {
                     throw new Error('expected value not to include ' + shortJson(expected));
                 }
             },
@@ -586,7 +585,7 @@ pm.expect = function (actual) {
                 }
             },
             include: function (expected) {
-                if (String(actual).indexOf(String(expected)) === -1) {
+                if (!includesValue(actual, expected)) {
                     throw new Error('expected value to include ' + shortJson(expected));
                 }
             },
@@ -976,6 +975,17 @@ function deepEqual(a, b, seen) {
         return true;
     }
     return a === b;
+}
+
+// Backlog line 88: chai's .include semantics — substring for strings,
+// element membership (strict indexOf) for arrays, KEY membership for
+// objects. The old String(container).indexOf(...) made [11,22].include(1)
+// and {a:1}.include('object') pass.
+function includesValue(container, value) {
+    if (typeof container === 'string') return container.indexOf(value) !== -1;
+    if (Array.isArray(container)) return container.indexOf(value) !== -1;
+    if (container !== null && typeof container === 'object') return value in container;
+    return false;
 }
 
 // ── pm.iterationData ──


### PR DESCRIPTION
Backlog V2 §2 line 88: pm.expect(arr).to.include(v) ran String(arr).indexOf(String(v)) — [11,22].include(1) and {a:1}.include('object') both passed, diverging from chai-shim. New includesValue() helper mirrors chai's Assertion.prototype.include (string → substring, array → element indexOf, object → key in obj, else false), wired into both to.include and the negated chain's include. Regression test: 14 cases incl. chai parity; k6 lib 110/110.\n\n**Stacked on PR #10** (fix/87-to-not-chain) because the negated include lives in buildNegated from that branch. Merge #10 first — once merged, this PR's diff resolves to just the include work.