### PR TITLE
test(runtime-wasm): smoke asserts checks PASS and http_req_failed === 0 (W1-A #7)

### DIFF
--- a/packages/runtime-wasm/smoke.mjs
+++ b/packages/runtime-wasm/smoke.mjs
@@ -186,6 +186,25 @@ if (outcome.iterations[1].scriptFailures !== 0) fail("scripts must pass on the s
 const checks = first.samples.filter((s) => s.metric === "checks");
 if (checks.length < 2) fail(`expected 2 checks samples, got ${checks.length}`);
 
+// W1-A wire-P0 regression: a decode failure still emits http_reqs and
+// pm.test swallows the assertion into a 0.0 check, so COUNTING checks can
+// never catch it. Every check must have PASSED — value === 1 (a 0.0 check
+// means the assertion body threw or the wire decoded a failure as pass).
+const failedChecks = checks.filter((s) => s.value !== 1);
+if (failedChecks.length > 0)
+  fail(`all checks must PASS (value === 1), got ${failedChecks.length} failing`);
+
+// W1-A wire-P0 regression: http_req_failed (Rate) must be 0 for every
+// request — the fixture transport answers 200. A re-introduced wire P0
+// that mis-decodes the failure flag (or drops it) surfaces here even
+// though http_reqs/checks still emit.
+const reqFailed = first.samples.filter((s) => s.metric === "http_req_failed");
+if (reqFailed.length === 0)
+  fail(`expected http_req_failed samples, got none (wire P0: failure flag missing)`);
+const failedReqs = reqFailed.filter((s) => s.value !== 0);
+if (failedReqs.length > 0)
+  fail(`all requests must succeed (http_req_failed === 0), got ${failedReqs.length} failed`);
+
 const expectedSeen = [
   "https://fixture.test/first",
   "https://fixture.test/second",


### PR DESCRIPTION
Closes W1-A #7 (TROPEL_MASTER_TODO line 133): the old smoke only COUNTED samples — never asserted their values. A wire P0 still emits `http_reqs`, `pm.test` swallows the assertion into a `0.0` check, and `record_script_failure` only fires on a throw, so all five assertions passed on a broken wire.

**Validated against the current SDK:** the stale wasm artifact + stale dist misaligned with the SDK `Response` struct (gained `request_body_size`/`redirects`) made every response fail decode with "Hit the end of buffer, expected more data" — and the old smoke reported PASS. The new assertions catch it:

- every `checks` sample must have `value === 1` (a 0.0 check means the assertion threw or the wire decoded a failure as pass)
- `http_req_failed` samples must EXIST and every one must be 0.0 (the fixture transport answers 200)

CI always rebuilds the wasm (wasm-size.sh) and dist (npm run build) fresh, so the gate is green in CI. Smoke passes locally against a fresh artifact; the reviewer confirmed the f64 `!== 1` comparison is exact (postcard round-trips IEEE bits) and the scope matches the file's existing first-iteration convention.