### PR TITLE
fix(k6): http.post(url, {obj}) sends form-urlencoded, not JSON

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4200,14 +4200,16 @@ mod tests {
                 .expect("read captured[1] body");
             assert_eq!(second_body, "plain text");
 
-            // 3. Iteration 1 (object body) still gets application/json ON THE
-            //    COPY (not on the caller's object).
+            // 3. Iteration 1 (object body) gets application/x-www-form-urlencoded
+            //    (k6 default for object bodies without explicit Content-Type).
             let first_headers: String = ctx
                 .eval("JSON.stringify(__captured[0].headers)")
                 .expect("read captured[0] headers");
             assert!(
-                first_headers.to_lowercase().contains("application/json"),
-                "object body not labelled json: {first_headers}"
+                first_headers
+                    .to_lowercase()
+                    .contains("x-www-form-urlencoded"),
+                "object body not labelled form-urlencoded per k6: {first_headers}"
             );
 
             // 4. Multipart: the generated boundary MUST reach the header.

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -399,6 +399,12 @@ function serializeK6Body(body, headers) {
                 headers['Content-Type'] = multipart.contentType;
             } else if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1 && typeof body === 'object') {
                 bodyStr = serializeUrlEncoded(body);
+            } else if (!contentType && typeof body === 'object') {
+                // k6 default: objects are form-urlencoded, not JSON.
+                bodyStr = serializeUrlEncoded(body);
+                if (!headers['Content-Type'] && !headers['content-type']) {
+                    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
             } else {
                 try {
                     bodyStr = JSON.stringify(body);


### PR DESCRIPTION
k6 defaults to form-urlencoded when the body is an object and no Content-Type is set. The shim was falling through to JSON.stringify + application/json, breaking every ported k6 script that posts an object.