### PR TITLE
fix(metrics): reject out-of-range percentiles at startup

### DIFF
--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -99,6 +99,16 @@ pub fn validate_thresholds(thresholds: &HashMap<String, ThresholdConfig>) -> Res
                         name, s, clause, expr
                     ));
                 }
+                // Reject out-of-range percentiles: p(150) silently becomes max,
+                // p(-5) silently becomes min — both are almost certainly typos.
+                if let Some(pct) = parse_percentile(s) {
+                    if !(0.0..=100.0).contains(&pct) {
+                        return Err(format!(
+                            "threshold '{}': percentile {} is out of range (must be 0-100) in clause '{}' of '{}'",
+                            name, s, clause, expr
+                        ));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
p(150) silently becomes max, p(-5) silently becomes min — both are almost certainly typos. Add range validation (0-100) to validate_thresholds so the run aborts at startup with a clear message.