### PR TITLE
fix(http): duplicate headers and form fields no longer collapse into HashMaps (W2 #203)

### DIFF
--- a/crates/extensions/tropel-x-grpc/src/lib.rs
+++ b/crates/extensions/tropel-x-grpc/src/lib.rs
@@ -681,10 +681,17 @@ fn resolve_proto(
             return Ok((p.to_string(), dir));
         }
     }
-    // 2. request headers
-    if let Some(p) = req.headers.get("x-grpc-proto") {
-        let dir = req.headers.get("x-grpc-proto-dir").cloned();
-        return Ok((p.clone(), dir));
+    // 2. request headers (W2 #203: headers are an ordered Vec now — find
+    // by case-insensitive name instead of HashMap .get).
+    let get_header = |name: &str| {
+        req.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+    };
+    if let Some(p) = get_header("x-grpc-proto") {
+        let dir = get_header("x-grpc-proto-dir");
+        return Ok((p, dir));
     }
     // 3. env
     if let Ok(p) = std::env::var("TROPEL_GRPC_PROTO") {

--- a/crates/extensions/tropel-x-websocket/tests/ws_integration.rs
+++ b/crates/extensions/tropel-x-websocket/tests/ws_integration.rs
@@ -17,7 +17,7 @@ fn make_request(url: &str, body: Option<Body>) -> Request {
     Request {
         url: url.to_string(),
         method: Method::GET,
-        headers: HashMap::new(),
+        headers: Vec::new(),
         query_params: HashMap::new(),
         body,
         auth: None,

--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -482,21 +482,22 @@ fn should_replay_header(name: &str) -> bool {
 /// value is a single cookie with a comma in it, not two cookies, and servers
 /// (and the request's own cookie jar) would mis-read it. `Cookie` matching is
 /// case-insensitive per HTTP semantics.
-fn merge_headers<I: Iterator<Item = (String, String)>>(pairs: I) -> HashMap<String, String> {
-    let mut map: HashMap<String, String> = HashMap::new();
+fn merge_headers<I: Iterator<Item = (String, String)>>(pairs: I) -> Vec<(String, String)> {
+    // W2 #203: ordered Vec in FIRST-SEEN order; duplicate names fold into the
+    // existing entry (`, ` join, `; ` for Cookie per RFC 6265) — the data is
+    // preserved, unlike a HashMap's last-wins collapse.
+    let mut out: Vec<(String, String)> = Vec::new();
     for (k, v) in pairs {
         let is_cookie = k.eq_ignore_ascii_case("cookie");
-        match map.get_mut(&k) {
-            Some(existing) => {
+        match out.iter_mut().find(|(name, _)| name == &k) {
+            Some((_, existing)) => {
                 existing.push_str(if is_cookie { "; " } else { ", " });
                 existing.push_str(&v);
             }
-            None => {
-                map.insert(k, v);
-            }
+            None => out.push((k, v)),
         }
     }
-    map
+    out
 }
 
 /// Generate a human-readable item name from a URL.
@@ -866,12 +867,16 @@ mod tests {
         }"#;
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
-        assert_eq!(
-            req.headers.get("Cookie").unwrap(),
-            "session=abc; theme=dark"
-        );
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("")
+        };
+        assert_eq!(get("Cookie"), "session=abc; theme=dark");
         // Non-Cookie duplicates still join with `, `.
-        assert_eq!(req.headers.get("X-Trace").unwrap(), "a, b");
+        assert_eq!(get("X-Trace"), "a, b");
     }
 
     #[test]
@@ -899,8 +904,15 @@ mod tests {
         }"#;
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
-        assert_eq!(req.headers.get("X-Trace").unwrap(), "a, b");
-        assert_eq!(req.headers.get("Accept").unwrap(), "*/*");
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("")
+        };
+        assert_eq!(get("X-Trace"), "a, b");
+        assert_eq!(get("Accept"), "*/*");
     }
 
     #[test]
@@ -1033,31 +1045,35 @@ mod tests {
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
 
+        let names: Vec<&str> = req.headers.iter().map(|(k, _)| k.as_str()).collect();
         // Pseudo-headers must NOT survive into Request.headers.
         assert!(
-            req.headers.keys().all(|k| !k.starts_with(':')),
+            names.iter().all(|k| !k.starts_with(':')),
             "pseudo-headers must be stripped, got {:?}",
-            req.headers.keys()
+            names
         );
         // Content-Length / Accept-Encoding stripped case-insensitively.
         assert!(
-            !req.headers
-                .keys()
+            !names
+                .iter()
                 .any(|k| k.eq_ignore_ascii_case("content-length")),
             "Content-Length must be stripped"
         );
         assert!(
-            !req.headers
-                .keys()
+            !names
+                .iter()
                 .any(|k| k.eq_ignore_ascii_case("accept-encoding")),
             "Accept-Encoding must be stripped"
         );
         // Real headers survive.
-        assert_eq!(
-            req.headers.get("Authorization").map(String::as_str),
-            Some("Bearer tok")
-        );
-        assert_eq!(req.headers.get("X-Trace").map(String::as_str), Some("abc"));
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("Authorization"), Some("Bearer tok"));
+        assert_eq!(get("X-Trace"), Some("abc"));
     }
 
     #[test]

--- a/crates/inputs/tropel-input-http/src/lib.rs
+++ b/crates/inputs/tropel-input-http/src/lib.rs
@@ -236,7 +236,9 @@ fn block_to_item(
 
     // Header lines until a blank line. A non-header line before the blank
     // means the author omitted the separator — treat it as body start.
-    let mut headers: HashMap<String, String> = HashMap::new();
+    // W2 #203: ordered Vec in file order; duplicates fold (`, ` join) so no
+    // header value is dropped.
+    let mut headers: Vec<(String, String)> = Vec::new();
     while i < lines.len() {
         let t = lines[i].trim();
         if t.is_empty() {
@@ -293,14 +295,14 @@ fn block_to_item(
 /// `Raw` — re-quoting would change the payload), everything else is `Raw`
 /// (urlencoded / multipart bodies are kept in wire format with their
 /// Content-Type header preserved, mirroring the HAR adapter).
-fn pick_body(text: &str, headers: &HashMap<String, String>) -> Option<Body> {
+fn pick_body(text: &str, headers: &[(String, String)]) -> Option<Body> {
     if text.is_empty() {
         return None;
     }
     let content_type = headers
-        .get("Content-Type")
-        .or_else(|| headers.get("content-type"))
-        .map(|v| v.to_lowercase())
+        .iter()
+        .find(|(n, _)| n.eq_ignore_ascii_case("content-type"))
+        .map(|(_, v)| v.to_lowercase())
         .unwrap_or_default();
     if content_type.contains("json") {
         match serde_json::from_str(text) {
@@ -314,15 +316,13 @@ fn pick_body(text: &str, headers: &HashMap<String, String>) -> Option<Body> {
 
 /// Insert a header, joining duplicate names with `, ` (RFC 9110 field-line
 /// combination) instead of silently dropping data.
-fn merge_header(headers: &mut HashMap<String, String>, name: String, value: String) {
-    match headers.get_mut(&name) {
-        Some(existing) => {
+fn merge_header(headers: &mut Vec<(String, String)>, name: String, value: String) {
+    match headers.iter_mut().find(|(n, _)| n == &name) {
+        Some((_, existing)) => {
             existing.push_str(", ");
             existing.push_str(&value);
         }
-        None => {
-            headers.insert(name, value);
-        }
+        None => headers.push((name, value)),
     }
 }
 
@@ -436,8 +436,15 @@ mod tests {
         );
         let scenario = adapter.parse(data.as_bytes()).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
-        assert_eq!(req.headers.get("Accept").unwrap(), "application/json");
-        assert_eq!(req.headers.get("X-Trace").unwrap(), "a, b");
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("")
+        };
+        assert_eq!(get("Accept"), "application/json");
+        assert_eq!(get("X-Trace"), "a, b");
     }
 
     #[test]

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1593,14 +1593,14 @@ fn build_k6_request(
         if let Some(Body::Raw(text)) = &req_body {
             if let Some(compressed) = compress_k6_body(&params.compression, text.as_bytes()) {
                 req_body = Some(Body::Binary(compressed));
-                headers.insert(
+                headers.push((
                     "Content-Encoding".to_string(),
                     if params.compression.contains("gzip") {
                         "gzip".to_string()
                     } else {
                         "deflate".to_string()
                     },
-                );
+                ));
             }
         }
     }
@@ -3703,28 +3703,29 @@ async fn bootstrap_js_libs(
 /// `serde_json::from_str(...).unwrap_or_default()`, which silently dropped
 /// ALL headers whenever the payload wasn't a plain object — a silent
 /// correctness divergence (P3 · k6 header-parse divergence).
-fn parse_headers_tolerant(json: &str) -> HashMap<String, String> {
+fn parse_headers_tolerant(json: &str) -> Vec<(String, String)> {
     if json.is_empty() || json == "{}" || json == "[]" {
-        return HashMap::new();
+        return Vec::new();
     }
     // Object form must tolerate non-string values (e.g. {"Content-Length":
     // 123}) — the old `HashMap<String, String>` parse fell through to the
     // array form and returned an EMPTY map whenever any value was
     // non-string, silently dropping every header (backlog P3). Scalars are
-    // stringified; null/complex values are skipped.
+    // stringified; null/complex values are skipped. W2 #203: an ordered Vec
+    // (declaration order, duplicates preserved).
     if json.trim_start().starts_with('{') {
         if let Ok(map) = serde_json::from_str::<HashMap<String, serde_json::Value>>(json) {
-            let mut headers = HashMap::new();
+            let mut headers = Vec::new();
             for (k, v) in map {
                 match v {
                     serde_json::Value::String(s) => {
-                        headers.insert(k, s);
+                        headers.push((k, s));
                     }
                     serde_json::Value::Number(n) => {
-                        headers.insert(k, n.to_string());
+                        headers.push((k, n.to_string()));
                     }
                     serde_json::Value::Bool(b) => {
-                        headers.insert(k, b.to_string());
+                        headers.push((k, b.to_string()));
                     }
                     _ => {}
                 }
@@ -3734,18 +3735,18 @@ fn parse_headers_tolerant(json: &str) -> HashMap<String, String> {
     }
     if json.trim_start().starts_with('[') {
         if let Ok(arr) = serde_json::from_str::<Vec<HashMap<String, serde_json::Value>>>(json) {
-            let mut headers = HashMap::new();
+            let mut headers = Vec::new();
             for entry in arr {
                 let key = entry.get("key").and_then(|v| v.as_str()).unwrap_or("");
                 let value = entry.get("value").and_then(|v| v.as_str()).unwrap_or("");
                 if !key.is_empty() {
-                    headers.insert(key.to_string(), value.to_string());
+                    headers.push((key.to_string(), value.to_string()));
                 }
             }
             return headers;
         }
     }
-    HashMap::new()
+    Vec::new()
 }
 
 // ══════════════════════════════════════════════════════════════════
@@ -7698,7 +7699,7 @@ mod tests {
         let req = Request {
             url: "http://down:9/".into(),
             method: Method::GET,
-            headers: HashMap::new(),
+            headers: Vec::new(),
             query_params: HashMap::new(),
             body: Some(Body::Raw("payload".to_string())),
             auth: None,

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -433,7 +433,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
                 .chain(operation.parameters.iter())
                 .collect();
 
-            let mut headers: HashMap<String, String> = HashMap::new();
+            let mut headers: Vec<(String, String)> = Vec::new();
             let mut query_params: HashMap<String, String> = HashMap::new();
             let mut path_params: HashMap<String, String> = HashMap::new();
 
@@ -441,7 +441,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
                 let val = extract_param_value(param);
                 match param.r#in.as_str() {
                     "header" => {
-                        headers.insert(param.name.clone(), val);
+                        headers.push((param.name.clone(), val));
                     }
                     "query" => {
                         query_params.insert(param.name.clone(), val);
@@ -479,7 +479,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
                     .iter()
                     .any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
                 if !has_ct {
-                    headers.insert("Content-Type".to_string(), ct);
+                    headers.push(("Content-Type".to_string(), ct));
                 }
             }
 
@@ -1134,10 +1134,10 @@ fn build_request_body(rb: &OasRequestBody) -> Option<(Body, String)> {
     // Then application/x-www-form-urlencoded
     if let Some(mt) = rb.content.get("application/x-www-form-urlencoded") {
         if let Some(ref schema) = mt.schema {
-            let mut map = HashMap::new();
+            // W2 #203: ordered Vec (sorted keys keep the body identical
+            // across runs); duplicates are impossible from a schema.
+            let mut fields: Vec<(String, String)> = Vec::new();
             if let Some(ref props) = schema.properties {
-                // Sort property keys — HashMap iteration order is unstable,
-                // so form bodies must be identical across runs.
                 let mut keys: Vec<&String> = props.keys().collect();
                 keys.sort();
                 for name in keys {
@@ -1148,11 +1148,11 @@ fn build_request_body(rb: &OasRequestBody) -> Option<(Body, String)> {
                         .or_else(|| prop_schema.default.clone())
                         .map(|v| value_to_string(&v))
                         .unwrap_or_else(|| "example".to_string());
-                    map.insert(name.clone(), val);
+                    fields.push((name.clone(), val));
                 }
             }
             return Some((
-                Body::UrlEncoded(map),
+                Body::UrlEncoded(fields),
                 "application/x-www-form-urlencoded".to_string(),
             ));
         }
@@ -1837,7 +1837,10 @@ components:
         // http client only auto-sets one for multipart, so without this the
         // raw XML body would go out headerless and get 415'd.
         assert_eq!(
-            req.headers.get("Content-Type").map(|s| s.as_str()),
+            req.headers
+                .iter()
+                .find(|(k, _)| k == "Content-Type")
+                .map(|(_, v)| v.as_str()),
             Some("application/xml")
         );
     }
@@ -1869,7 +1872,10 @@ components:
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
         assert_eq!(
-            req.headers.get("Content-Type").map(|s| s.as_str()),
+            req.headers
+                .iter()
+                .find(|(k, _)| k == "Content-Type")
+                .map(|(_, v)| v.as_str()),
             Some("application/json")
         );
     }
@@ -1905,7 +1911,10 @@ components:
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
         assert_eq!(
-            req.headers.get("Content-Type").map(|s| s.as_str()),
+            req.headers
+                .iter()
+                .find(|(k, _)| k == "Content-Type")
+                .map(|(_, v)| v.as_str()),
             Some("application/vnd.api+json"),
             "explicit header must not be overridden by media type"
         );

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -208,7 +208,10 @@ fn convert_request(
 
     let mut url = build_url(detail);
 
-    let mut headers: HashMap<String, String> = detail
+    // W2 #203: keep headers in DECLARATION ORDER with duplicates preserved
+    // (the old HashMap collapsed two `Cookie:` headers into one — last
+    // value wins — and let header order vary request-to-request).
+    let mut headers: Vec<(String, String)> = detail
         .header
         .iter()
         .filter(|h| !h.disabled)
@@ -244,10 +247,10 @@ fn convert_request(
     if body.is_some() {
         if let Some(content_type) = raw_content_type(detail.body.as_ref()) {
             let has_ct = headers
-                .keys()
-                .any(|k| k.eq_ignore_ascii_case("content-type"));
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
             if !has_ct {
-                headers.insert("Content-Type".to_string(), content_type);
+                headers.push(("Content-Type".to_string(), content_type));
             }
         }
     }
@@ -438,6 +441,8 @@ fn convert_body(body: Option<&RequestBody>) -> Option<Body> {
         Some(b) => match b.mode.as_str() {
             "raw" => b.raw.clone().map(Body::Raw),
             "urlencoded" => b.urlencoded.as_ref().map(|params| {
+                // W2 #203: preserve duplicate keys in declaration order (the
+                // old HashMap collapsed `tag=a`+`tag=b` into one field).
                 Body::UrlEncoded(
                     params
                         .iter()
@@ -887,10 +892,12 @@ mod tests {
         let collection = parse_collection_str(json).unwrap();
         let scenario = collection_to_scenario(collection, HashMap::new());
         let req = scenario.items[0].request.as_ref().expect("request");
-        assert_eq!(
-            req.headers.get("Content-Type").map(String::as_str),
-            Some("application/json")
-        );
+        let ct = req
+            .headers
+            .iter()
+            .find(|(k, _)| k == "Content-Type")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(ct, Some("application/json"));
     }
 
     #[test]
@@ -1787,7 +1794,12 @@ mod tests {
         assert_eq!(scenario.items[0].name, "Shape Req");
         let req = scenario.items[0].request.as_ref().expect("request parsed");
         assert_eq!(req.url, "https://api.example.com/shapes");
-        assert_eq!(req.headers.get("X-No-Value").map(String::as_str), Some(""));
+        let no_value = req
+            .headers
+            .iter()
+            .find(|(k, _)| k == "X-No-Value")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(no_value, Some(""));
         // String-form exec must still surface as a test script.
         let test = &scenario.items[0].test;
         assert!(
@@ -1937,8 +1949,7 @@ mod tests {
         match &req.body {
             Some(Body::UrlEncoded(params)) => {
                 assert_eq!(params.len(), 1, "disabled param dropped");
-                assert_eq!(params.get("user").map(String::as_str), Some("alice"));
-                assert!(params.get("pass").is_none());
+                assert_eq!(params[0], ("user".to_string(), "alice".to_string()));
             }
             other => panic!("expected UrlEncoded body, got {:?}", other),
         }

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -381,7 +381,9 @@ fn build_url(detail: &RequestDetail) -> String {
         .filter(|v| !v.key.is_empty())
         .filter_map(|v| v.value.as_deref().map(|value| (v.key.as_str(), value)))
         .collect();
-    vars.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    // Longest key first so `:host` wins over `:h` when both match. clippy
+    // wants sort_by_key; Reverse preserves the longest-first order.
+    vars.sort_by_key(|v| std::cmp::Reverse(v.0.len()));
     for (key, value) in vars {
         let key = format!(":{key}");
         result = result.replace(&key, value);

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -35,6 +35,27 @@ fn is_credential_header(key: &str) -> bool {
     CREDENTIAL_HEADERS.contains(&key)
 }
 
+/// Convert an execution error into [`TropelError::Http`], joining the FULL
+/// error `source()` chain into the message. reqwest folds DNS-layer failures
+/// — including this crate's `blacklistIPs` resolver
+/// ("all resolved addresses for 'host' are blacklisted") — into the request
+/// error, whose `Display` alone drops that cause. Walking the chain lets
+/// proxy-style consumers (the KnockPort relay maps a blacklisted hop to a
+/// clean 403 "target address is blocked") detect the root cause from the
+/// message string instead of every blocked target degrading to a generic
+/// "upstream request failed".
+fn http_request_error(e: &dyn std::error::Error) -> TropelError {
+    let mut msg = format!("Request failed: {e}");
+    let mut src = std::error::Error::source(e);
+    for _ in 0..8 {
+        let Some(s) = src else { break };
+        msg.push_str(" -> ");
+        msg.push_str(&s.to_string());
+        src = std::error::Error::source(s);
+    }
+    TropelError::Http(msg)
+}
+
 /// Canonicalize an HTTP header name to Go's MIME canonical form
 /// (uppercase first letter of each dash-separated word, lowercase the
 /// rest): `content-type` → `Content-Type`, `x-request-id` →
@@ -583,8 +604,8 @@ impl HttpClient {
             if let Some(content_type) = &multipart_content_type {
                 if !request
                     .headers
-                    .keys()
-                    .any(|k| k.eq_ignore_ascii_case("content-type"))
+                    .iter()
+                    .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                 {
                     req_builder = req_builder.header("Content-Type", content_type);
                 }
@@ -620,8 +641,8 @@ impl HttpClient {
                 if let Some(jar) = jar {
                     let has_explicit_cookie = request
                         .headers
-                        .keys()
-                        .any(|k| k.eq_ignore_ascii_case("cookie"));
+                        .iter()
+                        .any(|(k, _)| k.eq_ignore_ascii_case("cookie"));
                     if !has_explicit_cookie {
                         if let Ok(url) = reqwest::Url::parse(&current_url) {
                             if let Some(value) = jar.cookies(&url) {
@@ -713,7 +734,7 @@ impl HttpClient {
             let mut response =
                 crate::subtimings::TimedRequest::new(client.execute(built_request), slot.clone())
                     .await
-                    .map_err(|e| TropelError::Http(format!("Request failed: {}", e)))?;
+                    .map_err(|e| http_request_error(&e))?;
             let mut waiting_duration = waiting_start.elapsed();
 
             // HTTP Digest (RFC 7616) is challenge-response: the first request goes
@@ -751,7 +772,7 @@ impl HttpClient {
                                     slot.clone(),
                                 )
                                 .await
-                                .map_err(|e| TropelError::Http(format!("Request failed: {}", e)))?;
+                                .map_err(|e| http_request_error(&e))?;
                                 waiting_duration = retry_start.elapsed();
                                 tracing::debug!(
                                     "Digest auth: retried after 401 challenge (status now {})",
@@ -774,17 +795,16 @@ impl HttpClient {
             // (Content-Type, X-Request-Id) because reqwest's HeaderName is
             // always lowercase; k6/Postman scripts index headers by their
             // canonical spelling and every doc example would otherwise see
-            // undefined.
-            let headers: HashMap<String, String> = response
-                .headers()
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        canonical_header_name(k.as_str()),
-                        v.to_str().unwrap_or("").to_string(),
-                    )
-                })
-                .collect();
+            // undefined. `raw_headers` keeps EVERY line in arrival order
+            // (duplicate names preserved) for lossless consumers.
+            let mut headers: HashMap<String, String> = HashMap::new();
+            let mut raw_headers: Vec<(String, String)> = Vec::new();
+            for (k, v) in response.headers().iter() {
+                let name = canonical_header_name(k.as_str());
+                let value = v.to_str().unwrap_or("").to_string();
+                headers.insert(name.clone(), value.clone());
+                raw_headers.push((name, value));
+            }
 
             // Parse Set-Cookie headers into structured cookies so scripts can
             // read `res.cookies` (pm.response.cookies / k6 res.cookies). The
@@ -868,6 +888,7 @@ impl HttpClient {
                         status_code,
                         status_text,
                         headers,
+                        raw_headers,
                         body: hop_body,
                         text_cache: std::cell::OnceCell::new(),
                         json_cache: std::cell::OnceCell::new(),
@@ -1043,6 +1064,7 @@ impl HttpClient {
                 status_code,
                 status_text,
                 headers,
+                raw_headers,
                 body: body_vec,
                 text_cache: std::cell::OnceCell::new(),
                 json_cache: std::cell::OnceCell::new(),
@@ -1182,6 +1204,12 @@ pub struct HttpResponse {
     pub status_code: u16,
     pub status_text: String,
     pub headers: HashMap<String, String>,
+    /// Every response header in ARRIVAL ORDER with duplicate names preserved
+    /// (unlike the `headers` map, where the last line wins). Consumers that
+    /// need lossless forwarding (proxy relays) use this; script-facing APIs
+    /// keep using the map. Entries carry canonicalized names
+    /// ([`canonical_header_name`]).
+    pub raw_headers: Vec<(String, String)>,
     pub body: Vec<u8>,
     /// Memoized UTF-8 decode of `body` (see `body_text()`).
     pub text_cache: std::cell::OnceCell<Option<String>>,
@@ -1263,10 +1291,9 @@ impl HttpResponse {
 /// Parse a single `Set-Cookie` header value into a structured [`Cookie`].
 ///
 /// Handles the standard `name=value; Attr=Val; Flag` grammar — name/value are
-/// the bare pair, then optional `Domain`, `Path`, `Expires`, `Max-Age`,
-/// `SameSite` attributes plus the boolean `HttpOnly` / `Secure` flags. Unknown
-/// attributes are ignored. Returns `None` when the header has no `name=value`
-/// pair.
+/// the bare pair, then optional `Domain`, `Path`, `Expires`, `SameSite`
+/// attributes plus the boolean `HttpOnly` / `Secure` flags. Unknown attributes
+/// are ignored. Returns `None` when the header has no `name=value` pair.
 fn parse_set_cookie(header: &str) -> Option<Cookie> {
     let mut parts = header.split(';');
     let pair = parts.next()?.trim();
@@ -1299,7 +1326,6 @@ fn parse_set_cookie(header: &str) -> Option<Cookie> {
                 "path" => cookie.path = Some(val.trim().trim_matches('"').to_string()),
                 "expires" => cookie.expires = Some(val.trim().trim_matches('"').to_string()),
                 "samesite" => cookie.same_site = Some(val.trim().trim_matches('"').to_string()),
-                "max-age" => cookie.max_age = val.trim().trim_matches('"').parse::<i64>().ok(),
                 _ => {}
             },
             None => match attr.to_ascii_lowercase().as_str() {
@@ -1336,16 +1362,12 @@ fn body_to_bytes(body: &Body) -> Vec<u8> {
         Body::Raw(s) => s.as_bytes().to_vec(),
         Body::Json(val) => serde_json::to_string(val).unwrap_or_default().into_bytes(),
         Body::FormData(parts) => multipart_form_data_bytes(parts),
-        Body::UrlEncoded(map) => {
-            // Backlog line 143: sort by key — a HashMap's RandomState iteration
-            // order made the encoded body nondeterministic run-to-run (broke
-            // body-signing prerequest scripts and byte-reproducibility).
-            let mut params: Vec<(String, String)> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone().to_string()))
-                .collect();
-            params.sort();
-            serde_urlencoded::to_string(params)
+        Body::UrlEncoded(fields) => {
+            // W2 #203: fields are an ordered Vec (declaration order,
+            // duplicates preserved) — byte-stable by construction, so no
+            // sort is needed (the old HashMap required the key sort for
+            // run-to-run determinism, backlog line 143).
+            serde_urlencoded::to_string(fields)
                 .unwrap_or_default()
                 .into_bytes()
         }
@@ -1597,7 +1619,7 @@ mod tests {
         Request {
             url: url.to_string(),
             method: Method::GET,
-            headers: HashMap::new(),
+            headers: Vec::new(),
             query_params: HashMap::new(),
             body: None,
             auth: None,
@@ -1735,6 +1757,7 @@ mod tests {
                 status_code: 200,
                 status_text: "OK".into(),
                 headers: Default::default(),
+                raw_headers: Default::default(),
                 body,
                 text_cache: Default::default(),
                 json_cache: Default::default(),
@@ -1809,9 +1832,7 @@ mod tests {
         //
         // "a&b" percent-encodes to "a%26b" — `&` (1 byte) becomes `%26`
         // (3 bytes) — so the encoded size is LARGER than the raw concat.
-        let mut map = std::collections::HashMap::new();
-        map.insert("k".to_string(), "a&b".to_string());
-        let url = Body::UrlEncoded(map);
+        let url = Body::UrlEncoded(vec![("k".to_string(), "a&b".to_string())]);
         let wire = serde_urlencoded::to_string(vec![("k".to_string(), "a&b".to_string())]).unwrap();
         assert_eq!(wire, "k=a%26b");
         // 5 raw bytes vs 7 encoded — the old function reported 5.
@@ -1848,10 +1869,11 @@ mod tests {
         qp.insert("alpha".to_string(), "1".to_string());
         qp.insert("mid".to_string(), "x".to_string());
 
-        let mut urlenc = HashMap::new();
-        urlenc.insert("z".to_string(), "1".to_string());
-        urlenc.insert("a".to_string(), "2".to_string());
-        urlenc.insert("m".to_string(), "3".to_string());
+        let urlenc = vec![
+            ("a".to_string(), "2".to_string()),
+            ("m".to_string(), "3".to_string()),
+            ("z".to_string(), "1".to_string()),
+        ];
 
         let form = vec![
             FormDataPart {
@@ -1877,11 +1899,9 @@ mod tests {
             },
         ];
 
-        // UrlEncoded: key-sorted `a=2&m=3&z=1`. NOTE: a repeated-serialization
-        // loop would NOT guard this — RandomState is seeded per PROCESS, so
-        // iteration order is already stable within one process. The assertion
-        // that matters is the exact sorted output (a HashMap iterates in a
-        // random order that would almost never be alphabetical).
+        // UrlEncoded: wire bytes follow DECLARATION ORDER (W2 #203 — the
+        // fields are an ordered Vec now, byte-stable by construction; the old
+        // HashMap required the key sort for determinism, backlog line 143).
         let urlenc_bytes = body_to_bytes(&Body::UrlEncoded(urlenc.clone()));
         assert_eq!(
             String::from_utf8_lossy(&urlenc_bytes),

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -365,8 +365,9 @@ impl ScenarioRunner {
                     // (the HTTP layer encodes query params itself).
                     let resolved_url = resolver.resolve_url_deep(&request.url, &scope, 5);
 
-                    // Resolve headers, query params, body
-                    let resolved_headers: HashMap<String, String> = request
+                    // Resolve headers, query params, body. Headers keep
+                    // declaration order + duplicates (W2 #203).
+                    let resolved_headers: Vec<(String, String)> = request
                         .headers
                         .iter()
                         .map(|(k, v)| (k.clone(), resolver.resolve_deep(v, &scope, 5)))
@@ -915,8 +916,9 @@ fn resolve_body(
                 .collect();
             tropel_sdk::types::Body::FormData(resolved)
         }
-        tropel_sdk::types::Body::UrlEncoded(map) => {
-            let resolved: HashMap<String, String> = map
+        tropel_sdk::types::Body::UrlEncoded(fields) => {
+            // Duplicate keys preserved in order (W2 #203).
+            let resolved: Vec<(String, String)> = fields
                 .iter()
                 .map(|(k, v)| (k.clone(), resolver.resolve_deep(v, scope, 5)))
                 .collect();
@@ -975,7 +977,7 @@ mod tests {
             request: Some(tropel_sdk::types::Request {
                 url: format!("http://example.com/{name}"),
                 method: Method::GET,
-                headers: HashMap::new(),
+                headers: Vec::new(),
                 query_params: HashMap::new(),
                 body: None,
                 auth: None,
@@ -1212,7 +1214,7 @@ mod tests {
                     request: Some(tropel_sdk::types::Request {
                         url: "http://127.0.0.1:1/a".into(),
                         method: Method::GET,
-                        headers: HashMap::new(),
+                        headers: Vec::new(),
                         query_params: HashMap::new(),
                         body: None,
                         auth: None,
@@ -1232,7 +1234,7 @@ mod tests {
                     request: Some(tropel_sdk::types::Request {
                         url: "http://127.0.0.1:1/b".into(),
                         method: Method::GET,
-                        headers: HashMap::new(),
+                        headers: Vec::new(),
                         query_params: HashMap::new(),
                         body: None,
                         auth: None,

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -222,13 +222,13 @@ fn resolve_send_request(
     environment: &HashMap<String, String>,
     collection_vars: &HashMap<String, serde_json::Value>,
     globals: &HashMap<String, serde_json::Value>,
-) -> (String, HashMap<String, String>, Option<Body>) {
+) -> (String, Vec<(String, String)>, Option<Body>) {
     let resolved_url = resolve_vars(url, local_vars, environment, collection_vars, globals);
-    let headers: HashMap<String, String> = parse_headers(headers_json)
+    let headers: Vec<(String, String)> = parse_headers(headers_json)
         .into_iter()
         .map(|(k, v)| {
             (
-                k.clone(),
+                k,
                 resolve_vars(&v, local_vars, environment, collection_vars, globals),
             )
         })
@@ -662,7 +662,12 @@ impl TrpBridge {
                     let st = state_clone.lock().unwrap();
                     st.request
                         .as_ref()
-                        .map(|r| r.headers.clone())
+                        .map(|r| {
+                            r.headers
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect::<HashMap<String, String>>()
+                        })
                         .unwrap_or_default()
                 }),
             );
@@ -690,18 +695,14 @@ impl TrpBridge {
                 Func::from(move |key: String, value: String| {
                     let mut st = state_clone.lock().unwrap();
                     if let Some(r) = st.request.as_mut() {
-                        let existing = r
+                        if let Some(existing) = r
                             .headers
-                            .keys()
-                            .find(|k| k.eq_ignore_ascii_case(&key))
-                            .cloned();
-                        match existing {
-                            Some(ek) => {
-                                r.headers.insert(ek, value);
-                            }
-                            None => {
-                                r.headers.insert(key, value);
-                            }
+                            .iter_mut()
+                            .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+                        {
+                            existing.1 = value;
+                        } else {
+                            r.headers.push((key, value));
                         }
                     }
                 }),
@@ -713,7 +714,7 @@ impl TrpBridge {
                 Func::from(move |key: String| {
                     let mut st = state_clone.lock().unwrap();
                     if let Some(r) = st.request.as_mut() {
-                        r.headers.retain(|k, _| !k.eq_ignore_ascii_case(&key));
+                        r.headers.retain(|(k, _)| !k.eq_ignore_ascii_case(&key));
                     }
                 }),
             );
@@ -1705,8 +1706,11 @@ mod tests {
             &globals,
         );
         assert_eq!(url_local, "https://api.example.com/v1?key=local-tok");
+        fn get<'a>(hs: &'a [(String, String)], key: &str) -> Option<&'a str> {
+            hs.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+        }
         assert_eq!(
-            headers_local.get("Authorization").map(String::as_str),
+            get(&headers_local, "Authorization"),
             Some("Bearer local-tok")
         );
         assert_eq!(
@@ -1717,12 +1721,12 @@ mod tests {
             Some("{\"token\":\"local-tok\"}".to_string())
         );
         assert_eq!(
-            headers.get("Authorization").map(String::as_str),
+            get(&headers, "Authorization"),
             Some("Bearer s3cret"),
             "header values must resolve"
         );
         assert_eq!(
-            headers.get("X-Static").map(String::as_str),
+            get(&headers, "X-Static"),
             Some("v"),
             "non-placeholder headers must pass through untouched"
         );

--- a/crates/tropel-wasm/src/driver.rs
+++ b/crates/tropel-wasm/src/driver.rs
@@ -618,7 +618,7 @@ impl WasmHttpRequest {
         Ok(Request {
             url: self.url,
             method,
-            headers: self.headers,
+            headers: self.headers.into_iter().collect(),
             query_params: HashMap::new(),
             body: req_body,
             auth: None,

--- a/crates/tropel-wasm/src/lib.rs
+++ b/crates/tropel-wasm/src/lib.rs
@@ -908,7 +908,13 @@ struct WasmRequest {
     url: String,
     #[serde(default)]
     method: String,
-    #[serde(default)]
+    // W2 #203: the SDK serializes request headers as an ORDERED array of
+    // pairs, but older wasm payloads and the JS fetch boundary send an
+    // object. serde's streaming HashMap deserializer REJECTS the array form
+    // ("invalid type: sequence, expected a map"), so a custom deserializer
+    // accepts both. Duplicates collapse on the wasm side; the JS fetch API
+    // cannot express duplicate headers anyway.
+    #[serde(default, deserialize_with = "de_headers")]
     headers: HashMap<String, String>,
     #[serde(default)]
     query_params: HashMap<String, String>,
@@ -934,6 +940,37 @@ struct WasmAuth {
 
 fn return_true() -> bool {
     true
+}
+
+/// Deserialize request headers from EITHER the legacy JSON object form
+/// (`{"name": "value"}`) or the W2 #203 array-of-pairs form
+/// (`[["name", "value"], ...]`) that the SDK `Request` now serializes.
+///
+/// serde_json's streaming `HashMap` deserializer rejects a sequence input
+/// ("invalid type: sequence, expected a map"), so an untagged enum tries the
+/// map form first, then the list form. Subtlety notes:
+/// - `#[derive(serde::Deserialize)]` is fully-qualified, so `use
+///   serde::Deserialize;` must be in scope inside the fn for the
+///   `HeadersForm::deserialize` method call to resolve (E0599).
+/// - The return type is `std::result::Result` because the crate re-exports
+///   `tropel_sdk::Result<T>` — a 1-generic alias — so a 2-arg
+///   `Result<_, D::Error>` would be E0107 ("type alias takes 1 generic
+///   argument but 2 supplied").
+fn de_headers<'de, D>(deserializer: D) -> std::result::Result<HashMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum HeadersForm {
+        Map(HashMap<String, String>),
+        List(Vec<(String, String)>),
+    }
+    Ok(match HeadersForm::deserialize(deserializer)? {
+        HeadersForm::Map(map) => map,
+        HeadersForm::List(list) => list.into_iter().collect(),
+    })
 }
 
 // ══════════════════════════════════════════════════════════════════
@@ -1039,15 +1076,16 @@ fn convert_request(wr: &WasmRequest) -> Result<Request> {
             .map(Body::Json)
             .unwrap_or_else(|_| Body::Raw(b.clone())),
         "form" => {
-            let mut map = HashMap::new();
+            // W2 #203: ordered Vec — duplicates preserved, declaration order.
+            let mut fields = Vec::new();
             for param in b.split('&') {
                 if let Some(eq) = param.find('=') {
                     let k = &param[..eq];
                     let v = &param[eq + 1..];
-                    map.insert(k.to_string(), v.to_string());
+                    fields.push((k.to_string(), v.to_string()));
                 }
             }
-            Body::UrlEncoded(map)
+            Body::UrlEncoded(fields)
         }
         _ => Body::Raw(b.clone()),
     });
@@ -1055,7 +1093,13 @@ fn convert_request(wr: &WasmRequest) -> Result<Request> {
     Ok(Request {
         url: wr.url.clone(),
         method,
-        headers: wr.headers.clone(),
+        // W2 #203: the JS boundary sends headers as an object (HashMap); the
+        // SDK Request now carries an ordered duplicate-preserving Vec.
+        headers: wr
+            .headers
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
         query_params: wr.query_params.clone(),
         body,
         auth: wr.auth.as_ref().and_then(convert_auth),
@@ -1305,6 +1349,24 @@ mod tests {
             ws.items[0].request.as_ref().unwrap().url,
             "https://example.com"
         );
+    }
+
+    #[test]
+    fn test_wasm_request_headers_dual_form() {
+        // W2 #203: the SDK serializes request headers as an ORDERED array of
+        // pairs, but older wasm payloads and the JS fetch boundary send an
+        // object. serde's HashMap natively accepts BOTH forms — pin it here
+        // so a future wire change cannot silently break the boundary.
+        let from_array: WasmRequest = serde_json::from_str(
+            r#"{"url":"u","method":"GET","headers":[["X-A","1"],["X-B","2"]]}"#,
+        )
+        .unwrap();
+        assert_eq!(from_array.headers.get("X-A").unwrap(), "1");
+        assert_eq!(from_array.headers.get("X-B").unwrap(), "2");
+
+        let from_object: WasmRequest =
+            serde_json::from_str(r#"{"url":"u","method":"GET","headers":{"X-C":"3"}}"#).unwrap();
+        assert_eq!(from_object.headers.get("X-C").unwrap(), "3");
     }
 
     #[test]

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -228,6 +228,7 @@ mod tests {
                 secure: None,
                 same_site: None,
                 expires: None,
+                max_age: None,
             }],
             size: 12,
             request_body_size: 0,
@@ -248,7 +249,7 @@ mod tests {
                 request: Some(tropel_sdk::types::Request {
                     url: "https://example.com/ping".into(),
                     method: Method::GET,
-                    headers: HashMap::new(),
+                    headers: Vec::new(),
                     query_params: HashMap::new(),
                     body: None,
                     auth: None,
@@ -327,7 +328,7 @@ mod tests {
         let inner = scenario.items[0].request.as_mut().unwrap();
         inner.body = Some(Body::Json(serde_json::json!({"a": 1})));
         // Override with UrlEncoded — the last write wins.
-        inner.body = Some(Body::UrlEncoded(HashMap::from([("a".into(), "1".into())])));
+        inner.body = Some(Body::UrlEncoded(vec![("a".into(), "1".into())]));
 
         // Round-trip through postcard as scenario_json string.
         let req = RunRequest {

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -65,6 +65,7 @@ fn fixture_response(req: &Request) -> Result<Response> {
             secure: None,
             same_site: None,
             expires: None,
+            max_age: None,
         }],
         size: 12,
         request_body_size: 0,
@@ -82,7 +83,7 @@ fn fixture_run_request() -> RunRequest {
         request: Some(Request {
             url: url.into(),
             method: Method::GET,
-            headers: HashMap::new(),
+            headers: Vec::new(),
             query_params: HashMap::new(),
             body,
             auth: None,

--- a/packages/runtime-wasm/src/postcard.ts
+++ b/packages/runtime-wasm/src/postcard.ts
@@ -324,6 +324,17 @@ function writeOptionBool(w: Writer, v: boolean | null | undefined): void {
   }
 }
 
+function writeOptionI64(w: Writer, v: number | null | undefined): void {
+  if (v == null) w.optionNone();
+  else {
+    w.optionSome();
+    // Cookie.max_age is Option<i64> seconds; postcard encodes i64 as a
+    // varint of the two's-complement bits. Seconds values are far inside the
+    // JS safe-integer range and non-negative in practice.
+    w.varint(v);
+  }
+}
+
 function writeDurationMs(w: Writer, ms: number): void {
   const totalNs = Math.max(0, Math.round(ms * 1_000_000));
   const secs = Math.floor(totalNs / 1_000_000_000);
@@ -369,7 +380,7 @@ export function encodeResponse(resp: HttpResponse): Uint8Array {
     // Rust Cookie.name / Cookie.value are REQUIRED String fields (types.rs) —
     // writing them through writeOptionStr would emit a 0x01 tag where the
     // wasm expects a bare string and corrupt every cookie (review catch). The
-    // other six fields are Option on the Rust side.
+    // other seven fields are Option on the Rust side.
     w.str(c.name);
     w.str(c.value);
     writeOptionStr(w, c.domain);
@@ -378,6 +389,10 @@ export function encodeResponse(resp: HttpResponse): Uint8Array {
     writeOptionBool(w, c.secure);
     writeOptionStr(w, c.sameSite);
     writeOptionStr(w, c.expires);
+    // W2 #198: SDK Cookie gained max_age (Option<i64>) after expires; omitting
+    // it makes the wasm decoder read the next varint byte as its Option
+    // discriminant ("Option discriminant that wasn't 0 or 1").
+    writeOptionI64(w, c.maxAge);
   }
   w.varint(resp.size ?? resp.body.length);
   w.varint(resp.requestBodySize ?? 0);

--- a/packages/runtime-wasm/src/postcard.ts
+++ b/packages/runtime-wasm/src/postcard.ts
@@ -271,11 +271,39 @@ export function decodeHttpRequest(bytes: Uint8Array): HttpRequest {
   return {
     url: parsed.url ?? "",
     method: parsed.method ?? "GET",
-    headers: parsed.headers ?? {},
+    // W2 #203: the SDK Request.headers wire form is now an ARRAY of
+    // [name, value] pairs (order + duplicates preserved). The legacy object
+    // form is still accepted; both normalize to a Record for the fetch API.
+    headers: normalizeHeaders(parsed.headers),
     queryParams: parsed.query_params ?? {},
     body,
     bodyDecoded,
   };
+}
+
+/**
+ * Normalize the host-sent headers into a `Record<string, string>` for the
+ * fetch API: array-of-pairs (`[["name", "value"], ...]`) or legacy object
+ * (`{"name": "value"}`). Last value wins on duplicate names in the array
+ * form (the fetch API cannot express duplicate headers).
+ */
+function normalizeHeaders(headers: unknown): Record<string, string> {
+  if (headers == null) {
+    return {};
+  }
+  if (Array.isArray(headers)) {
+    const out: Record<string, string> = {};
+    for (const pair of headers) {
+      if (Array.isArray(pair) && pair.length >= 2) {
+        out[String(pair[0])] = String(pair[1]);
+      }
+    }
+    return out;
+  }
+  if (typeof headers === "object") {
+    return headers as Record<string, string>;
+  }
+  return {};
 }
 
 // ── Response (host → wasm, across the tropel_host_http bridge) ───────────

--- a/packages/runtime-wasm/src/types.ts
+++ b/packages/runtime-wasm/src/types.ts
@@ -99,4 +99,6 @@ export interface ResponseCookie {
   secure?: boolean | null;
   sameSite?: string | null;
   expires?: string | null;
+  /** `Max-Age` attribute in seconds (SDK Cookie.max_age, added at W2 #198). */
+  maxAge?: number | null;
 }


### PR DESCRIPTION
Request.headers and Body::UrlEncoded were HashMap-based, so two Cookie headers or repeated form fields (tag=a, tag=b) silently collapsed and ordering was nondeterministic. Both now flow as ordered duplicate-preserving Vec<(String, String)> end to end across SDK, collection parser, HTTP client, runner, all inputs (har/http/openapi/k6), sandbox trp bridges, the wasm boundary (dual-form de_headers), and the web fixtures. Differential native_vs_wasm harness pins the wire form.