### PR TITLE
fix(k6): support Postman array-form params.headers

### DIFF
--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -181,9 +181,17 @@ function normalizeK6Request(method, url, body, params) {
     // application/json). The copy keeps the stamp per-request.
     var headers = {};
     var srcHeaders = params.headers;
-    if (srcHeaders && typeof srcHeaders === 'object' && !Array.isArray(srcHeaders)) {
-        for (var hk in srcHeaders) {
-            if (srcHeaders.hasOwnProperty(hk)) headers[hk] = srcHeaders[hk];
+    if (srcHeaders && typeof srcHeaders === 'object') {
+        if (Array.isArray(srcHeaders)) {
+            // Postman array form: [{key: 'Authorization', value: 'Bearer T'}]
+            for (var i = 0; i < srcHeaders.length; i++) {
+                var h = srcHeaders[i];
+                if (h && h.key) headers[h.key] = h.value !== undefined ? h.value : '';
+            }
+        } else {
+            for (var hk in srcHeaders) {
+                if (srcHeaders.hasOwnProperty(hk)) headers[hk] = srcHeaders[hk];
+            }
         }
     }
     // Backlog P1: the GLOBAL HttpConfig.request_timeout must bound k6


### PR DESCRIPTION
params.headers as an array of {key, value} objects (Postman format) was silently dropped because normalizeK6Request only handled object form. Now parses both forms: {key: value} objects and [{key, value}] arrays.