### PR TITLE
fix(openapi): generate examples for allOf/oneOf/anyOf schemas (W4 #217)

### DIFF
--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -465,14 +465,20 @@ fn merge_pairs<I: Iterator<Item = (String, String)>>(pairs: I) -> HashMap<String
 ///
 /// Returns false for HTTP/2 pseudo-headers (`:method`, `:authority`,
 /// `:scheme`, `:path` — Chrome HARs record them; they're not valid HTTP/1.1
-/// header names and `HeaderName::try_from` rejects the `:`), and for
-/// `Content-Length` / `Accept-Encoding`, which the HTTP client manages
-/// itself. Everything else is replayed as recorded.
+/// header names and `HeaderName::try_from` rejects the `:`), for
+/// `Content-Length` / `Accept-Encoding` (the HTTP client manages them),
+/// and for cache-validation headers `If-None-Match` / `If-Modified-Since`
+/// — replaying them causes 304s with `http_req_failed` at 0.00,
+/// silently invalidating the entire load-test result (W4 #223).
+/// Everything else is replayed as recorded.
 fn should_replay_header(name: &str) -> bool {
     if name.starts_with(':') {
         return false;
     }
-    !name.eq_ignore_ascii_case("content-length") && !name.eq_ignore_ascii_case("accept-encoding")
+    !name.eq_ignore_ascii_case("content-length")
+        && !name.eq_ignore_ascii_case("accept-encoding")
+        && !name.eq_ignore_ascii_case("if-none-match")
+        && !name.eq_ignore_ascii_case("if-modified-since")
 }
 
 /// Combine duplicate header lines into one value per name.
@@ -1074,6 +1080,63 @@ mod tests {
         };
         assert_eq!(get("Authorization"), Some("Bearer tok"));
         assert_eq!(get("X-Trace"), Some("abc"));
+    }
+
+    #[test]
+    fn test_cache_validation_headers_stripped() {
+        // W4 #223: If-None-Match / If-Modified-Since cause 304 responses
+        // on replay, making http_req_failed 0.00 and silently invalidating
+        // the entire load-test result.
+        let adapter = HarInputAdapter;
+        let data = br#"{
+            "log": {
+                "version": "1.2",
+                "entries": [
+                    {
+                        "request": {
+                            "method": "GET",
+                            "url": "https://api.example.com/data",
+                            "headers": [
+                                {"name": "If-None-Match", "value": "\"abc123\""},
+                                {"name": "If-Modified-Since", "value": "Mon, 01 Jan 2024 00:00:00 GMT"},
+                                {"name": "Authorization", "value": "Bearer tok"},
+                                {"name": "Accept", "value": "application/json"}
+                            ],
+                            "queryString": []
+                        },
+                        "response": {"status": 200, "statusText": "OK"}
+                    }
+                ]
+            }
+        }"#;
+
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let names: Vec<&str> = req.headers.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(
+            !names
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case("if-none-match")),
+            "If-None-Match must be stripped, got {:?}",
+            names
+        );
+        assert!(
+            !names
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case("if-modified-since")),
+            "If-Modified-Since must be stripped, got {:?}",
+            names
+        );
+        // Real headers survive.
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("Authorization"), Some("Bearer tok"));
+        assert_eq!(get("Accept"), Some("application/json"));
     }
 
     #[test]

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -220,11 +220,11 @@ struct OasSchema {
     required: Vec<String>,
     // Composition keywords — the universal inheritance idiom.
     #[serde(default, rename = "allOf")]
-    all_of: Option<Vec<Box<OasSchema>>>,
+    all_of: Option<Vec<OasSchema>>,
     #[serde(default, rename = "oneOf")]
-    one_of: Option<Vec<Box<OasSchema>>>,
+    one_of: Option<Vec<OasSchema>>,
     #[serde(default, rename = "anyOf")]
-    any_of: Option<Vec<Box<OasSchema>>>,
+    any_of: Option<Vec<OasSchema>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1303,12 +1303,14 @@ fn generate_schema_example(schema: Option<&OasSchema>) -> Option<serde_json::Val
             }
         }
     }
-    for variants in [&schema.one_of, &schema.any_of] {
-        if let Some(ref vars) = variants {
-            for variant in vars {
-                if let Some(val) = generate_schema_example(Some(variant)) {
-                    return Some(val);
-                }
+    let variant_lists: Vec<&Vec<OasSchema>> = [&schema.one_of, &schema.any_of]
+        .iter()
+        .filter_map(|o| o.as_ref())
+        .collect();
+    for vars in variant_lists {
+        for variant in vars {
+            if let Some(val) = generate_schema_example(Some(variant)) {
+                return Some(val);
             }
         }
     }

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -218,6 +218,13 @@ struct OasSchema {
     items: Option<Box<OasSchema>>,
     #[serde(default)]
     required: Vec<String>,
+    // Composition keywords — the universal inheritance idiom.
+    #[serde(default, rename = "allOf")]
+    all_of: Option<Vec<Box<OasSchema>>>,
+    #[serde(default, rename = "oneOf")]
+    one_of: Option<Vec<Box<OasSchema>>>,
+    #[serde(default, rename = "anyOf")]
+    any_of: Option<Vec<Box<OasSchema>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1266,6 +1273,46 @@ fn generate_schema_example(schema: Option<&OasSchema>) -> Option<serde_json::Val
         return Some(default.clone());
     }
 
+    // Composition keywords (W4 #217): allOf merges properties from all
+    // sub-schemas; oneOf/anyOf picks the first variant that generates an
+    // example. Without this, these schemas silently produce null.
+    if let Some(ref all_of) = schema.all_of {
+        let mut merged_props: HashMap<String, &Box<OasSchema>> = HashMap::new();
+        for sub in all_of {
+            if let Some(ref props) = sub.properties {
+                for (k, v) in props {
+                    merged_props.entry(k.clone()).or_insert(v);
+                }
+            }
+        }
+        if !merged_props.is_empty() {
+            let mut keys: Vec<&String> = merged_props.keys().collect();
+            keys.sort();
+            let mut obj = serde_json::Map::new();
+            for name in keys {
+                let val = generate_schema_example(Some(merged_props[name]))
+                    .unwrap_or(serde_json::Value::Null);
+                obj.insert(name.clone(), val);
+            }
+            return Some(serde_json::Value::Object(obj));
+        }
+        // allOf with no properties — try the first sub-schema.
+        if let Some(first) = all_of.first() {
+            if let Some(val) = generate_schema_example(Some(first)) {
+                return Some(val);
+            }
+        }
+    }
+    for variants in [&schema.one_of, &schema.any_of] {
+        if let Some(ref vars) = variants {
+            for variant in vars {
+                if let Some(val) = generate_schema_example(Some(variant)) {
+                    return Some(val);
+                }
+            }
+        }
+    }
+
     match schema.r#type.as_deref() {
         Some("object") => {
             let mut obj = serde_json::Map::new();
@@ -2283,5 +2330,88 @@ components:
         assert_eq!(scenario.items.len(), 1);
         let req = scenario.items[0].request.as_ref().unwrap();
         assert_eq!(req.url, "/items");
+    }
+
+    #[test]
+    fn test_allof_schema_generates_merged_body() {
+        // W4 #217: allOf merges properties from all sub-schemas into one
+        // example object, instead of producing null.
+        let adapter = OpenApiInputAdapter;
+        let data = br##"{
+            "openapi": "3.0.0",
+            "info": {"title": "AllOf", "version": "1.0"},
+            "paths": {
+                "/items": {
+                    "post": {
+                        "operationId": "createItem",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "allOf": [
+                                            {"type": "object", "properties": {"name": {"type": "string"}}},
+                                            {"type": "object", "properties": {"count": {"type": "integer"}}}
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "Created"}}
+                    }
+                }
+            }
+        }"##;
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let body = req.body.as_ref().expect("allOf must generate a body");
+        match body {
+            Body::Json(v) => {
+                let s = v.to_string();
+                assert!(s.contains("\"name\""), "must contain 'name', got: {s}");
+                assert!(s.contains("\"count\""), "must contain 'count', got: {s}");
+            }
+            other => panic!("expected Json body, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_oneof_schema_picks_first_variant() {
+        // W4 #217: oneOf picks the first variant that generates an example.
+        let adapter = OpenApiInputAdapter;
+        let data = br##"{
+            "openapi": "3.0.0",
+            "info": {"title": "OneOf", "version": "1.0"},
+            "paths": {
+                "/items": {
+                    "post": {
+                        "operationId": "createItem",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "oneOf": [
+                                            {"type": "object", "properties": {"id": {"type": "integer"}}},
+                                            {"type": "string"}
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "Created"}}
+                    }
+                }
+            }
+        }"##;
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let body = req.body.as_ref().expect("oneOf must generate a body");
+        match body {
+            Body::Json(v) => {
+                // First variant is object with "id": 1
+                let s = v.to_string();
+                assert!(s.contains("\"id\""), "must pick first variant, got: {s}");
+            }
+            other => panic!("expected Json body, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
The OasSchema struct silently dropped allOf/oneOf/anyOf fields, so composition keywords — the universal OpenAPI inheritance idiom — produced a null body. Add the three fields and handle them in generate_schema_example:

- allOf: merge properties from all sub-schemas into one object
- oneOf/anyOf: pick the first variant that generates an example

Add regression tests. All 30 openapi tests pass.

Depends on #124.