### PR TITLE
perf(distributed): add mimalloc allocator to distributed binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,9 +4358,11 @@ name = "tropel-distributed"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "mimalloc",
  "rand",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/tropel-distributed/Cargo.toml
+++ b/crates/tropel-distributed/Cargo.toml
@@ -19,6 +19,11 @@ path = "src/bin/agent.rs"
 name = "tropel-cloud-run"
 path = "src/bin/cloud_run.rs"
 
+[features]
+default = ["alloc-mimalloc"]
+alloc-mimalloc = ["dep:mimalloc"]
+alloc-jemalloc = ["dep:tikv-jemallocator"]
+
 [dependencies]
 tropel-sdk.workspace = true
 tropel-core.workspace = true
@@ -33,3 +38,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
 rand.workspace = true
+mimalloc = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/tropel-distributed/src/bin/agent.rs
+++ b/crates/tropel-distributed/src/bin/agent.rs
@@ -4,6 +4,15 @@
 //! Usage:
 //!   tropel-agent --controller <host:port>
 
+// Select the global allocator at compile time via feature flags.
+#[cfg(feature = "alloc-mimalloc")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "alloc-jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::Parser;
 use std::path::PathBuf;
 use tropel_distributed::resolve_token;

--- a/crates/tropel-distributed/src/bin/cloud_run.rs
+++ b/crates/tropel-distributed/src/bin/cloud_run.rs
@@ -12,6 +12,15 @@
 //!   tropel-cloud-run agent --controller controller-svc:17890
 //!   tropel-cloud-run k8s --config job.json --agents 4 --image reg/tropel:v1 --namespace loadtest
 
+// Select the global allocator at compile time via feature flags.
+#[cfg(feature = "alloc-mimalloc")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "alloc-jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use tokio::net::TcpListener;

--- a/crates/tropel-distributed/src/bin/controller.rs
+++ b/crates/tropel-distributed/src/bin/controller.rs
@@ -4,6 +4,15 @@
 //! Usage:
 //!   tropel-controller --config <job.json> --agents <N> [--listen host:port]
 
+// Select the global allocator at compile time via feature flags.
+#[cfg(feature = "alloc-mimalloc")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "alloc-jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::net::TcpListener;


### PR DESCRIPTION
The main binary uses mimalloc for reduced fragmentation and faster allocation, but tropel-agent, tropel-controller, and tropel-cloud-run fell back to system malloc. tropel-agent is the binary that actually generates load in a distributed run, so the mimalloc win was silently lost exactly where it matters most.\n\nChanges:\n- Add mimalloc/jemalloc optional deps to tropel-distributed\n- Add #[global_allocator] to agent.rs, controller.rs, cloud_run.rs\n- Default feature enables mimalloc (matching main binary)\n\nBacklog line 326.