### PR TITLE
fix(pm): jsonBody string arg is a key path, not a whole-body deep-equal (W1-B #153)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -7366,6 +7366,23 @@ mod tests {
                 globalThis.__have_json_body = String((function () {
                     try { pm.response.to.have.jsonBody({ a: 1 }); return 'passed'; } catch (e) { return 'threw'; }
                 })());
+                // W1-B line 153: a STRING arg is a KEY PATH (chai-postman
+                // semantics), not a deep-equal of the whole body — the old
+                // code `deepEqual(body, 'a')` always threw on an object body,
+                // so `to.have.jsonBody('key')` was a false failure.
+                globalThis.__have_json_body_key = String((function () {
+                    try { pm.response.to.have.jsonBody('a'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                globalThis.__have_json_body_key_missing = String((function () {
+                    try { pm.response.to.have.jsonBody('b'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                // Two-arg form asserts the VALUE at the path too.
+                globalThis.__have_json_body_key_value_ok = String((function () {
+                    try { pm.response.to.have.jsonBody('a', 1); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                globalThis.__have_json_body_key_value_bad = String((function () {
+                    try { pm.response.to.have.jsonBody('a', 2); return 'passed'; } catch (e) { return 'threw'; }
+                })());
             "#,
             )
             .expect("script should eval");
@@ -7383,6 +7400,10 @@ mod tests {
             assert_eq!(ctx.eval::<String, _>("__have_hdr").unwrap(), "passed", "to.have.header must pass when header matches");
             assert_eq!(ctx.eval::<String, _>("__have_body").unwrap(), "passed", "to.have.body must pass when substring present");
             assert_eq!(ctx.eval::<String, _>("__have_json_body").unwrap(), "passed", "to.have.jsonBody must deep-compare");
+            assert_eq!(ctx.eval::<String, _>("__have_json_body_key").unwrap(), "passed", "jsonBody('a') must pass when the key exists (string = key path)");
+            assert_eq!(ctx.eval::<String, _>("__have_json_body_key_missing").unwrap(), "threw", "jsonBody('b') must throw when the key is missing");
+            assert_eq!(ctx.eval::<String, _>("__have_json_body_key_value_ok").unwrap(), "passed", "jsonBody('a', 1) must pass when the value matches");
+            assert_eq!(ctx.eval::<String, _>("__have_json_body_key_value_bad").unwrap(), "threw", "jsonBody('a', 2) must throw when the value mismatches");
 
             // The EXACT silent-pass the backlog verified (line 42): a bare
             // PROPERTY read `pm.response.to.be.json;` on a non-JSON body used
@@ -7435,6 +7456,66 @@ mod tests {
             );
             let err: String = obj.get("error").expect("error field");
             assert!(!err.is_empty(), "envelope must carry an error message");
+        });
+    }
+
+    #[test]
+    fn test_pm_jsonbody_string_key_path_parity() {
+        // W1-B line 153: jsonBody("key") must be a KEY-PATH existence check
+        // (chai-postman), not a deep-equal of the whole body — the old code
+        // `deepEqual(body, 'a')` always threw on an object body. Also pins
+        // the lodash-`get` reached-tracking corners: a present-null key
+        // ({a: null}) passes jsonBody('a'), a null MID-path ({a:null}, 'a.b')
+        // is MISSING (so the negated form passes). Exercises BOTH
+        // implementations: pm.js's pm.response.to.have chain and chai-shim's
+        // Assertion (pm.expect delegates to chai when it is loaded).
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
+                .expect("chai shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_pm_response_code = function () { return 200; };
+                globalThis.__tropel_pm_response_header = function (k) {
+                    if (String(k).toLowerCase() === 'content-type') return 'application/json';
+                    return null;
+                };
+                globalThis.__tropel_pm_response_headers = function () {
+                    return { 'Content-Type': 'application/json' };
+                };
+                // Present-NULL body: {a: null} — the key EXISTS with a null
+                // value, so jsonBody('a') must PASS (lodash get parity).
+                globalThis.__tropel_pm_response_json = function () { return '{"a":null}'; };
+                globalThis.__tropel_pm_response_body = function () { return '{"a":null}'; };
+
+                // pm.js chain: present-null key passes.
+                globalThis.__jb_null_key_pm = String((function () {
+                    try { pm.response.to.have.jsonBody('a'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                // pm.js chain: null MID-path is MISSING → throws.
+                globalThis.__jb_null_midpath_pm = String((function () {
+                    try { pm.response.to.have.jsonBody('a.b'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                // chai path (pm.expect delegates to chai): present-null passes.
+                globalThis.__jb_null_key_chai = String((function () {
+                    try { pm.expect(pm.response).to.have.jsonBody('a'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+                // chai path NEGATED: null mid-path is missing, so
+                // .not.jsonBody('a.b') must PASS (no TypeError).
+                globalThis.__jb_null_midpath_chai_not = String((function () {
+                    try { pm.expect(pm.response).to.not.have.jsonBody('a.b'); return 'passed'; } catch (e) { return 'threw'; }
+                })());
+            "#,
+            )
+            .expect("script should eval");
+
+            assert_eq!(ctx.eval::<String, _>("__jb_null_key_pm").unwrap(), "passed", "jsonBody('a') on {{a:null}} must pass (present-null key, pm.js chain)");
+            assert_eq!(ctx.eval::<String, _>("__jb_null_midpath_pm").unwrap(), "threw", "jsonBody('a.b') on {{a:null}} must throw (null mid-path = missing)");
+            assert_eq!(ctx.eval::<String, _>("__jb_null_key_chai").unwrap(), "passed", "chai pm.expect jsonBody('a') on {{a:null}} must pass");
+            assert_eq!(ctx.eval::<String, _>("__jb_null_midpath_chai_not").unwrap(), "passed", "negated .not.jsonBody('a.b') on {{a:null}} must pass, not TypeError");
         });
     }
 

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -869,10 +869,38 @@ var chai = chai || {};
         }
         return this;
     };
-    Assertion.prototype.jsonBody = function (expected) {
+    Assertion.prototype.jsonBody = function (expected, expectedValue) {
         var body = (typeof pm !== 'undefined' && pm.response) ? pm.response.json() : undefined;
         var negate = !!(this.__flags && this.__flags.negate);
-        var passed = nativeDeepEqual(body, expected) !== negate;
+        var passed;
+        if (typeof expected === 'string') {
+            // W1-B line 153: chai-postman treats a STRING as a KEY PATH, not
+            // a deep-equal of the whole body — the old code deep-equal'd
+            // `body` against the string, so `to.have.jsonBody('key')` always
+            // threw on an object body (false failure). `jsonBody('a.b')`
+            // asserts the path EXISTS; `jsonBody('a.b', 7)` asserts the
+            // value at that path.
+            var parts = expected.split('.');
+            var node = body;
+            // lodash `get` parity: only `undefined` at the FINAL segment
+            // means MISSING (a present-null key like `{a: null}` passes
+            // `jsonBody('a')`), but a null MID-path stops the walk — so
+            // track `reached` to tell "final value is null" from "stopped
+            // mid-path" (the latter is a missing path, so a negated
+            // `.not.jsonBody('a.b')` on `{a:null}` must PASS).
+            var reached = 0;
+            for (; reached < parts.length && node !== undefined && node !== null; reached++) {
+                node = node[parts[reached]];
+            }
+            var hasKey = reached === parts.length && node !== undefined;
+            if (expectedValue !== undefined) {
+                passed = (hasKey && nativeDeepEqual(node, expectedValue)) !== negate;
+            } else {
+                passed = hasKey !== negate;
+            }
+        } else {
+            passed = nativeDeepEqual(body, expected) !== negate;
+        }
         if (!passed) {
             throw new Error(
                 (this._msg ? this._msg + ': ' : '') +

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -461,8 +461,39 @@ pm.response.to = guardChain({
                 throw new Error('expected response body to contain ' + shortJson(substring));
             }
         },
-        jsonBody: function (expected) {
+        jsonBody: function (expected, expectedValue) {
             var body = pm.response.json();
+            if (typeof expected === 'string') {
+                // W1-B line 153: chai-postman treats a STRING as a KEY PATH,
+                // not a deep-equal of the whole body — the old code
+                // `deepEqual(body, 'key')` always threw on an object body, so
+                // the canonical `pm.response.to.have.jsonBody('key')` snippet
+                // was a false failure. `jsonBody('user.id')` asserts the
+                // path EXISTS; `jsonBody('user.id', 7)` asserts the value at
+                // that path too.
+                var parts = expected.split('.');
+                var node = body;
+                // lodash `get` parity: only `undefined` at the FINAL segment
+                // means MISSING (a present-null key like `{a: null}` passes
+                // `jsonBody('a')`), but a null MID-path stops the walk — so
+                // track `reached` to tell "final value is null" from
+                // "stopped mid-path" (the latter is a missing path, so a
+                // negated `.not.jsonBody('a.b')` on `{a:null}` must PASS).
+                var reached = 0;
+                for (; reached < parts.length && node !== undefined && node !== null; reached++) {
+                    node = node[parts[reached]];
+                }
+                if (reached !== parts.length || node === undefined) {
+                    throw new Error('expected response JSON body to have key ' + expected);
+                }
+                if (expectedValue !== undefined && !deepEqual(node, expectedValue)) {
+                    throw new Error(
+                        'expected ' + expected + ' to equal ' + shortJson(expectedValue) +
+                        ', got ' + shortJson(node)
+                    );
+                }
+                return;
+            }
             if (!deepEqual(body, expected)) {
                 throw new Error('expected response JSON body to match');
             }


### PR DESCRIPTION
pm.response.to.have.jsonBody('key') deep-equal'd the string against the whole body, so the canonical chai-postman existence idiom threw on any object body (false failure). A string arg is now a dotted KEY PATH with lodash-get parity: only undefined at the final segment means MISSING, a present-null key ({a:null}) passes jsonBody('a'), and a null MID-path stops the walk (reached-tracking) so a negated .not.jsonBody('a.b') passes instead of TypeErring. The two-arg form jsonBody('a.b', 7) also asserts the value at the path. Mirrored in both pm.js's have chain and chai-shim's Assertion (pm.expect delegates to chai). Regression trials in the status-classes test plus a dedicated test_pm_jsonbody_string_key_path_parity exercising both shims and the null/negated corners. Chained on fix/w1b-summary-unscoped-dur (PR #93); merge #93 first.