### PR TITLE
fix(runtime): reset pm.response per item so failures never leak stale data (W1-A)

### DIFF
--- a/crates/tropel-engine/tests/behavior_parity.rs
+++ b/crates/tropel-engine/tests/behavior_parity.rs
@@ -73,8 +73,17 @@ async fn start_peak_server() -> (std::net::SocketAddr, Arc<AtomicUsize>) {
                 // Hold the connection open so concurrent VUs overlap.
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 let body = r#"{"ok":true}"#;
+                // `Connection: close` is load-bearing: this server measures
+                // PEAK CONCURRENCY by counting open connections, so it must
+                // stay one-shot — but a one-shot server without the header
+                // races the client's HTTP/1.1 keep-alive pool (the client
+                // reuses a socket the server is closing → occasional pooled
+                // transport failures). W1-A made those failures COUNT as
+                // failed checks instead of being masked by the stale
+                // pm.response bug, so the header is what keeps the pool from
+                // reusing this connection at all.
                 let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
                     body.len(),
                     body
                 );

--- a/crates/tropel-engine/tests/end_to_end.rs
+++ b/crates/tropel-engine/tests/end_to_end.rs
@@ -178,38 +178,58 @@ async fn start_auth_capture_server(seen: Arc<Mutex<Vec<String>>>) -> std::net::S
             };
             let seen = seen.clone();
             tokio::spawn(async move {
-                let mut head = Vec::new();
-                let mut buf = [0u8; 4096];
+                // Keep-alive loop (same shape as start_echo_server): the
+                // client pools HTTP/1.1 connections, and a server that drops
+                // the socket after ONE response races the client's reuse —
+                // occasionally failing a pooled request. W1-A made those
+                // transport failures COUNT as failed checks (the stale
+                // pm.response bug used to mask them by passing the check
+                // against the previous request's 200), so this server MUST
+                // serve multiple requests per connection or the run reports
+                // hundreds of real failures.
                 loop {
-                    let n = match sock.read(&mut buf).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => n,
+                    // Read until the request-head terminator. A fresh head
+                    // per request so a split packet never loses the header
+                    // across requests.
+                    let mut head = Vec::new();
+                    let mut buf = [0u8; 4096];
+                    let read_ok = loop {
+                        let n = match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => break false,
+                            Ok(n) => n,
+                        };
+                        head.extend_from_slice(&buf[..n]);
+                        if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break true;
+                        }
                     };
-                    head.extend_from_slice(&buf[..n]);
-                    if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                    if !read_ok {
+                        break;
+                    }
+                    let text = String::from_utf8_lossy(&head).to_string();
+                    for line in text.lines() {
+                        // Match the header name case-insensitively but capture
+                        // the VALUE in its ORIGINAL case (lowercasing the
+                        // whole line would corrupt "Bearer s3cret" into
+                        // "bearer s3cret").
+                        if line.to_ascii_lowercase().starts_with("authorization:") {
+                            if let Some(idx) = line.find(':') {
+                                seen.lock()
+                                    .unwrap()
+                                    .push(line[idx + 1..].trim().to_string());
+                            }
+                        }
+                    }
+                    let body = r#"{"ok":true}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    if sock.write_all(resp.as_bytes()).await.is_err() {
                         break;
                     }
                 }
-                let text = String::from_utf8_lossy(&head).to_string();
-                for line in text.lines() {
-                    // Match the header name case-insensitively but capture the
-                    // VALUE in its ORIGINAL case (lowercasing the whole line
-                    // would corrupt "Bearer s3cret" into "bearer s3cret").
-                    if line.to_ascii_lowercase().starts_with("authorization:") {
-                        if let Some(idx) = line.find(':') {
-                            seen.lock()
-                                .unwrap()
-                                .push(line[idx + 1..].trim().to_string());
-                        }
-                    }
-                }
-                let body = r#"{"ok":true}"#;
-                let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = sock.write_all(resp.as_bytes()).await;
             });
         }
     });

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -288,6 +288,15 @@ impl ScenarioRunner {
                 {
                     let mut state = self.pm_state.lock().unwrap();
                     state.request = item.request.clone();
+                    // W1-A: `pm.response` must never leak the PREVIOUS item's
+                    // response. It is assigned only on request success, so a
+                    // transport error / skipped-scheme / skipped item leaves it
+                    // pointing at the prior request's 200 — `pm.test(...to.have
+                    // .status(200))` then passes against stale data, and
+                    // `pm.response.json().id` propagates a wrong id downstream.
+                    // Reset here, at the top of every item, alongside `request`;
+                    // the success path re-populates it after the request runs.
+                    state.response = None;
                     state.skip_tests = false;
                     state.skip_request = false;
                     state.current_request_name = item.name.clone();
@@ -1782,6 +1791,83 @@ mod tests {
             state.environment.get("saw").map(String::as_str),
             Some("local-tok"),
             "pm.variables (local scope) must win over iteration data"
+        );
+    }
+
+    /// Scripted mock: the first call succeeds (200), every later call fails
+    /// with a transport error — the exact shape of "request 1 succeeds, then
+    /// the server/target dies" that W1-A exercises.
+    struct FlakyClient {
+        calls: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl DriverHttpClient for FlakyClient {
+        async fn execute(
+            &self,
+            _req: &tropel_sdk::types::Request,
+        ) -> Result<tropel_sdk::types::Response> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(tropel_sdk::types::Response {
+                    url: "http://example.com/ok".into(),
+                    status_code: 200,
+                    status_text: "OK".into(),
+                    headers: HashMap::new(),
+                    body: br#"{"id":1}"#.to_vec(),
+                    text_cache: std::cell::OnceCell::new(),
+                    json_cache: std::cell::OnceCell::new(),
+                    response_time: Duration::from_millis(1),
+                    timings: None,
+                    cookies: vec![],
+                    size: 0,
+                    request_body_size: 0,
+                    redirects: vec![],
+                })
+            } else {
+                Err(tropel_sdk::TropelError::Io(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "connection refused (simulated transport failure)",
+                )))
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_request_clears_stale_pm_response() {
+        // W1-A: `pm.response` must never leak the PREVIOUS item's response.
+        // The loop previously assigned only on success and never reset, so a
+        // transport error on item 2 left `pm.response` pointing at item 1's
+        // 200 — `pm.test(..., to.have.status(200))` PASSED against stale
+        // data, and `pm.response.json().id` propagated a wrong id downstream.
+        // Worst exactly at saturation, when http_req_failed climbs while
+        // checks stay green.
+        let scenario = Arc::new(Scenario {
+            info: tropel_sdk::scenario::ScenarioInfo {
+                name: "stale".into(),
+                description: None,
+                schema: None,
+            },
+            variables: HashMap::new(),
+            auth: None,
+            items: vec![leaf("ok-item"), leaf("dead-item")],
+        });
+        let execution_items: Arc<Vec<ScenarioItem>> =
+            Arc::new(flatten_execution_items(&scenario.items));
+        let names: Arc<Vec<String>> =
+            Arc::new(execution_items.iter().map(|i| i.name.clone()).collect());
+        let client: Arc<dyn DriverHttpClient> = Arc::new(FlakyClient {
+            calls: Arc::new(AtomicU32::new(0)),
+        });
+        let mut runner =
+            ScenarioRunner::new(scenario, execution_items, names, client, 0, "stale".into());
+
+        let _ = runner.run_iteration(0, None, &HashMap::new()).await;
+
+        let state = runner.pm_state().lock().unwrap();
+        assert!(
+            state.response.is_none(),
+            "pm.response must be None after a failed request — got {:?} (stale from item 1)",
+            state.response.as_ref().map(|r| r.status_code)
         );
     }
 }


### PR DESCRIPTION
Fixes TROPEL_MASTER_TODO W1-A #1: stale `pm.response` after a failed request.

**Problem:** the item loop assigned `state.response` only on request success and never reset it — not on transport error, not on skipped-scheme, not per item, not per iteration. Request 2 fails → its `pm.test(..., to.have.status(200))` PASSED against request 1's 200, and `pm.response.json().id` propagated a wrong id downstream. Worst exactly at saturation, when `http_req_failed` climbs while checks stay green.

**Fix:** reset `state.response = None` at the top of every leaf item, alongside the existing `state.request` reset. The success paths (HTTP + non-HTTP scheme outcomes) still re-populate it after the request runs, so `pm.sendRequest` and normal flows are unaffected.

**Test:** `failed_request_clears_stale_pm_response` — a scripted FlakyClient mock (first call returns 200, later calls return Err(ConnectionRefused)) across two leaf items asserts `state.response.is_none()` after the run. 18/18 tropel-runtime lib tests pass; fmt + clippy -D warnings clean. Chained on `fix/w0-p04-camelcase`.