### PR TITLE
fix(npm): root workspace resolves @tropel/shims locally (W2 #186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,28 +254,33 @@ jobs:
           TROPEL_REQUIRE_WASM: "1"
         run: cargo test -p tropel-web --test native_vs_wasm
 
+      # P6 (@tropel/shims): the js/ shim bundle as an npm package. The smoke
+      # asserts the built bundle is byte-identical to the repo's js/ sources
+      # in the engine's ShimBundle::default() order — the single source of
+      # truth — so a stale copy fails the gate. MUST run BEFORE the
+      # runtime-wasm smoke (W2 #186): the root npm workspace resolves
+      # @tropel/shims to THIS local package, and runtime-wasm's tsc needs
+      # packages/shims/dist (gitignored) to exist.
+      - name: P6 shims npm smoke (@tropel/shims)
+        run: |
+          cd packages/shims
+          npm install --no-audit --no-fund
+          npm run build
+          node smoke.mjs
+
       # P6 (TROPEL_MODULARIZATION_TODO.md): @tropel/runtime-wasm — the npm host
       # that ships the wasm slice. Build the TS wrapper, copy the artifact
       # into the package (build.sh), and drive the same F3 fixture through
       # node:wasi from OUTSIDE Rust — proving the published package works.
       # TROPEL_REQUIRE_WASM=1 turns a missing artifact into a hard failure
-      # (same gate as the F3 harness).
+      # (same gate as the F3 harness). W2 #186: the root package.json
+      # workspace makes @tropel/shims resolve to packages/shims (NOT the
+      # npmjs.org copy), so a local js/ edit flows into this smoke too.
       - name: P6 npm smoke (@tropel/runtime-wasm)
         env:
           TROPEL_REQUIRE_WASM: "1"
         run: |
           cd packages/runtime-wasm
-          npm install --no-audit --no-fund
-          npm run build
-          node smoke.mjs
-
-      # P6 (@tropel/shims): the js/ shim bundle as an npm package. The smoke
-      # asserts the built bundle is byte-identical to the repo's js/ sources
-      # in the engine's ShimBundle::default() order — the single source of
-      # truth — so a stale copy fails the gate.
-      - name: P6 shims npm smoke (@tropel/shims)
-        run: |
-          cd packages/shims
           npm install --no-audit --no-fund
           npm run build
           node smoke.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ $RECYCLE.BIN/
 !packages/exec-wasm/package.json
 !packages/exec-wasm/tsconfig.json
 !packages/shims/package.json
+# W2 #186: the ROOT npm workspace manifest must be tracked — CI's npm install
+# resolves @tropel/shims to the local packages/ sibling only via this file.
+!/package.json
 !examples/openapi/working_api.json
 results/
 output/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tropel",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Monorepo root — npm workspace so @tropel/runtime-wasm resolves @tropel/shims from packages/ instead of npmjs.org (W2 #186).",
+  "license": "Apache-2.0",
+  "workspaces": [
+    "packages/*"
+  ]
+}


### PR DESCRIPTION
npm resolved @tropel/shims from npmjs.org in CI, so a local js/ edit flowed to the Rust harness (include_str!) while the npm smoke kept testing the published bundle.\n\n- Root package.json with workspaces [packages/*] — npm auto-symlinks the local sibling (the workspace: protocol is pnpm/yarn-only, npm 11 rejects it; file:../shims would embed a broken path in the published manifest)\n- CI builds shims BEFORE runtime-wasm (runtime-wasm tsc resolves @tropel/shims to packages/shims/dist, which is gitignored)\n- .gitignore un-ignores the root manifest (a blanket *.json rule was swallowing it)\n\nVerified locally: member-dir npm install resolves the LOCAL shims (defaultBundle length 6), shims smoke passes, runtime-wasm smoke PASSes against the local bundle.