### PR TITLE
fix(shims): one shim list with bru, and three bru.js bugs (W2 #182)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -5027,6 +5027,12 @@ mod tests {
                     throw new Error('setVar must not write collection vars');
                 };
                 globalThis.__tropel_pm_collection_vars_to_object = function () {
+                    throw new Error('getAllVars must not read collection vars');
+                };
+                // W2 line 182: getAllVars reads the LOCAL store setVar writes
+                // (the old code read collection_vars while setVar wrote
+                // local_vars — a runtime var never appeared in getAllVars).
+                globalThis.__tropel_pm_variables_to_object = function () {
                     return { userId: '42', token: '"abc"', flag: 'true' };
                 };
                 var v1 = bru.getVar('userId');
@@ -5077,6 +5083,111 @@ mod tests {
                 ctx.eval::<String, _>("__calls").unwrap(),
                 "get:userId|set:userId=42|get:userId|get:missing|unset:token|unset:userId|unset:token|unset:flag",
                 "getVar/setVar must hit the variables bridges (not collection), hasVar one lookup each, and deleteAllVars must unset every key"
+            );
+        });
+    }
+
+    #[test]
+    fn test_bru_get_env_var_unquotes_json_encoded() {
+        // W2 line 182: the environment_get bridge returns values JSON-encoded
+        // ("https://api.x" WITH literal quotes) so the correct JS type
+        // round-trips — the old bru.getEnvVar returned the raw string, so
+        // every URL built from the var was malformed. It must JSON.parse like
+        // pm.environment.get.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/bru.js"))
+                .expect("bru shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_pm_environment_get = function (key) {
+                    if (key === 'baseUrl') return '"https://api.example.com"';
+                    if (key === 'port') return '8080';
+                    return null;
+                };
+                globalThis.__base = bru.getEnvVar('baseUrl');
+                globalThis.__port = bru.getEnvVar('port');
+                globalThis.__missing_null = bru.getEnvVar('nope') === null;
+                // The canonical Bruno idiom: URL built from an unquoted var.
+                globalThis.__url = bru.getEnvVar('baseUrl') + '/users';
+                globalThis.__base_type = typeof bru.getEnvVar('baseUrl');
+            "#,
+            )
+            .expect("script should eval");
+            assert_eq!(
+                ctx.eval::<String, _>("__base").unwrap(),
+                "https://api.example.com",
+                "getEnvVar must strip the JSON quotes"
+            );
+            assert_eq!(
+                ctx.eval::<String, _>("__url").unwrap(),
+                "https://api.example.com/users",
+                "a URL built from getEnvVar must be well-formed (was malformed with literal quotes)"
+            );
+            assert_eq!(
+                ctx.eval::<String, _>("__base_type").unwrap(),
+                "string",
+                "getEnvVar must return a string, not a quoted JSON literal"
+            );
+            assert_eq!(
+                ctx.eval::<i64, _>("__port").unwrap(),
+                8080,
+                "JSON-encoded number restores as a number, like pm.environment.get"
+            );
+            assert!(
+                ctx.eval::<bool, _>("__missing_null").unwrap(),
+                "getEnvVar must return null on a miss"
+            );
+        });
+    }
+
+    #[test]
+    fn test_bru_assert_records_via_bool_bridge() {
+        // W2 line 182: bru.assert passed an INT (passed ? 1 : 0) where the
+        // __tropel_pm_test bridge takes a BOOL — rquickjs 0.12 has no bool
+        // coercion, so every call THREW (pm.js:506-508 warns about the rule).
+        // It also passed only 2 of the bridge's 3 args. It now passes a real
+        // bool + the empty tags string.
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/bru.js"))
+                .expect("bru shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                var __calls = [];
+                globalThis.__tropel_pm_test = function (name, passed, tags) {
+                    __calls.push(name + '|' + passed + '|' + typeof passed + '|' + tags);
+                };
+                bru.assert('1 === 1', 'one equals one');
+                bru.assert('1 === 2', 'one equals two');
+                // String form: the expression text is the default name.
+                bru.assert('2 > 1');
+                globalThis.__calls = __calls.join('\n');
+                globalThis.__n = __calls.length;
+            "#,
+            )
+            .expect("script should eval");
+            let calls: String = ctx.eval("__calls").expect("read recorded calls");
+            let lines: Vec<&str> = calls.lines().collect();
+            assert_eq!(
+                lines.len(),
+                3,
+                "three bru.assert calls must record: {calls}"
+            );
+            // Bool, not int, and the 3rd (tags) arg present.
+            assert!(
+                lines[0].contains("|true|boolean|"),
+                "pass must be a real bool: {calls}"
+            );
+            assert!(
+                lines[1].contains("|false|boolean|"),
+                "fail must be a real bool: {calls}"
+            );
+            assert!(
+                lines[0].contains("one equals one") && lines[2].contains("2 > 1"),
+                "name must carry the message or the expression: {calls}"
             );
         });
     }

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -22,6 +22,13 @@ pub(crate) const SHIM_BUNDLE_VERSION: &str = "0.1.0";
 
 /// All shim libraries concatenated at COMPILE TIME (concat!) into a single
 /// `&'static str`, byte-identical for every VU and every scenario.
+///
+/// W2 line 182: this list MUST mirror [`ShimBundle::default`] exactly — it
+/// previously carried only 5 shims while the default bundle carried 6 (with
+/// bru), so the bytecode path short-circuited on `is_default()` and bru.js
+/// was compiled into the binary but NEVER evaluated (`typeof bru ===
+/// 'undefined'` in every engine VU). Keep the two in lockstep: same 6 shims,
+/// same order, same section headers.
 const JS_SHIM_BUNDLE: &str = concat!(
     "// ==== shim: pm-shim ====\n",
     include_str!("../../../js/scripting-api/pm.js"),
@@ -37,6 +44,9 @@ const JS_SHIM_BUNDLE: &str = concat!(
     "\n",
     "// ==== shim: exec-shim ====\n",
     include_str!("../../../js/exec/exec.js"),
+    "\n",
+    "// ==== shim: bru-shim ====\n",
+    include_str!("../../../js/scripting-api/bru.js"),
 );
 
 /// One shim library: a name + its source text.
@@ -55,7 +65,8 @@ pub struct ShimBundle(pub Vec<ShimEntry>);
 impl ShimBundle {
     /// Render the bundle to source text, concatenated with section headers
     /// (byte-identical to the compile-time [`JS_SHIM_BUNDLE`] for the
-    /// default bundle).
+    /// default bundle — W2 line 182: both lists MUST enumerate the same 6
+    /// shims in the same order, or the bytecode path silently drops bru).
     pub fn render(&self) -> String {
         let mut out = String::new();
         for ShimEntry(name, src) in &self.0 {
@@ -342,6 +353,45 @@ mod tests {
     use tropel_sandbox::state::new_pm_state;
     use tropel_sdk::traits::DriverHttpClient;
 
+    /// W2 line 182: the TWO shim lists must stay in lockstep — JS_SHIM_BUNDLE
+    /// (the compile-time concat used by the bytecode path) used to carry 5
+    /// shims while ShimBundle::default() carried 6 (with bru), so bru.js was
+    /// compiled into the binary but NEVER evaluated (typeof bru ===
+    /// 'undefined' in every engine VU). Guard both invariants: the default
+    /// bundle must enumerate bru, and the bytecode source must embed the
+    /// same bru.js text.
+    #[test]
+    fn shim_lists_stay_in_lockstep_with_bru() {
+        let d = ShimBundle::default();
+        assert_eq!(
+            d.0.len(),
+            6,
+            "ShimBundle::default() must enumerate 6 shims (pm/chai/lodash/crypto/exec/bru)"
+        );
+        let bru_entry = d.0.iter().find(|e| e.0 == "bru-shim");
+        assert!(
+            bru_entry.is_some(),
+            "ShimBundle::default() must include the bru-shim entry"
+        );
+        let bru_src = bru_entry.expect("bru entry").1.as_ref();
+        assert!(
+            JS_SHIM_BUNDLE.contains(bru_src),
+            "JS_SHIM_BUNDLE must embed the same bru.js source as ShimBundle::default()"
+        );
+        assert_eq!(
+            d.0.iter().map(|e| e.0).collect::<Vec<_>>(),
+            vec![
+                "pm-shim",
+                "chai-shim",
+                "lodash-shim",
+                "cryptojs-shim",
+                "exec-shim",
+                "bru-shim"
+            ],
+            "shim order must match between JS_SHIM_BUNDLE and ShimBundle::default()"
+        );
+    }
+
     /// F1: `HttpClient` itself does not implement `DriverHttpClient` — the
     /// engine wraps it in `DriverHttpClientImpl` (vu_loop.rs). Reuse it here
     /// so the test builds the same trait object the VU loop passes.
@@ -383,13 +433,14 @@ mod tests {
             .eval(
                 "typeof acme === 'object' && typeof product === 'object' \
                  && product === acme && wire === acme && typeof pm === 'object' \
-                 && typeof trp === 'undefined' && typeof tropel === 'undefined'",
+                 && typeof bru === 'object' && typeof trp === 'undefined' \
+                 && typeof tropel === 'undefined'",
             )
             .await
             .expect("probe should eval");
         assert_eq!(
             check, "true",
-            "custom namespace/aliases must be installed via the preamble; default trp absent — got: {check}"
+            "custom namespace/aliases must be installed via the preamble; default trp absent; bru must be evaluated by the real bundle path — got: {check}"
         );
     }
 }

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -465,6 +465,24 @@ impl TrpBridge {
                 }),
             );
 
+            let state_clone = state.clone();
+            set_global!(
+                "__tropel_pm_variables_to_object",
+                // W2 line 182: the bru shim's getAllVars used to read the
+                // COLLECTION store while setVar writes LOCAL vars — a runtime
+                // var set via bru.setVar never appeared in getAllVars (the
+                // aliasing comment claimed the stores alias; they don't).
+                // Expose the LOCAL scope so the family is self-consistent:
+                // setVar → getAllVars round-trips.
+                Func::from(move || -> HashMap<String, String> {
+                    let st = state_clone.lock().unwrap();
+                    st.local_vars
+                        .iter()
+                        .map(|(k, v)| (k.clone(), variable_value_to_string(v)))
+                        .collect()
+                }),
+            );
+
             // ── Environment: has / toObject ──
             // Backlog line 145: Postman's pm.environment exposes has() and
             // toObject() alongside get/set/unset.

--- a/js/scripting-api/bru.js
+++ b/js/scripting-api/bru.js
@@ -19,7 +19,14 @@
     // Environment
     bru.getEnvVar = function (key) {
         if (typeof __tropel_pm_environment_get === 'function') {
-            return __tropel_pm_environment_get(key);
+            // W2 line 182: the bridge returns the value JSON-encoded ("..."
+            // with literal quotes) so the correct JS type round-trips — the
+            // old raw return meant getEnvVar('baseUrl') came back WITH the
+            // quotes and every URL built from it was malformed. Parse like
+            // pm.environment.get (pm.js:26).
+            var raw = __tropel_pm_environment_get(key);
+            if (raw === null || raw === undefined) return null;
+            try { return JSON.parse(raw); } catch (e) { return raw; }
         }
         return null;
     };
@@ -58,24 +65,24 @@
             __tropel_pm_variables_unset(key);
         }
     };
-    // NOTE (deleteAllVars cascade): getAllVars reads the store that the
-    // runtime vars currently alias onto, and deleteVar → variables_unset
-    // removes from collection_vars + environment + globals — so on a key
-    // collision this also clears an env/global var of the same name. Bounded
-    // by the documented §2 aliasing caveat; a scoped runtime-only unset needs
-    // a bridge change (TROPEL_PARITY_BRUNO.md §7).
+    // NOTE (deleteAllVars cascade): deleteVar → variables_unset removes from
+    // local + collection + environment + globals, so on a key collision this
+    // also clears an env/global var of the same name. A scoped runtime-only
+    // unset needs a bridge change (TROPEL_PARITY_BRUNO.md §7).
     bru.deleteAllVars = function () {
         var all = bru.getAllVars();
         for (var k in all) {
             if (Object.prototype.hasOwnProperty.call(all, k)) bru.deleteVar(k);
         }
     };
-    // getAllVars: the runtime store currently aliases onto collection_vars at
-    // the Rust state level (documented in TROPEL_PARITY_BRUNO.md §2), so the
-    // to_object bridge of that store is the honest view of "all runtime vars".
+    // getAllVars: reads the LOCAL runtime store that setVar writes
+    // (__tropel_pm_variables_to_object). W2 line 182: it used to read
+    // collection_vars while setVar wrote local_vars — the aliasing comment
+    // claimed the stores alias at the Rust level; they don't, so a runtime
+    // var set via setVar never appeared in getAllVars.
     bru.getAllVars = function () {
-        if (typeof __tropel_pm_collection_vars_to_object === 'function') {
-            var map = __tropel_pm_collection_vars_to_object() || {};
+        if (typeof __tropel_pm_variables_to_object === 'function') {
+            var map = __tropel_pm_variables_to_object() || {};
             var out = {};
             for (var k in map) {
                 if (Object.prototype.hasOwnProperty.call(map, k)) {
@@ -199,9 +206,14 @@
             passed = !!expr;
         }
         if (typeof __tropel_pm_test === 'function') {
+            // W2 line 182: the bridge takes (name, passed: BOOL, tags) — an
+            // int 1/0 has NO bool coercion in rquickjs (pm.js:506-508 warns
+            // about exactly this rule), so `passed ? 1 : 0` threw on EVERY
+            // call. Pass a real bool + the empty tags string like pm.test.
             __tropel_pm_test(
                 'bru.assert: ' + (errorMessage || String(expr)),
-                passed ? 1 : 0
+                passed ? true : false,
+                ''
             );
         }
     };


### PR DESCRIPTION
JS_SHIM_BUNDLE (the compile-time concat behind the bytecode path) carried only 5 shims while ShimBundle::default() carried 6 WITH bru — bootstrap_shims short-circuits the default into the bytecode path, so bru.js was compiled into the binary but NEVER evaluated (typeof bru === 'undefined' in every engine VU). The concat now mirrors the default bundle exactly (same 6 shims, same order, same headers), with a lockstep guard test pinning the invariant. Three bru.js bugs fixed alongside: (1) bru.getEnvVar returned the bridge value JSON-encoded (with literal quotes), malforming every URL built from it — now JSON.parses like pm.environment.get; (2) bru.getAllVars read COLLECTION vars while setVar writes LOCAL vars (the aliasing comment claiming the stores alias was false) — new __tropel_pm_variables_to_object bridge exposes the local scope so the family is self-consistent; (3) bru.assert passed an INT (passed ? 1 : 0) where the (name, bool, tags) bridge takes a BOOL (rquickjs 0.12 has no bool coercion — pm.js:506-508 warns about the rule) and only 2 of 3 args, so EVERY call threw — now passes a real bool + the empty tags string. Regression tests: engine config probe asserts typeof bru === 'object' through the real bundle path, plus shim_lists_stay_in_lockstep_with_bru, test_bru_get_env_var_unquotes_json_encoded, and test_bru_assert_records_via_bool_bridge. Gate: 5/5 bru tests, 2/2 engine js_bootstrap tests, fmt clean, clippy -D warnings clean. Chained on fix/w2-web-bootstrap-engine (PR #101); merge #101 first.