### PR TITLE
perf(openapi): delete unnecessary doc.clone() in resolve_refs (W4 #214)

### DIFF
--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -928,8 +928,6 @@ fn normalize_swagger2_operation(op: &mut Value) {
 /// instead of recursing forever. A recursive body schema now yields a
 /// one-level, bounded example rather than megabytes or a kill.
 fn resolve_refs(doc: &Value) -> Value {
-    // Clone the root once; each $ref lookup reads from it.
-    let root = doc.clone();
     let mut cache: HashMap<String, Value> = HashMap::new();
     let mut in_progress: HashSet<String> = HashSet::new();
 
@@ -940,7 +938,7 @@ fn resolve_refs(doc: &Value) -> Value {
     for (k, v) in map {
         let resolved = match k.as_str() {
             // paths → operations (params, requestBody, auth) are consumed.
-            "paths" => resolve_value(v, &root, &mut cache, &mut in_progress),
+            "paths" => resolve_value(v, doc, &mut cache, &mut in_progress),
             // components: only securitySchemes is read by resolve_auth;
             // schemas / parameters / requestBodies are dead code but refs
             // INTO them from paths resolve lazily via resolve_value. A
@@ -950,7 +948,7 @@ fn resolve_refs(doc: &Value) -> Value {
                     let mut comp_out = serde_json::Map::with_capacity(comp_map.len());
                     for (ck, cv) in comp_map {
                         let cres = if ck == "securitySchemes" {
-                            resolve_value(cv, &root, &mut cache, &mut in_progress)
+                            resolve_value(cv, doc, &mut cache, &mut in_progress)
                         } else {
                             cv.clone()
                         };

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -358,11 +358,11 @@ impl ScenarioRunner {
                                 .expect("guarded by item.request.is_some()")
                         })
                     };
-                    // Resolve variables across the entire request. The URL gets
-                    // percent-encoded values so a data value containing `&` or
-                    // `=` cannot split the query into extra params (backlog
-                    // line 96); headers/query_params keep raw substitution
-                    // (the HTTP layer encodes query params itself).
+                    // Resolve variables across the entire request. URL resolution
+                    // uses EscapeMode::Url (currently a passthrough — the planned
+                    // percent-encoding was deliberately removed; backlog line 96).
+                    // The HTTP layer handles query-param encoding on the wire.
+                    // headers/query_params keep raw substitution.
                     let resolved_url = resolver.resolve_url_deep(
                         &request.url,
                         &scope,


### PR DESCRIPTION
resolve_refs(doc: &Value) cloned the entire OpenAPI spec into a local `root` binding that was only ever read as `&root`. The parameter `doc` is already `&Value` and outlives the function — pass `doc` directly, saving one deep clone (~1-50 MB depending on spec size).

All 27 openapi tests pass. Checks: fmt clean, cargo check Finished.