### PR TITLE
fix(js): proxy guards no longer leak Object.prototype members (W1-A #6)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -5586,6 +5586,120 @@ mod tests {
     }
 
     #[test]
+    fn test_object_prototype_members_do_not_bypass_guards() {
+        // W1-A: both proxy guards used `prop in t`, which walks the ENTIRE
+        // prototype chain — `.toString`, `.constructor`, `.hasOwnProperty`,
+        // `.valueOf`, `.__proto__` resolved to truthy Functions inherited
+        // from Object.prototype and every one recorded PASS, so a typo like
+        // `pm.expect(x).to.be.tostring` could never fail (silent green). The
+        // guards now use own-property checks that stop before
+        // Object.prototype: the real assertion members still resolve, but
+        // Object.prototype members THROW. Internal instance state (`_actual`,
+        // `_obj`, `__flags`) stays readable — real chai exposes those too and
+        // the shims' own methods read them through the proxy.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
+                .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                // Stub the response bridges — the TODO's EXEC case is
+                // "against a 200", i.e. the plain-literal guard path
+                // (pm.response.to.be.*), which wraps a DIFFERENT target kind
+                // than the AssertChain instances pm.expect uses.
+                globalThis.__tropel_pm_response_code = function () { return 200; };
+                globalThis.__tropel_pm_response_status = function () { return 'OK'; };
+                globalThis.__tropel_pm_response_time = function () { return 42.5; };
+                globalThis.__tropel_pm_response_headers = function () {
+                    return { 'Content-Type': 'application/json' };
+                };
+                globalThis.__tropel_pm_response_header = function (key) {
+                    if (String(key).toLowerCase() === 'content-type') return 'application/json';
+                    return null;
+                };
+                globalThis.__tropel_pm_response_cookies = function () { return {}; };
+                globalThis.__tropel_pm_response_body = function () { return '{}'; };
+                globalThis.__tropel_pm_response_json = function () { return {}; };
+
+                globalThis.__r = {};
+                // Install the `.should` getter (chai.should() defines
+                // Object.prototype.should) — without it `(5).should.equal(5)`
+                // below would throw "should is not a function" before the
+                // guard is ever reached.
+                chai.should();
+                function trial(key, fn) {
+                    globalThis.__r[key] = String((function () {
+                        try { fn(); return true; }
+                        catch (e) { return e.name === 'RangeError' ? 'stack-overflow' : 'threw'; }
+                    })());
+                }
+                // pm.response.to (plain-literal guard path): Object.prototype
+                // members must throw — the TODO's "against a 200" EXEC.
+                trial('resp_toString', function () { pm.response.to.be.toString; });
+                trial('resp_constructor', function () { pm.response.to.constructor; });
+                trial('resp_hasOwnProperty', function () { pm.response.to.be.hasOwnProperty; });
+                trial('resp_valueOf', function () { pm.response.to.valueOf; });
+                trial('resp_proto', function () { pm.response.to.be.__proto__; });
+                // pm.expect chains (AssertChain guard path): same.
+                trial('pm_toString', function () { pm.expect(1).to.be.toString; });
+                trial('pm_constructor', function () { pm.expect(1).to.be.constructor; });
+                trial('pm_hasOwnProperty', function () { pm.expect(1).to.be.hasOwnProperty; });
+                trial('pm_valueOf', function () { pm.expect(1).to.be.valueOf; });
+                trial('pm_proto', function () { pm.expect(1).to.be.__proto__; });
+                // chai.expect chains: same.
+                trial('chai_toString', function () { chai.expect(1).to.be.toString; });
+                trial('chai_constructor', function () { chai.expect(1).to.be.constructor; });
+                trial('chai_hasOwnProperty', function () { chai.expect(1).to.be.hasOwnProperty; });
+                trial('chai_valueOf', function () { chai.expect(1).to.be.valueOf; });
+                trial('chai_proto', function () { chai.expect(1).to.be.__proto__; });
+                // Real assertions still resolve and pass.
+                trial('pm_real', function () { pm.expect(true).to.be.true; });
+                trial('resp_status_real', function () { pm.response.to.have.status(200); });
+                trial('chai_real', function () { chai.expect({ a: 1 }).to.deep.equal({ a: 1 }); });
+                trial('chai_should_real', function () { (5).should.equal(5); });
+                // Real typos still throw (guard parity).
+                trial('pm_typo', function () { pm.expect(1).to.be.tostring; });
+                trial('chai_typo', function () { chai.expect(1).to.be.tostring; });
+                "#,
+            )
+            .expect("guard leak script should eval");
+            for (name, want) in [
+                ("resp_toString", "threw"),
+                ("resp_constructor", "threw"),
+                ("resp_hasOwnProperty", "threw"),
+                ("resp_valueOf", "threw"),
+                ("resp_proto", "threw"),
+                ("pm_toString", "threw"),
+                ("pm_constructor", "threw"),
+                ("pm_hasOwnProperty", "threw"),
+                ("pm_valueOf", "threw"),
+                ("pm_proto", "threw"),
+                ("chai_toString", "threw"),
+                ("chai_constructor", "threw"),
+                ("chai_hasOwnProperty", "threw"),
+                ("chai_valueOf", "threw"),
+                ("chai_proto", "threw"),
+                ("pm_real", "true"),
+                ("resp_status_real", "true"),
+                ("chai_real", "true"),
+                ("chai_should_real", "true"),
+                ("pm_typo", "threw"),
+                ("chai_typo", "threw"),
+            ] {
+                let expr = format!("__r.{name}");
+                assert_eq!(
+                    ctx.eval::<String, _>(expr).unwrap(),
+                    want,
+                    "{name}: Object.prototype members must not bypass the guard"
+                );
+            }
+        });
+    }
+
+    #[test]
     fn test_pm_expect_chain_allocates_once_not_per_read() {
         // Backlog line 105: pm.expect was ~10x slower than chai.expect
         // (2511 ms vs 235 ms over 200k assertions) because EVERY call built

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -275,14 +275,19 @@ var chai = chai || {};
     // ── Assertion Methods ──
 
     // .equal(expected)
+    // Real chai: `.deep.equal(x)` performs a DEEP comparison (the `deep`
+    // chainable getter sets `__flags.deep`, and `equal` must honor it —
+    // W1-A exposed that `.deep.equal` silently did a shallow `===`, so
+    // `expect({a:1}).to.deep.equal({a:1})` threw).
     Assertion.prototype.equal = function (value) {
         var negate = !!(this.__flags && this.__flags.negate);
-        var passed = (this._obj === value) !== negate;
+        var deep = !!(this.__flags && this.__flags.deep);
+        var passed = (deep ? nativeDeepEqual(this._obj, value) : this._obj === value) !== negate;
         if (!passed) {
             throw new Error(
                 (this._msg ? this._msg + ': ' : '') +
                 'expected ' + JSON.stringify(this._obj) +
-                (negate ? ' not' : '') + ' to equal ' + JSON.stringify(value)
+                (negate ? ' not' : '') + (deep ? ' to deeply equal ' : ' to equal ') + JSON.stringify(value)
             );
         }
         return this;
@@ -712,7 +717,21 @@ var chai = chai || {};
                         return receiver;
                     };
                 }
-                if (prop in Assertion.prototype || prop in target) {
+                // W1-A: `prop in …` leaked Object.prototype — `.toString`,
+                // `.constructor`, `.hasOwnProperty`, `.__proto__`, `._obj`,
+                // `.__flags` all resolved (and recorded PASS) instead of
+                // throwing, so a typo could never fail. Own-property checks
+                // only: real assertions are defineProperty'd onto the
+                // Assertion prototype, and instance state (_obj/_flags) lives
+                // on the instance itself. `constructor` is an OWN property of
+                // every prototype object (the standard back-reference), so it
+                // would slip through the own-property check — reject it
+                // explicitly; it is not an assertion member.
+                if (
+                    prop !== 'constructor' &&
+                    (Object.prototype.hasOwnProperty.call(Assertion.prototype, prop) ||
+                        Object.prototype.hasOwnProperty.call(target, prop))
+                ) {
                     return Reflect.get(target, prop, receiver);
                 }
                 throw new Error("unknown assertion property '" + String(prop) + "'");
@@ -902,7 +921,19 @@ var chai = chai || {};
     chai.should = function () {
         Object.defineProperty(Object.prototype, 'should', {
             get: function () {
-                return guardAssertion(new Assertion(this));
+                // `(5).should` boxes the primitive — `this` is `new Number(5)`
+                // and `new Number(5) === 5` is false, so `(5).should.equal(5)`
+                // would throw "expected 5 to equal 5" with the boxed _obj.
+                // Unbox Number/String/Boolean wrappers (W1-A regression test
+                // exposed this; Date etc. keep their valueOf untouched).
+                var obj = this;
+                if (
+                    typeof obj === 'object' && obj !== null &&
+                    (obj instanceof Number || obj instanceof String || obj instanceof Boolean)
+                ) {
+                    obj = obj.valueOf();
+                }
+                return guardAssertion(new Assertion(obj));
             },
             set: function () {},
             configurable: true,

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -562,6 +562,38 @@ pm.test.skip = function (name) {
 // each pm.expect() allocates one small instance + one proxy, and
 // to/be/not/... return `this` (the same proxy) so a chain of any length
 // never allocates again.
+// W1-A #6: own-property + prototype walk UP TO BUT NOT INCLUDING
+// Object.prototype. `prop in t` walked the ENTIRE chain, so `.toString`,
+// `.constructor`, `.hasOwnProperty`, `.valueOf`, `.__proto__` all resolved
+// (truthy Functions → recorded PASS) instead of throwing — a typo could
+// never fail. guardChain wraps BOTH plain literals (pm.response.to — members
+// are own props) AND AssertChain instances (chain getters/methods live on
+// AssertChain.prototype), so the check must see own props of the target AND
+// own props of its prototypes, stopping before Object.prototype. Hoisted to a
+// named helper (defined once): the chain is a hot path and an inline IIFE
+// would allocate a closure per property read.
+function isChainMember(t, prop) {
+    // `constructor` is an OWN property of every prototype object (the
+    // standard back-reference), so the own-property walk below would find it
+    // on AssertChain.prototype and let `pm.expect(1).to.be.constructor`
+    // resolve to a truthy Function → silent PASS. It is NOT a chain member
+    // — reject it like any other unknown name (W1-A #6).
+    if (prop === 'constructor') {
+        return false;
+    }
+    if (Object.prototype.hasOwnProperty.call(t, prop)) {
+        return true;
+    }
+    var p = Object.getPrototypeOf(t);
+    while (p && p !== Object.prototype) {
+        if (Object.prototype.hasOwnProperty.call(p, prop)) {
+            return true;
+        }
+        p = Object.getPrototypeOf(p);
+    }
+    return false;
+}
+
 function guardChain(target) {
     return new Proxy(target, {
         get: function (t, prop, receiver) {
@@ -571,7 +603,7 @@ function guardChain(target) {
             ) {
                 return Reflect.get(t, prop, receiver);
             }
-            if (prop in t) {
+            if (isChainMember(t, prop)) {
                 // No recursion needed: every chain getter returns `this`
                 // (already the proxy), so nested reads cost one getter call.
                 return Reflect.get(t, prop, receiver);


### PR DESCRIPTION
Closes W1-A #6 (TROPEL_MASTER_TODO line 132): both proxy guards used `prop in t`, which walks the entire prototype chain — `.toString`, `.constructor`, `.hasOwnProperty`, `.valueOf`, `.__proto__` resolved to truthy inherited functions and recorded PASS, so a typo like `pm.expect(x).to.be.tostring` could never fail.

**Changes:**
- `pm.js` guardChain: hoisted `isChainMember(t, prop)` — own-property check + prototype walk stopping before `Object.prototype`, with explicit `constructor` rejection.
- `chai-shim.js` guardAssertion: own-property checks on `Assertion.prototype` and target, with `prop !== 'constructor'`.
- `Assertion.prototype.equal` now honors the `__flags.deep` flag via `nativeDeepEqual` (previously `.deep.equal` silently did shallow `===`).
- `chai.should` getter unboxes Number/String/Boolean wrappers so `(5).should.equal(5)` compares the primitive.

**Tests:** `test_object_prototype_members_do_not_bypass_guards` — 21 trials across the plain-literal `pm.response.to` path (stubbed bridges, the TODO's 'against a 200' EXEC), `pm.expect` and `chai.expect` chains. k6 lib suite 144/144, fmt clean, clippy clean.