### PR TITLE
fix(pm): record failed pm.test checks under the original name (W1-A)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -6481,21 +6481,21 @@ mod tests {
                 (name, s.value)
             })
             .collect();
-        // The merged canonical pm.js fix (backlog line 74) records rejections
-        // under `name + ' (error)'` — matching the sync catch path — so the
-        // failing-expect and rejecting bodies land under the suffixed names.
+        // W1-A: failures record under the ORIGINAL name (Postman/k6 parity) —
+        // renaming to `name + ' (error)'` minted a second series that a CI
+        // gate on `checks{check:...}` never read (100% pass by construction).
         assert!(
             checks
                 .iter()
-                .any(|(n, v)| n == "async failing expect (error)" && *v == 0.0),
-            "failing async expect must record FAIL, got: {:?}",
+                .any(|(n, v)| n == "async failing expect" && *v == 0.0),
+            "failing async expect must record FAIL under its own name, got: {:?}",
             checks
         );
         assert!(
             checks
                 .iter()
-                .any(|(n, v)| n == "async rejecting (error)" && *v == 0.0),
-            "Promise.reject body must record FAIL, got: {:?}",
+                .any(|(n, v)| n == "async rejecting" && *v == 0.0),
+            "Promise.reject body must record FAIL under its own name, got: {:?}",
             checks
         );
         assert!(
@@ -6670,18 +6670,21 @@ mod tests {
                 (n, p)
             };
 
-            let (n, p) = by_name("async-fail (error)");
-            assert_eq!(n, "async-fail (error)", "rejected async body name");
+            // W1-A: failures record under the ORIGINAL name — a gate on
+            // `checks{check:...}` must see the failures, not a derived
+            // ` (error)` series that is pass-by-construction.
+            let (n, p) = by_name("async-fail");
+            assert_eq!(n, "async-fail", "rejected async body name");
             assert!(!p, "rejected async body must record a FAILED check, not PASS");
-            let (_n, p) = by_name("async-reject (error)");
+            let (_n, p) = by_name("async-reject");
             assert!(!p, "Promise.reject body must record a FAILED check");
             let (n, p) = by_name("async-pass");
             assert_eq!(n, "async-pass");
             assert!(p, "resolved async body returning true must PASS");
             let (_n, p) = by_name("sync-pass");
             assert!(p, "sync true body must still PASS");
-            let (_n, p) = by_name("sync-fail (error)");
-            assert!(!p, "sync throwing body must still FAIL");
+            let (_n, p) = by_name("sync-fail");
+            assert!(!p, "sync throwing body must still FAIL under its own name");
         });
     }
 

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -494,7 +494,12 @@ pm.test = function (name, fn) {
                 },
                 function (e) {
                     if (typeof __tropel_pm_test === 'function') {
-                        __tropel_pm_test(name + ' (error)', false, '');
+                        // W1-A: record under the ORIGINAL name — Postman/k6
+                        // record failures under the check's own name, and a
+                        // CI gate on `checks{check:...}` must see the failures
+                        // (renaming produced a second series that was 100%
+                        // pass by construction).
+                        __tropel_pm_test(name, false, '');
                     }
                     console.error(__ns + '.test error:', e);
                     return false;
@@ -510,7 +515,10 @@ pm.test = function (name, fn) {
         return passed;
     } catch (e) {
         if (typeof __tropel_pm_test === 'function') {
-            __tropel_pm_test(name + ' (error)', false, '');
+            // W1-A: see the async rejection path above — failures must be
+            // recorded under the original name, not a derived ` (error)`
+            // series that a check-name gate never reads.
+            __tropel_pm_test(name, false, '');
         }
         console.error(__ns + '.test error:', e);
         return false;


### PR DESCRIPTION
Fixes TROPEL_MASTER_TODO W1-A #2: `pm.test` renames the check on failure.

**Problem:** `pm.js:497,513` recorded failures as `name + ' (error)'` while `state.rs:157` tags checks with the raw name — the same test passing then failing produced TWO series. A CI gate on `checks{check:status is 200}` read a series that was **100% pass by construction**. Postman and k6 both record failures under the original name.

**Fix:** both failure paths (async rejection + sync catch) now call `__tropel_pm_test(name, false, '')` with the ORIGINAL name. `check()` was already raw-named (state.rs), so it's unaffected; `pm.test.skip` uses its own bridge.

**Tests:** the two driver tests that pinned the old `(error)`-suffixed names (`test_pm_test_async_body_records_real_result`, `test_pm_test_async_body_records_on_settlement`) now assert failures land under their own names. 143/143 k6 lib tests pass; fmt + clippy -D warnings clean; repo-wide grep confirms zero remaining `(error)` series references. Chained on `fix/w1a-stale-pm-response`.