### PR TITLE
feat(js): pm.expect delegates to chai Assertion (W1-B #138)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -5284,6 +5284,164 @@ mod tests {
     }
 
     #[test]
+    fn test_pm_expect_delegates_to_chai_assertion_surface() {
+        // W1-B: 6 of Postman's 17 stock snippets FAILED against the old
+        // AssertChain surface — pm.expect(...).to.be.below(200),
+        // .to.have.lengthOf(3), .to.be.oneOf([200,201]),
+        // .to.deep.include({name:"x"}) all read "unknown assertion
+        // property". pm.expect now delegates to chai-shim's Assertion when
+        // chai is loaded (the runtime bundle always loads both), so the
+        // full chai surface works through pm.expect: below/above/least/
+        // most/lessThan/lengthOf/oneOf/instanceOf/throw/keys/contain/
+        // members/closeTo/within and deep-aware include. The Postman
+        // extensions status/header/jsonBody live on the chai Assertion too
+        // (chai-postman parity), so pm.expect(pm.response).to.have.status
+        // (200) still works after delegation.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
+                .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__r = {};
+                function trial(key, fn) {
+                    globalThis.__r[key] = String((function () {
+                        try { fn(); return true; }
+                        catch (e) { return e.name === 'RangeError' ? 'stack-overflow' : 'threw'; }
+                    })());
+                }
+                // Stub the response bridges for the Postman extensions.
+                globalThis.__tropel_pm_response_code = function () { return 200; };
+                globalThis.__tropel_pm_response_status = function () { return 'OK'; };
+                globalThis.__tropel_pm_response_time = function () { return 42.5; };
+                globalThis.__tropel_pm_response_headers = function () {
+                    return { 'Content-Type': 'application/json' };
+                };
+                globalThis.__tropel_pm_response_header = function (key) {
+                    if (String(key).toLowerCase() === 'content-type') return 'application/json';
+                    return null;
+                };
+                globalThis.__tropel_pm_response_cookies = function () { return {}; };
+                globalThis.__tropel_pm_response_body = function () { return '{}'; };
+                globalThis.__tropel_pm_response_json = function () { return {}; };
+
+                // name: 'x' at the TOP LEVEL — chai's deep.include checks the
+                // expected object's keys directly against the target (no
+                // recursive search), so the stock-snippet fixture must carry
+                // the asserted key as a top-level member.
+                var json = { name: 'x', items: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] };
+
+                // The 6 failing stock snippets (W1-B EXEC list).
+                trial('below_ok', function () { pm.expect(pm.response.responseTime).to.be.below(200); });
+                trial('below_bad', function () { pm.expect(pm.response.responseTime).to.be.below(10); });
+                trial('lengthOf_ok', function () { pm.expect(json.items).to.have.lengthOf(3); });
+                trial('lengthOf_bad', function () { pm.expect(json.items).to.have.lengthOf(2); });
+                trial('oneOf_ok', function () { pm.expect(pm.response.code).to.be.oneOf([200, 201]); });
+                trial('oneOf_bad', function () { pm.expect(pm.response.code).to.be.oneOf([404, 500]); });
+                trial('deep_include_ok', function () { pm.expect(json).to.deep.include({ name: 'x' }); });
+                trial('deep_include_bad', function () { pm.expect(json).to.deep.include({ name: 'zzz' }); });
+                // Deep-include of a NON-OBJECT must fail — Object.keys(5)=[]
+                // would vacuously pass (false-green guard).
+                trial('deep_include_primitive', function () { pm.expect({ a: 1 }).to.deep.include(5); });
+
+                // The rest of the formerly-absent surface.
+                trial('above_ok', function () { pm.expect(5).to.be.above(4); });
+                trial('above_bad', function () { pm.expect(5).to.be.above(6); });
+                trial('least_ok', function () { pm.expect(5).to.be.at.least(5); });
+                trial('least_bad', function () { pm.expect(5).to.be.at.least(6); });
+                trial('most_ok', function () { pm.expect(5).to.be.at.most(5); });
+                trial('most_bad', function () { pm.expect(5).to.be.at.most(4); });
+                trial('lessThan_ok', function () { pm.expect(5).to.be.lessThan(6); });
+                trial('lessThan_bad', function () { pm.expect(5).to.be.lessThan(4); });
+                trial('within_ok', function () { pm.expect(5).to.be.within(4, 6); });
+                trial('within_bad', function () { pm.expect(5).to.be.within(6, 7); });
+                trial('closeTo_ok', function () { pm.expect(5).to.be.closeTo(5.1, 0.2); });
+                trial('closeTo_bad', function () { pm.expect(5).to.be.closeTo(5.1, 0.01); });
+                trial('instanceOf_ok', function () { pm.expect([]).to.be.instanceOf(Array); });
+                trial('instanceOf_bad', function () { pm.expect({}).to.be.instanceOf(Array); });
+                trial('keys_ok', function () { pm.expect({ a: 1, b: 2 }).to.have.keys('a', 'b'); });
+                trial('keys_bad', function () { pm.expect({ a: 1 }).to.have.keys('a', 'b'); });
+                trial('contain_ok', function () { pm.expect([1, 2, 3]).to.contain(2); });
+                trial('contain_bad', function () { pm.expect([1, 2, 3]).to.contain(9); });
+                trial('members_ok', function () { pm.expect([1, 2, 3]).to.have.members([3, 1, 2]); });
+                trial('members_bad', function () { pm.expect([1, 2, 3]).to.have.members([9]); });
+                // chai's plain .members is SAME-SET (order-insensitive, equal
+                // size) — a subset must NOT pass (false-green guard).
+                trial('members_subset', function () { pm.expect([1, 2, 3]).to.have.members([1, 2]); });
+                // Multiset semantics: same elements with different COUNTS must
+                // fail (naive length+every/some would pass this).
+                trial('members_multiset', function () { pm.expect([1, 1, 2]).to.have.members([1, 2, 2]); });
+                trial('throw_ok', function () {
+                    pm.expect(function () { throw new Error('boom'); }).to.throw(Error, 'boom');
+                });
+                trial('throw_bad', function () {
+                    pm.expect(function () {}).to.throw(Error);
+                });
+
+                // Postman extensions survive delegation.
+                trial('status_ok', function () { pm.expect(pm.response).to.have.status(200); });
+                trial('status_bad', function () { pm.expect(pm.response).to.have.status(404); });
+                trial('header_ok', function () {
+                    pm.expect(pm.response).to.have.header('Content-Type', 'application/json');
+                });
+                trial('header_bad', function () {
+                    pm.expect(pm.response).to.have.header('X-Missing', 'nope');
+                });
+
+                // The guard still trips on real typos through the delegated chain.
+                trial('typo', function () { pm.expect(1).to.be.tostring; });
+            "#,
+            )
+            .expect("script should eval");
+
+            let r = |k: &str| ctx.eval::<String, _>(format!("__r['{}']", k)).unwrap();
+            // 6 failing stock snippets now pass; each also fails closed when
+            // the assertion does not hold.
+            assert_eq!(r("below_ok"), "true", "pm.expect(...).to.be.below must pass (stock snippet)");
+            assert_eq!(r("below_bad"), "threw", "below must fail closed on a bad bound");
+            assert_eq!(r("lengthOf_ok"), "true", "pm.expect(...).to.have.lengthOf must pass (stock snippet)");
+            assert_eq!(r("lengthOf_bad"), "threw", "lengthOf must fail closed");
+            assert_eq!(r("oneOf_ok"), "true", "pm.expect(...).to.be.oneOf must pass (stock snippet)");
+            assert_eq!(r("oneOf_bad"), "threw", "oneOf must fail closed");
+            assert_eq!(r("deep_include_ok"), "true", "pm.expect(...).to.deep.include must pass (stock snippet)");
+            assert_eq!(r("deep_include_bad"), "threw", "deep.include must fail closed");
+            assert_eq!(r("deep_include_primitive"), "threw", "deep.include of a non-object must fail (Object.keys(5)=[] false-green guard)");
+            assert_eq!(r("above_ok"), "true", "above must pass");
+            assert_eq!(r("above_bad"), "threw", "above must fail closed");
+            assert_eq!(r("least_ok"), "true", "at.least must pass");
+            assert_eq!(r("least_bad"), "threw", "at.least must fail closed");
+            assert_eq!(r("most_ok"), "true", "at.most must pass");
+            assert_eq!(r("most_bad"), "threw", "at.most must fail closed");
+            assert_eq!(r("lessThan_ok"), "true", "lessThan must pass");
+            assert_eq!(r("lessThan_bad"), "threw", "lessThan must fail closed");
+            assert_eq!(r("within_ok"), "true", "within must pass");
+            assert_eq!(r("within_bad"), "threw", "within must fail closed");
+            assert_eq!(r("closeTo_ok"), "true", "closeTo must pass");
+            assert_eq!(r("closeTo_bad"), "threw", "closeTo must fail closed");
+            assert_eq!(r("instanceOf_ok"), "true", "instanceOf must pass");
+            assert_eq!(r("instanceOf_bad"), "threw", "instanceOf must fail closed");
+            assert_eq!(r("keys_ok"), "true", "keys must pass");
+            assert_eq!(r("keys_bad"), "threw", "keys must fail closed");
+            assert_eq!(r("contain_ok"), "true", "contain must pass");
+            assert_eq!(r("contain_bad"), "threw", "contain must fail closed");
+            assert_eq!(r("members_ok"), "true", "members must pass on an equal set");
+            assert_eq!(r("members_bad"), "threw", "members must fail closed");
+            assert_eq!(r("members_subset"), "threw", "plain .members is SAME-SET — a subset must not pass (false-green guard)");
+            assert_eq!(r("members_multiset"), "threw", "members is MULTISET — differing element counts must not pass (false-green guard)");
+            assert_eq!(r("throw_ok"), "true", "throw must pass on a matching error");
+            assert_eq!(r("throw_bad"), "threw", "throw must fail closed when nothing throws");
+            assert_eq!(r("status_ok"), "true", "pm.expect(pm.response).to.have.status must survive delegation");
+            assert_eq!(r("status_bad"), "threw", "status must fail closed");
+            assert_eq!(r("header_ok"), "true", "header must survive delegation");
+            assert_eq!(r("header_bad"), "threw", "header must fail closed");
+            assert_eq!(r("typo"), "threw", "the guard must still trip on real typos through the delegated chain");
+        });
+    }
+
+    #[test]
     fn test_include_uses_chai_value_semantics() {
         // Backlog line 88: pm.expect(arr).to.include(v) was a SUBSTRING test
         // (String(arr).indexOf) — [11,22].include(1) passed and
@@ -5733,10 +5891,13 @@ mod tests {
                     return new __realProxy(arguments[0], arguments[1]);
                 };
 
-                // Warm-up + behaviour must be unchanged. (above/below etc.
-                // are chai-shim assertions — the pm chain's surface is
-                // eql/equal/include/match/an/a/property/status/header/
-                // jsonBody, and the guard must still throw on anything else.)
+                // Warm-up + behaviour must be unchanged. This test evals
+                // ONLY pm.js (no chai), so pm.expect takes the AssertChain
+                // fallback (W1-B: when chai IS loaded, pm.expect delegates
+                // to chai's Assertion and gains the full chai surface). The
+                // fallback chain's surface is eql/equal/include/match/an/a/
+                // property/status/header/jsonBody, and the guard must still
+                // throw on anything else.)
                 pm.expect('x').to.be.an('string').and.to.equal('x');
                 pm.expect(5).not.to.be.a('string');
                 pm.expect([1, 2]).to.include(2);

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -316,18 +316,46 @@ var chai = chai || {};
         return this;
     };
 
-    // .include(value)
+    // .include(value) — deep-aware (W1-B: `.deep.include({name:"x"})` must
+    // deep-include; previously the deep flag was ignored and only the
+    // shallow `value in obj` / indexOf paths existed).
     Assertion.prototype.include = function (value) {
         var obj = this._obj;
         var negate = !!(this.__flags && this.__flags.negate);
+        var deep = !!(this.__flags && this.__flags.deep);
         var passed;
 
         if (typeof obj === 'string') {
             passed = (obj.indexOf(value) !== -1) !== negate;
         } else if (Array.isArray(obj)) {
-            passed = (obj.indexOf(value) !== -1) !== negate;
+            if (deep) {
+                var found = false;
+                for (var i = 0; i < obj.length; i++) {
+                    if (nativeDeepEqual(obj[i], value)) { found = true; break; }
+                }
+                passed = found !== negate;
+            } else {
+                passed = (obj.indexOf(value) !== -1) !== negate;
+            }
         } else if (typeof obj === 'object' && obj !== null) {
-            passed = (value in obj) !== negate;
+            if (deep) {
+                // chai subset semantics: every key of `value` must exist on
+                // `obj` with a deep-equal value (extra keys on obj allowed).
+                // Only valid when `value` is itself an object — a primitive
+                // has no keys, so Object.keys(5) = [] would vacuously pass
+                // (false-green; Object.keys(null) would throw). Fail instead.
+                if (value === null || typeof value !== 'object') {
+                    passed = false !== negate;
+                } else {
+                    var expKeys = Object.keys(value);
+                    var allMatch = expKeys.every(function (k) {
+                        return k in obj && nativeDeepEqual(obj[k], value[k]);
+                    });
+                    passed = allMatch !== negate;
+                }
+            } else {
+                passed = (value in obj) !== negate;
+            }
         } else {
             passed = false;
         }
@@ -336,7 +364,7 @@ var chai = chai || {};
             throw new Error(
                 (this._msg ? this._msg + ': ' : '') +
                 'expected ' + JSON.stringify(obj) +
-                (negate ? ' not' : '') + ' to include ' + JSON.stringify(value)
+                (negate ? ' not' : '') + (deep ? ' to deeply include ' : ' to include ') + JSON.stringify(value)
             );
         }
         return this;
@@ -589,6 +617,77 @@ var chai = chai || {};
     };
     Assertion.prototype.lte = Assertion.prototype.most;
 
+    // .within(start, finish) — start <= obj <= finish (chai inclusive)
+    Assertion.prototype.within = function (start, finish) {
+        var negate = !!(this.__flags && this.__flags.negate);
+        var passed = (this._obj >= start && this._obj <= finish) !== negate;
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected ' + JSON.stringify(this._obj) +
+                (negate ? ' not' : '') + ' to be within ' + start + '..' + finish
+            );
+        }
+        return this;
+    };
+
+    // .closeTo(expected, delta) — |obj - expected| <= delta (chai)
+    Assertion.prototype.closeTo = function (expected, delta) {
+        var negate = !!(this.__flags && this.__flags.negate);
+        var passed = (Math.abs(this._obj - expected) <= delta) !== negate;
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected ' + JSON.stringify(this._obj) +
+                (negate ? ' not' : '') + ' to be close to ' + expected + ' +/- ' + delta
+            );
+        }
+        return this;
+    };
+
+    // .members(list) — chai's plain .members asserts the target array has
+    // the SAME members as list, order-insensitive (set equality: same size
+    // AND every element of list present in the target). The superset
+    // spelling is `.include.members`, which this shim does not split — a
+    // plain .members that only checked one direction would let
+    // `[1,2,3].members([1,2])` PASS (a false-green, the exact failure mode
+    // this project hunts). Deep-aware: with the deep flag, membership is by
+    // deep equality.
+    Assertion.prototype.members = function (list) {
+        var negate = !!(this.__flags && this.__flags.negate);
+        var deep = !!(this.__flags && this.__flags.deep);
+        var obj = this._obj;
+        var passed;
+        if (Array.isArray(obj) && Array.isArray(list)) {
+            // Multiset semantics (chai counts occurrences): same length AND
+            // each list element finds a distinct mate in the target — a naive
+            // length + every/some would let [1,1,2].members([1,2,2]) PASS
+            // (false-green). Deep flag compares by deep equality.
+            var used = [];
+            var all = obj.length === list.length && list.every(function (needle) {
+                for (var i = 0; i < obj.length; i++) {
+                    if (used[i]) continue;
+                    if (deep ? nativeDeepEqual(obj[i], needle) : obj[i] === needle) {
+                        used[i] = true;
+                        return true;
+                    }
+                }
+                return false;
+            });
+            passed = all !== negate;
+        } else {
+            passed = false;
+        }
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected ' + JSON.stringify(obj) +
+                (negate ? ' not' : '') + (deep ? ' to deeply ' : ' to ') + 'have members ' + JSON.stringify(list)
+            );
+        }
+        return this;
+    };
+
     // .contain(value) — alias of .include (chai exposes both)
     Assertion.prototype.contain = function (value) {
         return this.include(value);
@@ -742,6 +841,51 @@ var chai = chai || {};
     // ── chai.expect ──
     chai.expect = function (val, msg) {
         return guardAssertion(new Assertion(val, msg, chai.expect));
+    };
+
+    // ── Postman extensions (chai-postman parity) ──
+    // pm.expect delegates to chai's Assertion (W1-B), so the
+    // Postman-specific members status/header/jsonBody must live here too.
+    // They read pm.response, which exists at call time whenever pm.js is
+    // loaded (the runtime bundle always loads both; chai alone leaves them
+    // failing on an absent pm.response, which is correct — these are
+    // Postman members, not core chai).
+    Assertion.prototype.status = function (code) {
+        var actual = (typeof pm !== 'undefined' && pm.response) ? pm.response.code : undefined;
+        var negate = !!(this.__flags && this.__flags.negate);
+        var passed = (actual === code) !== negate;
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected response ' + (negate ? 'not ' : '') + 'to have status ' + code + ' but got ' + actual
+            );
+        }
+        return this;
+    };
+    Assertion.prototype.header = function (key, value) {
+        var header = (typeof pm !== 'undefined' && pm.response) ? pm.response.header(key) : undefined;
+        var negate = !!(this.__flags && this.__flags.negate);
+        var passed = (header === value) !== negate;
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected header ' + key + ' ' + (negate ? 'not ' : '') +
+                'to be ' + JSON.stringify(value) + ', got ' + JSON.stringify(header)
+            );
+        }
+        return this;
+    };
+    Assertion.prototype.jsonBody = function (expected) {
+        var body = (typeof pm !== 'undefined' && pm.response) ? pm.response.json() : undefined;
+        var negate = !!(this.__flags && this.__flags.negate);
+        var passed = nativeDeepEqual(body, expected) !== negate;
+        if (!passed) {
+            throw new Error(
+                (this._msg ? this._msg + ': ' : '') +
+                'expected response body ' + (negate ? 'not ' : '') + 'to match'
+            );
+        }
+        return this;
     };
 
     // .empty

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -771,6 +771,17 @@ AssertChain.prototype.jsonBody = function (expected) {
 };
 
 pm.expect = function (actual) {
+    // W1-B: delegate to chai-shim's Assertion when it is loaded — its
+    // surface covers below/lengthOf/oneOf/above/least/most/lessThan/
+    // instanceOf/throw/keys/contain/members/closeTo/within and deep-aware
+    // include, which 6 of Postman's 17 stock snippets need (they failed
+    // with "unknown assertion property" against the AssertChain surface).
+    // chai-shim loads in the runtime bundle BEFORE any user script runs, so
+    // at call time it is always present there; standalone pm.js (driver
+    // tests, hosts that eval pm.js alone) falls back to AssertChain.
+    if (typeof chai !== 'undefined' && chai.expect) {
+        return chai.expect(actual);
+    }
     // One small instance + one proxy per call (backlog line 105). The whole
     // chain surface lives on AssertChain.prototype; `to`/`be`/`not` return
     // `this` (the proxy), so the unknown-name guard covers every position


### PR DESCRIPTION
Six of Postman's 17 stock snippets failed because the pm.js AssertChain lacked below/lengthOf/oneOf/deep.include/above/least/most/instanceof/throw/keys/contain. pm.expect now delegates to chai.expect(actual) when chai is loaded (AssertChain fallback for standalone pm.js), and the chai shim gains deep-aware include (subset semantics), within/closeTo/members (multiset semantics), plus the Postman status/header/jsonBody extensions so pm.expect(pm.response).to.have.status(200) survives delegation. Regression test covers every stock snippet plus false-green guards (deep-include primitives, members with multiplicity). Chained on fix/w1a-stoponerror-removal (PR #86); merge #86 first.