### PR TITLE
fix(pm): sendRequest callback runs once, real error propagates (W1-B #149)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4702,6 +4702,63 @@ mod tests {
     }
 
     #[test]
+    fn test_pm_send_request_callback_runs_once_and_real_error_propagates() {
+        // W1-B line 149: pm.sendRequest called the callback TWICE and
+        // replaced the real error. callback(null, resp) was invoked INSIDE
+        // the try, so a throw from the user's callback (a failing pm.expect
+        // — the entire point) was caught by the sibling catch and the
+        // callback re-entered with a bogus "Failed to parse sendRequest
+        // response" error. The callback must run exactly once and its real
+        // error must surface unchanged.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_pm_send_request = function () {
+                    return JSON.stringify({ code: 200, statusText: 'OK', body: '{}',
+                                            headers: {}, responseTime: 5 });
+                };
+                globalThis.__cb_runs = 0;
+                var thrown = null;
+                try {
+                    pm.sendRequest('http://ok/', function (err, resp) {
+                        globalThis.__cb_runs++;
+                        // A failing assertion inside the callback — the
+                        // canonical auth-token-fetch pattern.
+                        pm.expect(resp.code).to.eql(999);
+                    });
+                } catch (e) {
+                    thrown = e.message;
+                }
+                globalThis.__thrown = thrown;
+            "#,
+            )
+            .expect("script should eval");
+            let runs: i64 = ctx
+                .eval("globalThis.__cb_runs")
+                .expect("read callback run count");
+            assert_eq!(
+                runs, 1,
+                "callback must run exactly ONCE, not be re-entered by the sibling catch"
+            );
+            let thrown: String = ctx
+                .eval("globalThis.__thrown")
+                .expect("read thrown message");
+            assert!(
+                thrown.contains("eql 999"),
+                "the REAL assertion error must propagate: {thrown}"
+            );
+            assert!(
+                !thrown.contains("Failed to parse sendRequest response"),
+                "the bogus parse error must NOT replace the real error: {thrown}"
+            );
+        });
+    }
+
+    #[test]
     fn test_pm_response_members_are_value_properties() {
         // Backlog line 143: pm.response.code/status/responseTime/headers/
         // cookies are VALUE properties in Postman, not functions. The old

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -218,8 +218,16 @@ pub(crate) fn parse_metric_ref(metric_ref: &str) -> (&str, Vec<(&str, &str)>, Op
                 if pair.is_empty() {
                     return None;
                 }
-                // Support both `:` and `=` as key=value separators
-                let sep = if pair.contains(':') { ':' } else { '=' };
+                // Support both `:` and `=` as key=value separators. Pick the
+                // one that occurs FIRST positionally — a naive
+                // `contains(':') ? ':' : '='` makes the scheme colon win in
+                // `url=https://…` and splits into key "url=https" (never
+                // matches, silent `✗ 0.00 FAIL` — W1-B line 147).
+                let eq = pair.find('=').unwrap_or(usize::MAX);
+                let colon = pair.find(':').unwrap_or(usize::MAX);
+                // Neither present → '=' yields split_once None → pair dropped
+                // (pre-existing behavior preserved).
+                let sep = if eq <= colon { '=' } else { ':' };
                 pair.split_once(sep).map(|(k, v)| (k.trim(), v.trim()))
             })
             .collect()
@@ -2409,6 +2417,27 @@ mod tests {
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0], ("status", "200"));
         assert_eq!(stat, Some("p95"));
+    }
+
+    #[test]
+    fn test_parse_metric_ref_url_scoped_splits_on_first_separator() {
+        // W1-B line 147: `url=https://…` — the scheme colon must NOT win the
+        // split, or the key becomes "url=https" and the threshold silently
+        // never matches. The separator that occurs FIRST positionally wins.
+        let (name, tags, stat) =
+            parse_metric_ref("http_req_duration{url=https://api.x.dev/a?b=1}.p95");
+        assert_eq!(name, "http_req_duration");
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0], ("url", "https://api.x.dev/a?b=1"));
+        assert_eq!(stat, Some("p95"));
+
+        // Colon-scoped tags still split on the colon (no `=` present).
+        let (_, tags, _) = parse_metric_ref("http_req_duration{method:POST}.p95");
+        assert_eq!(tags, vec![("method", "POST")]);
+
+        // A key with an `=` BEFORE the scheme colon keeps the `=` split.
+        let (_, tags, _) = parse_metric_ref("http_req_duration{name=a=b}.p95");
+        assert_eq!(tags, vec![("name", "a=b")]);
     }
 
     #[test]

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -1315,8 +1315,16 @@ pm.sendRequest = function (options, callback) {
             (options && options.responseType) || 'text'
         );
 
-        // Fire callback with the response
+        // Fire callback with the response. The callback is invoked OUTSIDE
+        // the try: the old code called it INSIDE, so a throw from the user's
+        // callback (a failing pm.expect — the entire point of sendRequest)
+        // was caught by the sibling catch and the callback re-entered with a
+        // bogus "Failed to parse" error — running twice and replacing the
+        // real error (W1-B line 149). Parse/build here; call the user's code
+        // only once, after, so its exceptions propagate as-is.
         if (typeof callback === 'function') {
+            var cbErr = null;
+            var response = null;
             try {
                 var result = JSON.parse(resultJson);
                 // Backlog line 147: transport failures (DNS/conn refused/timeout)
@@ -1325,22 +1333,27 @@ pm.sendRequest = function (options, callback) {
                 // never fired. The bridge now stamps an `error` field; surface it
                 // as the first (err) argument so the canonical guard works.
                 if (result.error) {
-                    callback(new Error(result.error), null);
-                    return;
+                    cbErr = new Error(result.error);
+                } else {
+                    response = {
+                        code: result.code || 0,
+                        status: result.statusText || '',
+                        text: function () { return result.body || ''; },
+                        json: function () {
+                            try { return JSON.parse(result.body || '{}'); }
+                            catch (e) { return null; }
+                        },
+                        headers: function () { return result.headers || {}; },
+                        responseTime: result.responseTime || 0
+                    };
                 }
-                callback(null, {
-                    code: result.code || 0,
-                    status: result.statusText || '',
-                    text: function () { return result.body || ''; },
-                    json: function () {
-                        try { return JSON.parse(result.body || '{}'); }
-                        catch (e) { return null; }
-                    },
-                    headers: function () { return result.headers || {}; },
-                    responseTime: result.responseTime || 0
-                });
             } catch (e) {
-                callback(new Error('Failed to parse sendRequest response: ' + e.message), null);
+                cbErr = new Error('Failed to parse sendRequest response: ' + e.message);
+            }
+            if (cbErr) {
+                callback(cbErr, null);
+            } else {
+                callback(null, response);
             }
         }
         return;


### PR DESCRIPTION
callback(null, resp) was invoked INSIDE the try, so a throw from the user's callback (a failing pm.expect — the entire point of sendRequest) was caught by the sibling catch and the callback re-entered with a bogus 'Failed to parse sendRequest response' error — running twice and replacing the real error. The try now only parses JSON and builds the response (or cbErr for transport errors); the callback is invoked exactly once after the try/catch so its exceptions propagate as-is. Regression test asserts the callback runs exactly once and the thrown message is the real 'eql 999' error. Chained on fix/w1b-url-thresholds (PR #89); merge #89 first.