### PR TITLE
fix(runtime): correct stale comment claiming URL percent-encoding (W2 #205.4)

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -358,11 +358,11 @@ impl ScenarioRunner {
                                 .expect("guarded by item.request.is_some()")
                         })
                     };
-                    // Resolve variables across the entire request. The URL gets
-                    // percent-encoded values so a data value containing `&` or
-                    // `=` cannot split the query into extra params (backlog
-                    // line 96); headers/query_params keep raw substitution
-                    // (the HTTP layer encodes query params itself).
+                    // Resolve variables across the entire request. URL resolution
+                    // uses EscapeMode::Url (currently a passthrough — the planned
+                    // percent-encoding was deliberately removed; backlog line 96).
+                    // The HTTP layer handles query-param encoding on the wire.
+                    // headers/query_params keep raw substitution.
                     let resolved_url = resolver.resolve_url_deep(
                         &request.url,
                         &scope,


### PR DESCRIPTION
The comment at runner.rs:362 claimed resolve_url_deep applies percent-encoding to data values so '&' or '=' cannot split query params. In reality EscapeMode::Url is a no-op passthrough — the planned encoding was deliberately removed (backlog line 96). Update the comment to reflect actual behavior.