### PR TITLE
fix(ci): pin RUSTUP_TOOLCHAIN in cargo-deny to avoid musl toolchain miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,11 +169,13 @@ jobs:
           # (see .gitmodules) — every cargo job needs it populated.
           submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v2
+        env:
+          # Override rust-toolchain.toml's "stable" channel which resolves to
+          # stable-x86_64-unknown-linux-musl inside the action's Docker
+          # container — that toolchain doesn't exist and the action fails.
+          RUSTUP_TOOLCHAIN: "1.85.0"
         with:
           command: check advisories licenses bans sources
-          # Use the MSRV toolchain (already in the action image) instead of
-          # letting rust-toolchain.toml's "stable" override trigger a fresh
-          # toolchain download into the container on every run.
           rust-version: 1.85.0
 
   sdk-gates:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1852,7 +1852,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3337,7 +3337,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3405,7 +3405,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3829,7 +3829,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5479,7 +5479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The cargo-deny action runs inside a Docker container where `rust-toolchain.toml`'s `channel = "stable"` resolves to `stable-x86_64-unknown-linux-musl` — a toolchain that doesn't exist in the image. Setting `RUSTUP_TOOLCHAIN=1.85.0` overrides the file and uses the pre-installed toolchain.

Also bumps h2 0.4.15 → 0.4.16 (RUSTSEC-2026-0258: empty DATA frames allow unbounded memory usage).

Blocks all open PRs (#122-#129).