### PR TITLE
fix(js): one canonical deep-equal shared by pm/chai/lodash shims (W2 #190)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -3504,6 +3504,9 @@ fn is_typescript_ext(path: &Path) -> bool {
 /// the promise queue, so one eval per phase cuts the per-VU bootstrap
 /// overhead ~4× beyond the bytecode win.
 const K6_BASE_SHIM_BUNDLE: &str = concat!(
+    "// ==== shim: deep-equal-shim ====\n",
+    include_str!("../../../../js/shared/deep-equal.js"),
+    "\n",
     "// ==== shim: chai-shim ====\n",
     include_str!("../../../../js/chai/chai-shim.js"),
     "\n",
@@ -4688,6 +4691,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -4745,6 +4750,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -4810,6 +4817,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -4866,6 +4875,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             // Stub the response bridges with known values.
@@ -5315,6 +5326,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -5380,10 +5393,16 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/lodash/lodash-shim.js"))
                 .expect("lodash shim should eval");
             ctx.eval::<(), _>(
@@ -5487,6 +5506,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -5565,8 +5586,12 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -5718,8 +5743,12 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
             ctx.eval::<(), _>(
@@ -5786,8 +5815,12 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -6023,8 +6056,12 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -6153,6 +6190,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -6219,6 +6258,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
             ctx.eval::<(), _>(
@@ -6288,6 +6329,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -6423,6 +6466,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -6544,6 +6589,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -7226,6 +7273,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -7312,6 +7361,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -7708,6 +7759,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -7917,8 +7970,12 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/chai/chai-shim.js"))
                 .expect("chai shim should eval");
             ctx.eval::<(), _>(
@@ -7974,6 +8031,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(
@@ -8070,6 +8129,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
             ctx.eval::<(), _>(

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -30,6 +30,9 @@ pub(crate) const SHIM_BUNDLE_VERSION: &str = "0.1.0";
 /// 'undefined'` in every engine VU). Keep the two in lockstep: same 6 shims,
 /// same order, same section headers.
 const JS_SHIM_BUNDLE: &str = concat!(
+    "// ==== shim: deep-equal-shim ====\n",
+    include_str!("../../../js/shared/deep-equal.js"),
+    "\n",
     "// ==== shim: pm-shim ====\n",
     include_str!("../../../js/scripting-api/pm.js"),
     "\n",
@@ -93,6 +96,10 @@ impl ShimBundle {
 impl Default for ShimBundle {
     fn default() -> Self {
         Self(vec![
+            ShimEntry(
+                "deep-equal-shim",
+                std::borrow::Cow::Borrowed(include_str!("../../../js/shared/deep-equal.js")),
+            ),
             ShimEntry(
                 "pm-shim",
                 std::borrow::Cow::Borrowed(include_str!("../../../js/scripting-api/pm.js")),
@@ -365,8 +372,8 @@ mod tests {
         let d = ShimBundle::default();
         assert_eq!(
             d.0.len(),
-            6,
-            "ShimBundle::default() must enumerate 6 shims (pm/chai/lodash/crypto/exec/bru)"
+            7,
+            "ShimBundle::default() must enumerate 7 shims (deep-equal/pm/chai/lodash/crypto/exec/bru)"
         );
         let bru_entry = d.0.iter().find(|e| e.0 == "bru-shim");
         assert!(
@@ -381,6 +388,7 @@ mod tests {
         assert_eq!(
             d.0.iter().map(|e| e.0).collect::<Vec<_>>(),
             vec![
+                "deep-equal-shim",
                 "pm-shim",
                 "chai-shim",
                 "lodash-shim",

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1318,6 +1318,10 @@ mod tests {
                 .expect("js context should construct"),
         );
         js_ctx
+            .eval(include_str!("../../../js/shared/deep-equal.js"))
+            .await
+            .expect("shared deep-equal should eval");
+        js_ctx
             .eval(include_str!("../../../js/scripting-api/pm.js"))
             .await
             .expect("pm shim should eval");
@@ -1425,6 +1429,10 @@ mod tests {
                 .expect("js context should construct"),
         );
         js_ctx
+            .eval(include_str!("../../../js/shared/deep-equal.js"))
+            .await
+            .expect("shared deep-equal should eval");
+        js_ctx
             .eval(include_str!("../../../js/scripting-api/pm.js"))
             .await
             .expect("pm shim should eval");
@@ -1522,6 +1530,10 @@ mod tests {
                 .expect("js context should construct"),
         );
         js_ctx
+            .eval(include_str!("../../../js/shared/deep-equal.js"))
+            .await
+            .expect("shared deep-equal should eval");
+        js_ctx
             .eval(include_str!("../../../js/scripting-api/pm.js"))
             .await
             .expect("pm shim should eval");
@@ -1578,6 +1590,10 @@ mod tests {
                 .await
                 .expect("js context should construct"),
         );
+        js_ctx
+            .eval(include_str!("../../../js/shared/deep-equal.js"))
+            .await
+            .expect("shared deep-equal should eval");
         js_ctx
             .eval(include_str!("../../../js/scripting-api/pm.js"))
             .await

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -1817,6 +1817,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
 
@@ -1895,6 +1897,8 @@ mod tests {
             };
             ctx.eval::<(), _>(cfg.render_js_preamble())
                 .expect("config preamble should eval");
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
 
@@ -1962,6 +1966,8 @@ mod tests {
         let rt = rquickjs::Runtime::new().unwrap();
         let ctx = rquickjs::Context::full(&rt).unwrap();
         ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/shared/deep-equal.js"))
+                .expect("shared deep-equal should eval");
             ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
                 .expect("pm shim should eval");
 

--- a/crates/tropel-web/src/bootstrap.rs
+++ b/crates/tropel-web/src/bootstrap.rs
@@ -18,7 +18,8 @@ use tropel_sandbox::state::SharedPmState;
 /// longer carries ~150–250 KB of uncompressed JS and a `pm.*` fix ships as a
 /// JS asset with the web app — no wasm rebuild, no release).
 #[cfg(not(target_arch = "wasm32"))]
-const SHIM_SOURCES: [&str; 6] = [
+const SHIM_SOURCES: [&str; 7] = [
+    include_str!("../../../js/shared/deep-equal.js"),
     include_str!("../../../js/scripting-api/pm.js"),
     include_str!("../../../js/chai/chai-shim.js"),
     include_str!("../../../js/lodash/lodash-shim.js"),

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -234,7 +234,8 @@ fn host_http(mut caller: Caller<'_, HostState>, req_ptr: i32, req_len: i32) -> i
 /// (bootstrap.rs::SHIM_SOURCES), joined with "\n" exactly like
 /// `shim_bundle()` does, so the two legs bootstrap identical shims.
 fn host_shim(mut caller: Caller<'_, HostState>) -> i64 {
-    const SHIM_SOURCES: [&str; 6] = [
+    const SHIM_SOURCES: [&str; 7] = [
+        include_str!("../../../js/shared/deep-equal.js"),
         include_str!("../../../js/scripting-api/pm.js"),
         include_str!("../../../js/chai/chai-shim.js"),
         include_str!("../../../js/lodash/lodash-shim.js"),

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -6,149 +6,16 @@
 var chai = chai || {};
 
 (function () {
-    // Proper JS deep-equal (handles NaN, undefined, key-order)
-    // Backlog line 85: Date/Set/Map/RegExp used to collapse to
-    // Object.keys() = [] — ANY two instances compared equal
-    // (chai.expect(new Set([1])).to.eql(new Set([9])) passed). They now
-    // compare by VALUE (time for Date, source+flags for RegExp, size +
-    // order-insensitive entries for Map/Set). Circular structures no longer
-    // overflow the stack (seen-pair guard: revisiting the exact (a,b) pair
-    // mid-compare is assumed equal).
-    function jsDeepEqual(a, b, seen) {
-        if (a === b) return true;
-        if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
-        if (a === null || b === null || a === undefined || b === undefined) return a === b;
-        if (typeof a !== typeof b) return false;
-        // Date: compare by epoch time; two invalid dates compare equal.
-        if (a instanceof Date || b instanceof Date) {
-            if (!(b instanceof Date)) return false;
-            var ta = a.getTime(), tb = b.getTime();
-            return (isNaN(ta) && isNaN(tb)) || ta === tb;
-        }
-        // RegExp: canonical toString (normalizes flag order — /gi vs /ig are
-        // the same expression, matching chai's deep-eql).
-        if (a instanceof RegExp || b instanceof RegExp) {
-            if (!(b instanceof RegExp)) return false;
-            return String(a) === String(b);
-        }
-        if (Array.isArray(a)) {
-            if (!Array.isArray(b) || a.length !== b.length) return false;
-            seen = seen || [];
-            for (var s = 0; s < seen.length; s++) {
-                if (seen[s][0] === a && seen[s][1] === b) return true;
-            }
-            seen.push([a, b]);
-            for (var i = 0; i < a.length; i++) {
-                if (!jsDeepEqual(a[i], b[i], seen)) {
-                    seen.pop();
-                    return false;
-                }
-            }
-            seen.pop();
-            return true;
-        }
-        if (typeof a === 'object') {
-            if (Array.isArray(b) || b === null || b === undefined) return false;
-            // Map: same size, each entry's key+value finds a deep-equal mate
-            // (order-insensitive).
-            if (a instanceof Map || b instanceof Map) {
-                if (!(b instanceof Map) || a.size !== b.size) return false;
-                // Cycle guard: Map nodes can be self-referential; revisiting the
-                // exact (a, b) pair mid-compare is assumed equal.
-                seen = seen || [];
-                for (var s = 0; s < seen.length; s++) {
-                    if (seen[s][0] === a && seen[s][1] === b) return true;
-                }
-                seen.push([a, b]);
-                var aEntries = Array.from(a.entries());
-                var bEntries = Array.from(b.entries());
-                var usedB = [];
-                outer:
-                for (var mi = 0; mi < aEntries.length; mi++) {
-                    for (var mj = 0; mj < bEntries.length; mj++) {
-                        if (usedB[mj]) continue;
-                        if (jsDeepEqual(aEntries[mi][0], bEntries[mj][0], seen) &&
-                            jsDeepEqual(aEntries[mi][1], bEntries[mj][1], seen)) {
-                            usedB[mj] = true;
-                            continue outer;
-                        }
-                    }
-                    seen.pop();
-                    return false;
-                }
-                seen.pop();
-                return true;
-            }
-            // Set: same size, each member finds a deep-equal mate.
-            if (a instanceof Set || b instanceof Set) {
-                if (!(b instanceof Set) || a.size !== b.size) return false;
-                // Cycle guard: Set nodes can be self-referential; revisiting the
-                // exact (a, b) pair mid-compare is assumed equal.
-                seen = seen || [];
-                for (var s = 0; s < seen.length; s++) {
-                    if (seen[s][0] === a && seen[s][1] === b) return true;
-                }
-                seen.push([a, b]);
-                var aMembers = Array.from(a);
-                var bMembers = Array.from(b);
-                var usedS = [];
-                outer2:
-                for (var si = 0; si < aMembers.length; si++) {
-                    for (var sj = 0; sj < bMembers.length; sj++) {
-                        if (usedS[sj]) continue;
-                        if (jsDeepEqual(aMembers[si], bMembers[sj], seen)) {
-                            usedS[sj] = true;
-                            continue outer2;
-                        }
-                    }
-                    seen.pop();
-                    return false;
-                }
-                seen.pop();
-                return true;
-            }
-            // Plain object: key-set comparison with a cycle guard.
-            seen = seen || [];
-            for (var k = 0; k < seen.length; k++) {
-                if (seen[k][0] === a && seen[k][1] === b) return true;
-            }
-            seen.push([a, b]);
-            var keysA = Object.keys(a).sort();
-            var keysB = Object.keys(b).sort();
-            if (keysA.length !== keysB.length) {
-                seen.pop();
-                return false;
-            }
-            for (var j = 0; j < keysA.length; j++) {
-                if (keysA[j] !== keysB[j] || !jsDeepEqual(a[keysA[j]], b[keysB[j]], seen)) {
-                    seen.pop();
-                    return false;
-                }
-            }
-            seen.pop();
-            return true;
-        }
-        return a === b;
+    // W2 line 190: single canonical deep-equal — js/shared/deep-equal.js
+    // (globalThis.__tropelDeepEqual), evaluated FIRST in every bundle. The
+    // per-shim copy is gone and so is the dead __tropel_native_deep_equal
+    // bridge (registered nowhere): chai captured it at LOAD time while
+    // lodash checked at CALL time, so if it were ever registered the two
+    // shims would have DIVERGED. Both names now delegate to the canonical.
+    function jsDeepEqual(a, b) {
+        return globalThis.__tropelDeepEqual(a, b);
     }
-
-    // Use native deep-equal via JSON-string bridge if available
-    var nativeDeepEqual = (typeof __tropel_native_deep_equal === 'function')
-        ? function (a, b) {
-            // Handle NaN/undefined in JS before calling native bridge
-            if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
-            if (a === b) return true;
-            if (a === null || a === undefined || b === null || b === undefined) return a === b;
-            // Backlog line 85: JSON.stringify collapses Date/Set/Map/RegExp
-            // (Date → ISO string, others → "{}") so typed values must never
-            // go through the string bridge — the JS impl compares them by
-            // value.
-            if (a instanceof Date || a instanceof RegExp || a instanceof Set || a instanceof Map ||
-                b instanceof Date || b instanceof RegExp || b instanceof Set || b instanceof Map) {
-                return jsDeepEqual(a, b);
-            }
-            return __tropel_native_deep_equal(JSON.stringify(a), JSON.stringify(b));
-        }
-        : jsDeepEqual;
+    var nativeDeepEqual = jsDeepEqual;
 
     // chai's type() name for a value (backlog line 104: a/an were not
     // callable — they were plain getters returning `this`, so

--- a/js/lodash/lodash-shim.js
+++ b/js/lodash/lodash-shim.js
@@ -469,146 +469,17 @@ var _ = _ || {};
         return deep(value);
     };
 
-    // Backlog line 85: Date/Set/Map/RegExp used to collapse to
-    // Object.keys() = [] — ANY two instances compared equal. They now
-    // compare by VALUE (time for Date, source+flags for RegExp, size +
-    // order-insensitive entries for Map/Set). Circular structures no longer
-    // overflow the stack (seen-pair guard: revisiting the exact (a,b) pair
-    // mid-compare is assumed equal).
-    function isEqualDeep(a, b, seen) {
-        if (a === b) return true;
-        if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
-        if (a === null || b === null || a === undefined || b === undefined) return a === b;
-        if (typeof a !== typeof b) return false;
-        // Date: compare by epoch time; two invalid dates compare equal.
-        if (a instanceof Date || b instanceof Date) {
-            if (!(b instanceof Date)) return false;
-            var ta = a.getTime(), tb = b.getTime();
-            return (isNaN(ta) && isNaN(tb)) || ta === tb;
-        }
-        // RegExp: source + flags.
-        if (a instanceof RegExp || b instanceof RegExp) {
-            if (!(b instanceof RegExp)) return false;
-            // Canonical toString normalizes flag order (/gi vs /ig equal),
-            // matching lodash's isEqual.
-            return String(a) === String(b);
-        }
-        if (Array.isArray(a)) {
-            if (!Array.isArray(b) || a.length !== b.length) return false;
-            seen = seen || [];
-            for (var s = 0; s < seen.length; s++) {
-                if (seen[s][0] === a && seen[s][1] === b) return true;
-            }
-            seen.push([a, b]);
-            for (var i = 0; i < a.length; i++) {
-                if (!isEqualDeep(a[i], b[i], seen)) {
-                    seen.pop();
-                    return false;
-                }
-            }
-            seen.pop();
-            return true;
-        }
-        if (typeof a === 'object') {
-            if (Array.isArray(b) || b === null || b === undefined) return false;
-            // Map: same size, each entry's key+value finds a deep-equal mate
-            // (order-insensitive).
-            if (a instanceof Map || b instanceof Map) {
-                if (!(b instanceof Map) || a.size !== b.size) return false;
-                // Cycle guard: Map nodes can be self-referential; revisiting the
-                // exact (a, b) pair mid-compare is assumed equal.
-                seen = seen || [];
-                for (var s = 0; s < seen.length; s++) {
-                    if (seen[s][0] === a && seen[s][1] === b) return true;
-                }
-                seen.push([a, b]);
-                var aEntries = Array.from(a.entries());
-                var bEntries = Array.from(b.entries());
-                var usedB = [];
-                outer:
-                for (var mi = 0; mi < aEntries.length; mi++) {
-                    for (var mj = 0; mj < bEntries.length; mj++) {
-                        if (usedB[mj]) continue;
-                        if (isEqualDeep(aEntries[mi][0], bEntries[mj][0], seen) &&
-                            isEqualDeep(aEntries[mi][1], bEntries[mj][1], seen)) {
-                            usedB[mj] = true;
-                            continue outer;
-                        }
-                    }
-                    seen.pop();
-                    return false;
-                }
-                seen.pop();
-                return true;
-            }
-            // Set: same size, each member finds a deep-equal mate.
-            if (a instanceof Set || b instanceof Set) {
-                if (!(b instanceof Set) || a.size !== b.size) return false;
-                // Cycle guard: Set nodes can be self-referential; revisiting the
-                // exact (a, b) pair mid-compare is assumed equal.
-                seen = seen || [];
-                for (var s = 0; s < seen.length; s++) {
-                    if (seen[s][0] === a && seen[s][1] === b) return true;
-                }
-                seen.push([a, b]);
-                var aMembers = Array.from(a);
-                var bMembers = Array.from(b);
-                var usedS = [];
-                outer2:
-                for (var si = 0; si < aMembers.length; si++) {
-                    for (var sj = 0; sj < bMembers.length; sj++) {
-                        if (usedS[sj]) continue;
-                        if (isEqualDeep(aMembers[si], bMembers[sj], seen)) {
-                            usedS[sj] = true;
-                            continue outer2;
-                        }
-                    }
-                    seen.pop();
-                    return false;
-                }
-                seen.pop();
-                return true;
-            }
-            // Plain object: key-set comparison with a cycle guard.
-            seen = seen || [];
-            for (var k = 0; k < seen.length; k++) {
-                if (seen[k][0] === a && seen[k][1] === b) return true;
-            }
-            seen.push([a, b]);
-            var keysA = Object.keys(a).sort();
-            var keysB = Object.keys(b).sort();
-            if (keysA.length !== keysB.length) {
-                seen.pop();
-                return false;
-            }
-            for (var j = 0; j < keysA.length; j++) {
-                if (keysA[j] !== keysB[j] || !isEqualDeep(a[keysA[j]], b[keysB[j]], seen)) {
-                    seen.pop();
-                    return false;
-                }
-            }
-            seen.pop();
-            return true;
-        }
-        return a === b;
+    // W2 line 190: single canonical deep-equal — js/shared/deep-equal.js
+    // (globalThis.__tropelDeepEqual), evaluated FIRST in every bundle. The
+    // per-shim copy is gone and so is the dead __tropel_native_deep_equal
+    // bridge (registered nowhere): lodash checked it at CALL time while
+    // chai captured it at LOAD time, so if it were ever registered the two
+    // shims would have DIVERGED. _.isEqual delegates to the canonical.
+    function isEqualDeep(a, b) {
+        return globalThis.__tropelDeepEqual(a, b);
     }
 
     _.isEqual = function (a, b) {
-        // Use native deep-equal via JSON-string bridge if available
-        if (typeof __tropel_native_deep_equal === 'function') {
-            if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
-            if (a === b) return true;
-            if (a === null || a === undefined || b === null || b === undefined) return a === b;
-            // Backlog line 85: JSON.stringify collapses Date/Set/Map/RegExp
-            // (Date → ISO string, others → "{}") so typed values must never
-            // go through the string bridge — the JS impl compares them by
-            // value.
-            if (a instanceof Date || a instanceof RegExp || a instanceof Set || a instanceof Map ||
-                b instanceof Date || b instanceof RegExp || b instanceof Set || b instanceof Map) {
-                return isEqualDeep(a, b);
-            }
-            return __tropel_native_deep_equal(JSON.stringify(a), JSON.stringify(b));
-        }
         return isEqualDeep(a, b);
     };
 

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -1040,133 +1040,14 @@ function shortJson(v) {
 }
 
 // Proper JS deep-equality (chai .eql semantics): handles NaN, undefined,
-// key order, nested arrays/objects. Mirrors the jsDeepEqual in
-// js/chai/chai-shim.js — the backlog fix for .eql must not depend on chai
-// being loaded first (pm.js is bundled standalone).
-//
-// Backlog line 85: Date/Set/Map/RegExp used to collapse to Object.keys()
-// = [] — ANY two instances compared equal (pm.expect(new Date(1))
-// .to.eql(new Date(999999)) passed). They now compare by VALUE (time for
-// Date, source+flags for RegExp, size + order-insensitive entries for
-// Map/Set). Circular structures no longer overflow the stack (a seen-pair
-// guard: revisiting the exact (a,b) pair mid-compare is assumed equal).
+// key order, nested arrays/objects. W2 line 190: the single canonical
+// implementation now lives in js/shared/deep-equal.js
+// (globalThis.__tropelDeepEqual), evaluated FIRST in every bundle. This
+// thin wrapper keeps pm.js's internal call sites (jsonPath, to.have.jsonBody,
+// pm.expect AssertChain) working — and, because chai-shim and lodash-shim
+// delegate to the SAME function, a fix here can no longer skew the others.
 function deepEqual(a, b, seen) {
-    if (a === b) return true;
-    if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
-    if (a === null || b === null || a === undefined || b === undefined) return a === b;
-    if (typeof a !== typeof b) return false;
-    // Date: compare by epoch time; two invalid dates compare equal.
-    if (a instanceof Date || b instanceof Date) {
-        if (!(b instanceof Date)) return false;
-        var ta = a.getTime(), tb = b.getTime();
-        return (isNaN(ta) && isNaN(tb)) || ta === tb;
-    }
-    // RegExp: canonical toString (normalizes flag order — /gi vs /ig are
-    // the same expression, matching chai's deep-eql).
-    if (a instanceof RegExp || b instanceof RegExp) {
-        if (!(b instanceof RegExp)) return false;
-        return String(a) === String(b);
-    }
-    if (Array.isArray(a)) {
-        if (!Array.isArray(b) || a.length !== b.length) return false;
-        seen = seen || [];
-        for (var s = 0; s < seen.length; s++) {
-            if (seen[s][0] === a && seen[s][1] === b) return true;
-        }
-        seen.push([a, b]);
-        for (var i = 0; i < a.length; i++) {
-            if (!deepEqual(a[i], b[i], seen)) {
-                seen.pop();
-                return false;
-            }
-        }
-        seen.pop();
-        return true;
-    }
-    if (typeof a === 'object') {
-        if (Array.isArray(b) || b === null || b === undefined) return false;
-        // Map: same size, each entry's key+value finds a deep-equal mate
-        // (order-insensitive).
-        if (a instanceof Map || b instanceof Map) {
-            if (!(b instanceof Map) || a.size !== b.size) return false;
-            // Cycle guard: Map nodes can be self-referential (a Map whose value
-            // is itself); revisiting the exact (a, b) pair mid-compare is
-            // assumed equal.
-            seen = seen || [];
-            for (var s = 0; s < seen.length; s++) {
-                if (seen[s][0] === a && seen[s][1] === b) return true;
-            }
-            seen.push([a, b]);
-            var aEntries = Array.from(a.entries());
-            var bEntries = Array.from(b.entries());
-            var usedB = [];
-            outer:
-            for (var mi = 0; mi < aEntries.length; mi++) {
-                for (var mj = 0; mj < bEntries.length; mj++) {
-                    if (usedB[mj]) continue;
-                    if (deepEqual(aEntries[mi][0], bEntries[mj][0], seen) &&
-                        deepEqual(aEntries[mi][1], bEntries[mj][1], seen)) {
-                        usedB[mj] = true;
-                        continue outer;
-                    }
-                }
-                seen.pop();
-                return false;
-            }
-            seen.pop();
-            return true;
-        }
-        // Set: same size, each member finds a deep-equal mate.
-        if (a instanceof Set || b instanceof Set) {
-            if (!(b instanceof Set) || a.size !== b.size) return false;
-            // Cycle guard: Set nodes can be self-referential (a Set containing
-            // itself); revisiting the exact (a, b) pair mid-compare is assumed
-            // equal.
-            seen = seen || [];
-            for (var s = 0; s < seen.length; s++) {
-                if (seen[s][0] === a && seen[s][1] === b) return true;
-            }
-            seen.push([a, b]);
-            var aMembers = Array.from(a);
-            var bMembers = Array.from(b);
-            var usedS = [];
-            outer2:
-            for (var si = 0; si < aMembers.length; si++) {
-                for (var sj = 0; sj < bMembers.length; sj++) {
-                    if (usedS[sj]) continue;
-                    if (deepEqual(aMembers[si], bMembers[sj], seen)) {
-                        usedS[sj] = true;
-                        continue outer2;
-                    }
-                }
-                seen.pop();
-                return false;
-            }
-            seen.pop();
-            return true;
-        }
-        // Plain object: key-set comparison with a cycle guard.
-        seen = seen || [];
-        for (var k = 0; k < seen.length; k++) {
-            if (seen[k][0] === a && seen[k][1] === b) return true;
-        }
-        seen.push([a, b]);
-        var keysA = Object.keys(a).sort();
-        var keysB = Object.keys(b).sort();
-        if (keysA.length !== keysB.length) {
-            seen.pop();
-            return false;
-        }
-        for (var j = 0; j < keysA.length; j++) {
-            if (keysA[j] !== keysB[j] || !deepEqual(a[keysA[j]], b[keysB[j]], seen)) {
-                seen.pop();
-                return false;
-            }
-        }
-        seen.pop();
-        return true;
-    }
-    return a === b;
+    return globalThis.__tropelDeepEqual(a, b, seen);
 }
 
 // Backlog line 88: chai's .include semantics — substring for strings,

--- a/js/shared/deep-equal.js
+++ b/js/shared/deep-equal.js
@@ -1,0 +1,143 @@
+// ══════════════════════════════════════════════════════════════════
+// W2 line 190 (TROPEL_MASTER_TODO.md): THE canonical deep-equal.
+//
+// pm.js `deepEqual`, chai-shim `jsDeepEqual`/`nativeDeepEqual`, and
+// lodash-shim `isEqualDeep` used to carry three near-identical copies —
+// they agreed on 9/9 inputs today, which is exactly why a fix to one would
+// silently skew the others. All three now DELEGATE to
+// `globalThis.__tropelDeepEqual` defined here.
+//
+// Load order: this file must be evaluated FIRST in every bundle (the
+// engine's JS_SHIM_BUNDLE / ShimBundle::default, the k6 driver's
+// K6_BASE_SHIM_BUNDLE, the web SHIM_SOURCES, @tropel/shims). It is
+// IDEMPOTENT — re-evaluation is a no-op, so a test that evals it before
+// several shims in sequence is safe.
+//
+// Semantics (locked by the driver's deep-equal regression tests):
+//   • NaN == NaN, key order irrelevant, cycles never overflow the stack
+//     (seen-pair guard: revisiting the exact (a,b) pair is assumed equal)
+//   • Date by epoch time (two invalid dates compare equal)
+//   • RegExp by canonical toString (flag order normalized: /gi == /ig)
+//   • Map/Set by size + order-insensitive deep-equal mates
+//   • plain objects by sorted key-set + recursive values
+// ══════════════════════════════════════════════════════════════════
+if (typeof globalThis.__tropelDeepEqual !== 'function') {
+    globalThis.__tropelDeepEqual = function __tropelDeepEqual(a, b, seen) {
+        if (a === b) return true;
+        if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) return true;
+        if (a === null || b === null || a === undefined || b === undefined) return a === b;
+        if (typeof a !== typeof b) return false;
+        // Date: compare by epoch time; two invalid dates compare equal.
+        if (a instanceof Date || b instanceof Date) {
+            if (!(b instanceof Date)) return false;
+            var ta = a.getTime(), tb = b.getTime();
+            return (isNaN(ta) && isNaN(tb)) || ta === tb;
+        }
+        // RegExp: canonical toString (normalizes flag order — /gi vs /ig are
+        // the same expression, matching chai's deep-eql).
+        if (a instanceof RegExp || b instanceof RegExp) {
+            if (!(b instanceof RegExp)) return false;
+            return String(a) === String(b);
+        }
+        if (Array.isArray(a)) {
+            if (!Array.isArray(b) || a.length !== b.length) return false;
+            seen = seen || [];
+            for (var s = 0; s < seen.length; s++) {
+                if (seen[s][0] === a && seen[s][1] === b) return true;
+            }
+            seen.push([a, b]);
+            for (var i = 0; i < a.length; i++) {
+                if (!__tropelDeepEqual(a[i], b[i], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
+            return true;
+        }
+        if (typeof a === 'object') {
+            if (Array.isArray(b) || b === null || b === undefined) return false;
+            // Map: same size, each entry's key+value finds a deep-equal mate
+            // (order-insensitive).
+            if (a instanceof Map || b instanceof Map) {
+                if (!(b instanceof Map) || a.size !== b.size) return false;
+                // Cycle guard: Map nodes can be self-referential (a Map whose
+                // value is itself); revisiting the exact (a, b) pair mid-compare
+                // is assumed equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aEntries = Array.from(a.entries());
+                var bEntries = Array.from(b.entries());
+                var usedB = [];
+                outer:
+                for (var mi = 0; mi < aEntries.length; mi++) {
+                    for (var mj = 0; mj < bEntries.length; mj++) {
+                        if (usedB[mj]) continue;
+                        if (__tropelDeepEqual(aEntries[mi][0], bEntries[mj][0], seen) &&
+                            __tropelDeepEqual(aEntries[mi][1], bEntries[mj][1], seen)) {
+                            usedB[mj] = true;
+                            continue outer;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Set: same size, each member finds a deep-equal mate.
+            if (a instanceof Set || b instanceof Set) {
+                if (!(b instanceof Set) || a.size !== b.size) return false;
+                // Cycle guard: Set nodes can be self-referential (a Set containing
+                // itself); revisiting the exact (a, b) pair mid-compare is assumed
+                // equal.
+                seen = seen || [];
+                for (var s = 0; s < seen.length; s++) {
+                    if (seen[s][0] === a && seen[s][1] === b) return true;
+                }
+                seen.push([a, b]);
+                var aMembers = Array.from(a);
+                var bMembers = Array.from(b);
+                var usedS = [];
+                outer2:
+                for (var si = 0; si < aMembers.length; si++) {
+                    for (var sj = 0; sj < bMembers.length; sj++) {
+                        if (usedS[sj]) continue;
+                        if (__tropelDeepEqual(aMembers[si], bMembers[sj], seen)) {
+                            usedS[sj] = true;
+                            continue outer2;
+                        }
+                    }
+                    seen.pop();
+                    return false;
+                }
+                seen.pop();
+                return true;
+            }
+            // Plain object: key-set comparison with a cycle guard.
+            seen = seen || [];
+            for (var k = 0; k < seen.length; k++) {
+                if (seen[k][0] === a && seen[k][1] === b) return true;
+            }
+            seen.push([a, b]);
+            var keysA = Object.keys(a).sort();
+            var keysB = Object.keys(b).sort();
+            if (keysA.length !== keysB.length) {
+                seen.pop();
+                return false;
+            }
+            for (var j = 0; j < keysA.length; j++) {
+                if (keysA[j] !== keysB[j] || !__tropelDeepEqual(a[keysA[j]], b[keysB[j]], seen)) {
+                    seen.pop();
+                    return false;
+                }
+            }
+            seen.pop();
+            return true;
+        }
+        return a === b;
+    };
+}

--- a/packages/shims/scripts/build.sh
+++ b/packages/shims/scripts/build.sh
@@ -8,6 +8,7 @@ cd "$(dirname "$0")/.."
 
 # ── 1. Refresh the shim sources from ../../js/ ────────────────────────────
 mkdir -p shim
+cp ../../js/shared/deep-equal.js shim/deep-equal.js
 cp ../../js/scripting-api/pm.js shim/pm.js
 cp ../../js/scripting-api/bru.js shim/bru.js
 cp ../../js/chai/chai-shim.js shim/chai-shim.js
@@ -18,7 +19,7 @@ cp ../../js/k6-shim/k6-shim.js shim/k6-shim.js
 cp ../../js/k6-shim/jslib-shim.js shim/jslib-shim.js
 cp ../../js/k6-shim/open-data-shim.js shim/open-data-shim.js
 cp ../../js/k6-shim/sleep-shim.js shim/sleep-shim.js
-echo "  copied 10 shim sources from ../../js/"
+echo "  copied 11 shim sources from ../../js/"
 
 # ── 2. Render the ESM bundle + types ──────────────────────────────────────
 node scripts/render-bundle.mjs

--- a/packages/shims/scripts/render-bundle.mjs
+++ b/packages/shims/scripts/render-bundle.mjs
@@ -16,6 +16,7 @@ const root = join(here, "..");
 // this list AND smoke.mjs's DEFAULT_ORDER together — the smoke proves
 // content parity, not list completeness.
 const DEFAULT_ORDER = [
+  ["deep-equal-shim", "shim/deep-equal.js"],
   ["pm-shim", "shim/pm.js"],
   ["chai-shim", "shim/chai-shim.js"],
   ["lodash-shim", "shim/lodash-shim.js"],

--- a/packages/shims/smoke.mjs
+++ b/packages/shims/smoke.mjs
@@ -18,6 +18,7 @@ const repo = path.join(__dirname, "..", "..");
 // (ShimBundle::default()). If that file gains or reorders an entry, update
 // this list AND scripts/render-bundle.mjs's DEFAULT_ORDER together.
 const DEFAULT_ORDER = [
+  ["deep-equal-shim", "js/shared/deep-equal.js"],
   ["pm-shim", "js/scripting-api/pm.js"],
   ["chai-shim", "js/chai/chai-shim.js"],
   ["lodash-shim", "js/lodash/lodash-shim.js"],


### PR DESCRIPTION
Three near-identical deep-equal copies (pm.js deepEqual, chai-shim jsDeepEqual/nativeDeepEqual, lodash-shim isEqualDeep) agreed on 9/9 inputs today - a fix to one would silently skew the others.\n\n- NEW js/shared/deep-equal.js: single canonical impl, idempotently installed as globalThis.__tropelDeepEqual\n- pm/chai/lodash now delegate to it; dead __tropel_native_deep_equal bridge deleted (registered nowhere; chai load-time capture vs lodash call-time check would have diverged)\n- Prepended FIRST to every bundle: engine JS_SHIM_BUNDLE + ShimBundle::default (lockstep test now asserts 7), k6 K6_BASE_SHIM_BUNDLE, web SHIM_SOURCES + native_vs_wasm, @tropel/shims build/render/smoke\n- Standalone shim test evals load the shared file first\n\nVerified: 155/155 k6 lib, 17/17 sandbox lib, 39/39 engine lib (incl. lockstep), fmt 0, clippy -D warnings clean, @tropel/shims smoke PASS.