### PR TITLE
perf(k6): retain sink Vec capacity across iterations

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1258,7 +1258,9 @@ impl DriverInstance for K6DriverInstance {
         // active scenario name (this is what makes scenario-scoped thresholds
         // like `http_req_duration{scenario:api_load}` resolve) — stamp it on
         // the drained samples so they match k6 semantics.
-        let mut bridge_samples = std::mem::take(&mut *self.sample_sink.lock().unwrap());
+        // drain(..) preserves the Vec's capacity — mem::take would replace
+        // with Vec::new() and lose it, causing re-growth every iteration.
+        let mut bridge_samples: Vec<_> = self.sample_sink.lock().unwrap().drain(..).collect();
         if !ctx.scenario_name.is_empty() {
             let scenario = ctx.scenario_name.clone();
             for s in &mut bridge_samples {


### PR DESCRIPTION
mem::take replaces the Vec with Vec::new() which has zero capacity, causing re-growth 4->8->16 every iteration (3 allocs + 2 memcpys). Use drain(..).collect() which moves elements out while preserving the Vec's existing capacity in the sink.