### PR TITLE
fix(web): validate expectedStatuses at load, propagate parse errors (W0 P0#3)

### DIFF
--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -136,6 +136,15 @@ pub async fn run_request(req: RunRequest) -> RunOutcome {
 
     let client: Arc<dyn DriverHttpClient> = Arc::new(http::WebHttpClient);
 
+    // W0 P0#3: a malformed expectedStatuses pattern is a hard request error
+    // (validated at load), not a silent all-match or a silent empty list.
+    let expected_statuses = match req.parsed_expected_statuses() {
+        Ok(s) => s,
+        Err(e) => {
+            return RunOutcome::failed(format!("tropel_run: invalid expectedStatuses: {e}"));
+        }
+    };
+
     let mut runner = ScenarioRunner::new(
         scenario,
         flattened,
@@ -144,7 +153,7 @@ pub async fn run_request(req: RunRequest) -> RunOutcome {
         req.vu_id,
         req.scenario_name.clone(),
     )
-    .with_expected_statuses(req.parsed_expected_statuses());
+    .with_expected_statuses(expected_statuses);
 
     let pm_state = runner.state_handle();
     if let Some(ctx) = bootstrap::create_web_js_context(&pm_state).await {

--- a/crates/tropel-web/src/wire.rs
+++ b/crates/tropel-web/src/wire.rs
@@ -53,13 +53,17 @@ impl RunRequest {
     /// Parse the postcard-safe spec strings into `ExpectedStatus` values
     /// (numeric → `Single`, everything else → `Range`, mirroring
     /// [`ExpectedStatus::matches`]'s parsing).
-    pub fn parsed_expected_statuses(&self) -> Vec<ExpectedStatus> {
+    pub fn parsed_expected_statuses(&self) -> Result<Vec<ExpectedStatus>, String> {
         self.expected_statuses
             .iter()
-            .map(|spec| match spec.trim().parse::<u16>() {
-                Ok(code) => ExpectedStatus::Single(code),
-                Err(_) => ExpectedStatus::Range(spec.clone()),
-            })
+            // W0 P0#3: use the SDK's strict parse (fail-closed on malformed
+            // patterns) instead of hand-rolling an untagged u16-or-String
+            // match — the old code turned a typo like "200-" into a Range
+            // that matched every code, greening a run against all-500s. The
+            // error is PROPAGATED, not filtered: a malformed pattern must
+            // fail the run loudly, not silently become an empty expected
+            // list (which would fail every request without a message).
+            .map(|spec| ExpectedStatus::parse(spec))
             .collect()
     }
 }


### PR DESCRIPTION
Fixes TROPEL_MASTER_TODO W0 P0#3: the `ExpectedStatus` typo zeroed `http_req_failed`.

**Root repo changes:**
- `crates/tropel-web/src/wire.rs`: `parsed_expected_statuses` now returns `Result<Vec<ExpectedStatus>, String>` — malformed patterns propagate instead of being silently dropped (a dropped pattern used to yield an empty list → all requests failed without a message).
- `crates/tropel-web/src/lib.rs`: the caller maps the parse error to `RunOutcome::failed` (loud, fail-closed).
- Submodule pointer bumped to the SDK commit with the strict `ExpectedStatus::parse` + custom `Deserialize`.

SDK change is its own PR (fix in `crates/tropel-sdk` repo). Chained on `fix/w0-p02-dist-run-duration`.