### PR TITLE
fix(chai): .deep.equal honors deep flag, kill dead .eql branch (W1-B #146)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -5818,6 +5818,17 @@ mod tests {
                 trial('resp_status_real', function () { pm.response.to.have.status(200); });
                 trial('chai_real', function () { chai.expect({ a: 1 }).to.deep.equal({ a: 1 }); });
                 trial('chai_should_real', function () { (5).should.equal(5); });
+                // Line 146: .deep.equal must honor the deep flag (deep-equal by
+                // value, fail-closed on mismatch, .not.deep.equal inverts,
+                // .eql stays deep, and PLAIN .equal on distinct objects must
+                // still throw — chai parity on all five).
+                trial('chai_deep_equal_ok', function () {
+                    chai.expect({ a: 1, b: { c: [1, 2] } }).to.deep.equal({ a: 1, b: { c: [1, 2] } });
+                });
+                trial('chai_deep_equal_mismatch', function () { chai.expect({ a: 1 }).to.deep.equal({ a: 2 }); });
+                trial('chai_deep_equal_negated', function () { chai.expect({ a: 1 }).to.not.deep.equal({ a: 2 }); });
+                trial('chai_eql_still_deep', function () { chai.expect({ a: 1 }).to.eql({ a: 1 }); });
+                trial('chai_shallow_equal_throws', function () { chai.expect({ a: 1 }).to.equal({ a: 1 }); });
                 // Real typos still throw (guard parity).
                 trial('pm_typo', function () { pm.expect(1).to.be.tostring; });
                 trial('chai_typo', function () { chai.expect(1).to.be.tostring; });
@@ -5844,6 +5855,11 @@ mod tests {
                 ("resp_status_real", "true"),
                 ("chai_real", "true"),
                 ("chai_should_real", "true"),
+                ("chai_deep_equal_ok", "true"),
+                ("chai_deep_equal_mismatch", "threw"),
+                ("chai_deep_equal_negated", "true"),
+                ("chai_eql_still_deep", "true"),
+                ("chai_shallow_equal_throws", "threw"),
                 ("pm_typo", "threw"),
                 ("chai_typo", "threw"),
             ] {

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -293,18 +293,12 @@ var chai = chai || {};
         return this;
     };
 
-    // .eql(expected) — deep equality
+    // .eql(expected) — deep equality (chai's .eql is ALWAYS deep, so the
+    // deep flag is irrelevant here; the `if (deep || true)` dead branch is
+    // gone — line 146 of the master TODO).
     Assertion.prototype.eql = function (value) {
         var negate = !!(this.__flags && this.__flags.negate);
-        var deep = !!(this.__flags && this.__flags.deep);
-        var passed;
-
-        if (deep || true) {
-            // Always use deep comparison for .eql
-            passed = nativeDeepEqual(this._obj, value) !== negate;
-        } else {
-            passed = (this._obj === value) !== negate;
-        }
+        var passed = nativeDeepEqual(this._obj, value) !== negate;
 
         if (!passed) {
             throw new Error(


### PR DESCRIPTION
chai.expect({a:1}).to.deep.equal({a:1}) failed in the shim but passes in real chai — .equal only did shallow ===. The deep-honoring fix was already in place from the W1-A chain; this PR removes the dead if (deep || true) branch in .eql (its else was unreachable — chai's .eql is always deep) and pins the full behavior with five regression trials: nested deep.equal passes, mismatch throws, .not.deep.equal inverts, .eql stays deep, plain .equal on distinct objects still throws. Chained on fix/w1b-pm-expect-delegate-clean (PR #87); merge #87 first.