### PR TITLE
fix(report): surface series_dropped in stdout summary

### DIFF
--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -92,6 +92,12 @@ impl StdoutReporter {
                 "Samples dropped", result.output_samples_dropped
             ));
         }
+        if result.series_dropped > 0 {
+            out.push_str(&format!(
+                "    {:<14}{}\n",
+                "Series dropped", result.series_dropped
+            ));
+        }
 
         // HTTP requests — aligned two-column block
         out.push_str("\n  ── HTTP requests ─────────────────────────────────────────\n");


### PR DESCRIPTION
The series_dropped counter existed in MetricsResult but was never rendered in the console output. Users had no visibility into whether the cardinality cap was hit.\n\nChanges:\n- Show 'Series dropped' in the Execution block when > 0\n\nBacklog line 232 sub-item.