### PR TITLE
fix(distributed): stamp true run_duration in merged results (W0 P0#2)

### DIFF
--- a/crates/tropel-distributed/src/bin/cloud_run.rs
+++ b/crates/tropel-distributed/src/bin/cloud_run.rs
@@ -149,7 +149,8 @@ async fn run(args: Args) -> Result<()> {
             tracing::info!("Controller listening on {listen}. Waiting for {agents} agent(s)...");
             let test_start = std::time::Instant::now();
             let result =
-                tropel_distributed::run_controller(listener, &config, agents, &token).await?;
+                tropel_distributed::run_controller(listener, &config, agents, &token, test_start)
+                    .await?;
             tropel_distributed::report_and_thresholds(&config, &result, test_start).await
         }
         Cmd::Agent {
@@ -173,7 +174,7 @@ async fn run(args: Args) -> Result<()> {
             tracing::info!("Cloud-run local mode: {agents} in-process agent(s)");
             let token = resolve_token(token, token_file).unwrap_or_else(|_| generate_token());
             let test_start = std::time::Instant::now();
-            let result = tropel_distributed::run_cloud(&config, agents, &token).await?;
+            let result = tropel_distributed::run_cloud(&config, agents, &token, test_start).await?;
             tropel_distributed::report_and_thresholds(&config, &result, test_start).await
         }
         Cmd::K8s {

--- a/crates/tropel-distributed/src/bin/controller.rs
+++ b/crates/tropel-distributed/src/bin/controller.rs
@@ -71,7 +71,9 @@ async fn run(args: Args) -> Result<()> {
     );
 
     let test_start = std::time::Instant::now();
-    let result = tropel_distributed::run_controller(listener, &config, args.agents, &token).await?;
+    let result =
+        tropel_distributed::run_controller(listener, &config, args.agents, &token, test_start)
+            .await?;
 
     // Report through the configured reporters + evaluate thresholds
     // (exit-code contract shared with `tropel-cloud-run`).

--- a/crates/tropel-distributed/src/cloud.rs
+++ b/crates/tropel-distributed/src/cloud.rs
@@ -49,7 +49,12 @@ const JOB_BACKOFF_LIMIT: u64 = 3;
 /// This is the "cloud-run" mode: `tropel-cloud-run local --config job.json
 /// --agents N`. The caller (CLI) reports the merged result and evaluates
 /// thresholds, mirroring the controller binary's tail.
-pub async fn run_cloud(config: &JobConfig, agents: u32, token: &str) -> Result<MetricsResult> {
+pub async fn run_cloud(
+    config: &JobConfig,
+    agents: u32,
+    token: &str,
+    test_start: std::time::Instant,
+) -> Result<MetricsResult> {
     if agents == 0 {
         return Err(TropelError::Config("--agents must be >= 1".into()));
     }
@@ -75,7 +80,7 @@ pub async fn run_cloud(config: &JobConfig, agents: u32, token: &str) -> Result<M
     // with a job-bounded timeout — a hung agent fails the run, not the host.
     // On error, abort the in-process agents so no detached tasks keep running
     // the load engine in the background before propagating.
-    let merged = match run_controller(listener, config, agents, &token).await {
+    let merged = match run_controller(listener, config, agents, &token, test_start).await {
         Ok(m) => m,
         Err(e) => {
             for h in &handles {
@@ -402,7 +407,7 @@ mod tests {
             ..Default::default()
         };
 
-        let merged = run_cloud(&config, 2, "test-token").await?;
+        let merged = run_cloud(&config, 2, "test-token", std::time::Instant::now()).await?;
         assert_eq!(
             merged.http_reqs, 4,
             "merged http_reqs = 4: {}",

--- a/crates/tropel-distributed/src/controller.rs
+++ b/crates/tropel-distributed/src/controller.rs
@@ -33,6 +33,7 @@ pub async fn run_controller(
     config: &JobConfig,
     num_agents: u32,
     token: &str,
+    test_start: std::time::Instant,
 ) -> Result<MetricsResult> {
     if num_agents == 0 {
         return Err(TropelError::Config("--agents must be >= 1".into()));
@@ -192,7 +193,10 @@ pub async fn run_controller(
     tracing::info!("Controller: all {num_agents} agents done — merging losslessly");
     // A corrupt histogram (bad base64 / truncated V2 bytes) fails the merge
     // loudly instead of silently fabricating results from a partial set.
-    merge_snapshots(snapshots, config.thresholds.clone())
+    // W0 P0#2: test_start is the controller-side wall clock recorded by the
+    // CLI before dispatch — merge_snapshots stamps run_duration from it so a
+    // distributed run reports the true duration, not the merge instant.
+    merge_snapshots(snapshots, config.thresholds.clone(), test_start)
 }
 
 /// Read an agent's snapshot frame (drain any prior frames defensively).
@@ -323,8 +327,9 @@ mod tests {
         let addr_str = addr.to_string();
         let cfg = config.clone();
 
-        let controller =
-            tokio::spawn(async move { run_controller(listener, &cfg, 2, "test-token").await });
+        let controller = tokio::spawn(async move {
+            run_controller(listener, &cfg, 2, "test-token", std::time::Instant::now()).await
+        });
         let mut agents = Vec::new();
         for _ in 0..2 {
             let a = addr_str.clone();
@@ -388,9 +393,15 @@ mod tests {
         };
         let listener = TokioListener::bind("127.0.0.1:0").await.unwrap();
         // 3 boundaries in the sequence vs --agents 2 → hard error, no hang.
-        let err = run_controller(listener, &config, 2, "test-token")
-            .await
-            .unwrap_err();
+        let err = run_controller(
+            listener,
+            &config,
+            2,
+            "test-token",
+            std::time::Instant::now(),
+        )
+        .await
+        .unwrap_err();
         assert!(err.to_string().contains("boundaries"));
     }
 
@@ -420,8 +431,9 @@ mod tests {
         let addr_str = listener.local_addr().unwrap().to_string();
         let cfg = config.clone();
 
-        let controller =
-            tokio::spawn(async move { run_controller(listener, &cfg, 1, "right-token").await });
+        let controller = tokio::spawn(async move {
+            run_controller(listener, &cfg, 1, "right-token", std::time::Instant::now()).await
+        });
         let agent =
             tokio::spawn(async move { crate::agent::run_agent(&addr_str, "wrong-token").await });
 

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1402,9 +1402,16 @@ pub struct MetricsSnapshot {
 /// script-declared thresholds shipped in the snapshot (e.g. k6
 /// `options.thresholds`); the job config wins on key collisions. Trend stats
 /// are inherited from the workers.
+///
+/// `test_start` is the controller-side run start (the wall clock the CLI
+/// records before dispatching agents). The merged result's `run_duration` is
+/// stamped from it — W0 P0#2: a fresh `Aggregator::new()` here stamps
+/// `started = now` (the MERGE instant), so a 600s run used to report
+/// run_duration = the ~50ms merge time, computing ~20,000,000 req/s.
 pub fn merge_snapshots(
     snapshots: Vec<MetricsSnapshot>,
     thresholds: std::collections::HashMap<String, tropel_core::config::ThresholdConfig>,
+    test_start: Instant,
 ) -> Result<MetricsResult> {
     // Script-declared thresholds ride back in each worker's snapshot; overlay
     // them on the controller's job-level set so they are not discarded.
@@ -1430,7 +1437,14 @@ pub fn merge_snapshots(
     for snap in &snapshots {
         agg.absorb_snapshot(snap)?;
     }
-    Ok(agg.build_results())
+    let mut result = agg.build_results();
+    // W0 P0#2: the fresh Aggregator's `started` is the merge instant, so
+    // build_results stamps run_duration = merge time. Override with the
+    // true controller-side wall clock before any reporter or threshold sees
+    // it — otherwise a 600s distributed run reports ~50ms and every
+    // per-second rate / threshold is ~12,000× inflated.
+    result.run_duration = test_start.elapsed();
+    Ok(result)
 }
 
 /// Build the Trend-typed `MetricSummary` shared by all five construction
@@ -1939,7 +1953,8 @@ mod tests {
             summary_trend_stats: worker_stats.clone(),
             thresholds: snap_thresholds,
         };
-        let result = merge_snapshots(vec![snap], std::collections::HashMap::new()).expect("merge");
+        let result = merge_snapshots(vec![snap], std::collections::HashMap::new(), Instant::now())
+            .expect("merge");
         // The worker's declaration must be adopted, NOT the k6 defaults.
         assert_eq!(result.summary_trend_stats, worker_stats);
         // The p(75) declaration implies histograms are retained for exactness.
@@ -1959,8 +1974,12 @@ mod tests {
             summary_trend_stats: vec![],
             ..with_stats.clone()
         };
-        let result2 = merge_snapshots(vec![empty, with_stats], std::collections::HashMap::new())
-            .expect("merge");
+        let result2 = merge_snapshots(
+            vec![empty, with_stats],
+            std::collections::HashMap::new(),
+            Instant::now(),
+        )
+        .expect("merge");
         assert_eq!(result2.summary_trend_stats, vec!["p(99.9)".to_string()]);
     }
 
@@ -2583,7 +2602,8 @@ mod tests {
             summary_trend_stats: k6_default_trend_stats(),
             thresholds: HashMap::new(),
         };
-        let err = merge_snapshots(vec![snap], std::collections::HashMap::new()).unwrap_err();
+        let err = merge_snapshots(vec![snap], std::collections::HashMap::new(), Instant::now())
+            .unwrap_err();
         assert!(
             err.to_string().contains("http_req_duration"),
             "error must name the metric: {err}"
@@ -2616,7 +2636,8 @@ mod tests {
             summary_trend_stats: k6_default_trend_stats(),
             thresholds: HashMap::new(),
         };
-        let err = merge_snapshots(vec![snap], std::collections::HashMap::new()).unwrap_err();
+        let err = merge_snapshots(vec![snap], std::collections::HashMap::new(), Instant::now())
+            .unwrap_err();
         assert!(
             err.to_string().contains("iteration_duration"),
             "error must name the metric: {err}"
@@ -2673,7 +2694,7 @@ mod tests {
             },
         );
 
-        let result = merge_snapshots(vec![snap], job).expect("merge succeeds");
+        let result = merge_snapshots(vec![snap], job, Instant::now()).expect("merge succeeds");
         // Script-declared metric survives alongside the job's.
         assert!(result.effective_thresholds.contains_key("http_req_failed"));
         // Job config wins the collision, script-declared expression is dropped.
@@ -2704,11 +2725,41 @@ mod tests {
                 ..snap2
             }],
             std::collections::HashMap::new(),
+            Instant::now(),
         )
         .expect("merge succeeds");
         assert_eq!(
             result2.effective_thresholds["iterations"].expression,
             "iterations > 100"
+        );
+    }
+
+    /// W0 P0#2: the merged run_duration must come from the controller-side
+    /// `test_start`, NOT the merge instant. A fresh `Aggregator::new()`
+    /// stamps `started = now`, so a 600s distributed run used to report
+    /// run_duration ≈ the ~50ms merge time (every per-second rate / threshold
+    /// ~12,000× inflated). A test_start 10s in the past must yield a
+    /// run_duration ≈ 10s.
+    #[test]
+    fn merge_snapshots_stamps_test_start_not_merge_time() {
+        let snap = MetricsSnapshot {
+            series: vec![],
+            totals: HashMap::new(),
+            summary_trend_stats: k6_default_trend_stats(),
+            thresholds: HashMap::new(),
+        };
+        let test_start = Instant::now() - Duration::from_secs(10);
+        let result =
+            merge_snapshots(vec![snap], std::collections::HashMap::new(), test_start).unwrap();
+        assert!(
+            result.run_duration >= Duration::from_secs(9),
+            "run_duration must derive from test_start (>= 9s for a 10s-old start), got {:?}",
+            result.run_duration
+        );
+        assert!(
+            result.run_duration < Duration::from_secs(11),
+            "run_duration must not exceed test_start.elapsed() by more than real time, got {:?}",
+            result.run_duration
         );
     }
 
@@ -2742,8 +2793,12 @@ mod tests {
         }
         let snap_b = agg2.build_snapshot();
 
-        let merged =
-            merge_snapshots(vec![snap_a, snap_b], std::collections::HashMap::new()).unwrap();
+        let merged = merge_snapshots(
+            vec![snap_a, snap_b],
+            std::collections::HashMap::new(),
+            Instant::now(),
+        )
+        .unwrap();
         let m = merged.http_req_duration.expect("merged duration");
         assert_eq!(m.count, 5, "all 5 samples must merge");
         assert!(m.max >= 100_000.0, "max must reflect the merged buckets");


### PR DESCRIPTION
Closes TROPEL_MASTER_TODO **W0 P0#2**: distributed `run_duration` = merge time.

## Bug
`merge_snapshots` built a fresh `Aggregator::new()` whose `started` is the **merge** instant, so a 600s distributed run reported `run_duration ≈ the ~50ms merge time`. 50 agents x 20k requests over 600s (true 1667 req/s) → **20,000,000 req/s** reported. The old value was ZERO (obviously wrong); the new one was small-and-positive, passing every guard.

## Fix
- `merge_snapshots` now takes `test_start: Instant` and stamps `result.run_duration = test_start.elapsed()` after `build_results()`, before any reporter or threshold reads it
- `run_controller` and `run_cloud` thread `test_start` from the CLI bins (`bin/controller.rs`, `bin/cloud_run.rs` controller + local modes)
- Every `run_controller` / `run_cloud` / `merge_snapshots` call site updated

## Regression test
`merge_snapshots_stamps_test_start_not_merge_time` — a 10s-past `test_start` must yield `run_duration` in [9s, 11s), not the merge instant.

Gate: check ✓ fmt ✓ clippy -D warnings ✓ metrics 11/11 ✓ distributed 26/26 ✓

**Chained on #75** — merge #75 first.