### PR TITLE
fix(metrics): surface dropped samples in stdout summary (P0)

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -52,6 +52,7 @@ impl Engine {
         // Forget any unit declarations from a previous run in this process
         // (backlog line 32) — the registry must never leak across runs.
         tropel_metrics::time_metrics::clear();
+        tropel_metrics::OUTPUT_SAMPLES_DROPPED.store(0, std::sync::atomic::Ordering::Relaxed);
 
         let registry = Arc::new(self.extension_registry.clone());
         let format_hint = config.input_type.clone();

--- a/crates/tropel-engine/src/outputs.rs
+++ b/crates/tropel-engine/src/outputs.rs
@@ -41,7 +41,8 @@ pub(crate) fn spawn_extension_output(
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::trace!("extension output dropped {n} samples (consumer lag)");
+                        tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!("extension output dropped {n} samples (consumer lag)");
                     }
                 },
                 _ = tick.tick() => {

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1158,6 +1158,8 @@ impl Aggregator {
             data_sent,
             errors,
             series_dropped: self.series_dropped,
+            output_samples_dropped: crate::OUTPUT_SAMPLES_DROPPED
+                .load(std::sync::atomic::Ordering::Relaxed),
             dropped_iterations: self
                 .totals
                 .get("dropped_iterations")
@@ -1566,6 +1568,9 @@ pub struct MetricsResult {
     /// (backlog line 53: previously counted and read nowhere — now surfaced
     /// so reporters can warn on truncated per-URL stats).
     pub series_dropped: u64,
+    /// Samples dropped by streaming output consumers due to broadcast lag
+    /// (P0: backlog line 332). Surfaced so reporters warn on data loss.
+    pub output_samples_dropped: u64,
     /// Iterations dropped because the VU pool was saturated (arrival-rate mode).
     pub dropped_iterations: u64,
     /// HTTP request failure rate (0.0 - 1.0).
@@ -1604,6 +1609,7 @@ impl Default for MetricsResult {
             data_sent: 0.0,
             errors: 0,
             series_dropped: 0,
+            output_samples_dropped: 0,
             dropped_iterations: 0,
             http_req_failed: 0.0,
             iterations: 0,

--- a/crates/tropel-metrics/src/lib.rs
+++ b/crates/tropel-metrics/src/lib.rs
@@ -13,6 +13,14 @@ pub use collector::*;
 pub use histogram::*;
 pub use thresholds::*;
 
+/// Global atomic counter of samples dropped by output consumers due to
+/// broadcast lag (RecvError::Lagged).  Every streaming output (InfluxDB,
+/// StatsD, JSON-stream, OTLP, Prometheus, extension) increments this on
+/// lag; the stdout reporter and MetricsResult surface it so users can
+/// see how many samples were silently lost.
+pub static OUTPUT_SAMPLES_DROPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// The k6 metric unit model (backlog line 32): a metric carries BOTH an
 /// aggregation type (`MetricType`: Counter/Gauge/Rate/Trend) AND a unit
 /// (`Time`/`Data`/`Default`). `Time` values are fractional milliseconds

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -1063,6 +1063,7 @@ mod tests {
             http_reqs: 0,
             errors: 0,
             series_dropped: 0,
+            output_samples_dropped: 0,
             checks_total: 0,
             checks_passed: 0,
             checks_failed: 0,

--- a/crates/tropel-report/src/influxdb.rs
+++ b/crates/tropel-report/src/influxdb.rs
@@ -144,7 +144,8 @@ impl InfluxdbOutput {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("influxdb dropped {n} samples (consumer lag)");
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("influxdb dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = tick.tick() => {

--- a/crates/tropel-report/src/json_stream.rs
+++ b/crates/tropel-report/src/json_stream.rs
@@ -80,7 +80,8 @@ impl JsonStreamOutput {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("json-stream dropped {n} samples (consumer lag)");
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("json-stream dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = tick.tick() => {

--- a/crates/tropel-report/src/otlp.rs
+++ b/crates/tropel-report/src/otlp.rs
@@ -97,7 +97,8 @@ impl OtlpOutput {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("otlp output dropped {n} samples (consumer lag)");
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("otlp output dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = tick.tick() => {

--- a/crates/tropel-report/src/output.rs
+++ b/crates/tropel-report/src/output.rs
@@ -139,7 +139,8 @@ impl StreamingStdoutOutput {
                         Ok(sample) => state.record(&sample),
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("Streaming output dropped {} samples (consumer lag)", n);
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("extension output dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = ticker.tick() => {

--- a/crates/tropel-report/src/prometheus.rs
+++ b/crates/tropel-report/src/prometheus.rs
@@ -163,7 +163,8 @@ impl PrometheusRemoteWriteOutput {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("prometheus output dropped {n} samples (consumer lag)");
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("prometheus output dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = tick.tick() => {

--- a/crates/tropel-report/src/statsd.rs
+++ b/crates/tropel-report/src/statsd.rs
@@ -109,7 +109,8 @@ impl StatsdOutput {
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::trace!("statsd dropped {n} samples (consumer lag)");
+                            tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                            tracing::warn!("statsd dropped {n} samples (consumer lag)");
                         }
                     },
                     _ = tick.tick() => {

--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -86,6 +86,12 @@ impl StdoutReporter {
         for (label, value) in exec_rows {
             out.push_str(&format!("    {:<14}{}\n", label, value));
         }
+        if result.output_samples_dropped > 0 {
+            out.push_str(&format!(
+                "    {:<14}{}\n",
+                "Samples dropped", result.output_samples_dropped
+            ));
+        }
 
         // HTTP requests — aligned two-column block
         out.push_str("\n  ── HTTP requests ─────────────────────────────────────────\n");

--- a/crates/tropel-report/tests/reporters.rs
+++ b/crates/tropel-report/tests/reporters.rs
@@ -50,6 +50,7 @@ fn fixture() -> MetricsResult {
         checks_failed: 4,
         errors: 0,
         series_dropped: 0,
+        output_samples_dropped: 0,
         summary_trend_stats: k6_default_trend_stats(),
         effective_thresholds: HashMap::from([
             (


### PR DESCRIPTION
All six streaming output Lagged handlers logged at trace! level — invisible at the default INFO level. This makes output consumer lag completely invisible to users.\n\nChanges:\n- Add global AtomicU64 counter (OUTPUT_SAMPLES_DROPPED) in tropel-metrics\n- Every Lagged handler increments it and logs at warn! instead of trace!\n- MetricsResult carries the new output_samples_dropped field\n- Stdout summary shows 'Samples dropped' line when non-zero\n- Counter reset at engine run start\n\nCloses backlog line 332 (P0).