### PR TITLE
fix(report): escape newlines/control chars in InfluxDB tags and StatsD

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1258,7 +1258,9 @@ impl DriverInstance for K6DriverInstance {
         // active scenario name (this is what makes scenario-scoped thresholds
         // like `http_req_duration{scenario:api_load}` resolve) — stamp it on
         // the drained samples so they match k6 semantics.
-        let mut bridge_samples = std::mem::take(&mut *self.sample_sink.lock().unwrap());
+        // drain(..) preserves the Vec's capacity — mem::take would replace
+        // with Vec::new() and lose it, causing re-growth every iteration.
+        let mut bridge_samples: Vec<_> = self.sample_sink.lock().unwrap().drain(..).collect();
         if !ctx.scenario_name.is_empty() {
             let scenario = ctx.scenario_name.clone();
             for s in &mut bridge_samples {

--- a/crates/tropel-report/src/influxdb.rs
+++ b/crates/tropel-report/src/influxdb.rs
@@ -171,6 +171,19 @@ impl InfluxdbOutput {
                 ' ' | ',' | '=' if !in_quotes => out.push('\\'),
                 '"' if in_quotes => out.push('\\'),
                 '\\' => out.push('\\'),
+                // Newlines/tabs in tag values inject extra lines into the
+                // line protocol, causing silent metric corruption.
+                '\n' | '\r' | '\t' => {
+                    out.push('\\');
+                    let esc = match c {
+                        '\n' => "n",
+                        '\r' => "r",
+                        '\t' => "t",
+                        _ => unreachable!(),
+                    };
+                    out.push_str(esc);
+                    continue;
+                }
                 _ => {}
             }
             out.push(c);

--- a/crates/tropel-report/src/statsd.rs
+++ b/crates/tropel-report/src/statsd.rs
@@ -212,6 +212,10 @@ fn sanitize_component(s: &str) -> String {
         .map(|c| {
             if matches!(c, ':' | '|' | ',' | '#' | '@') {
                 '_'
+            } else if c.is_control() {
+                // Newlines/tabs/control chars in tag values inject extra
+                // lines into the UDP datagram, causing metric corruption.
+                '_'
             } else {
                 c
             }


### PR DESCRIPTION
Newlines in tag values inject extra lines into the InfluxDB line protocol and StatsD UDP datagrams, causing silent metric corruption. Escape \n/\r/\t in InfluxDB tags and replace control chars with _ in StatsD components.