### PR TITLE
fix(report): wire -o/--output to json/csv reporters

### DIFF
--- a/crates/tropel-distributed/src/lib.rs
+++ b/crates/tropel-distributed/src/lib.rs
@@ -138,7 +138,7 @@ pub async fn report_and_thresholds(
 ) -> Result<()> {
     let mut reporters = Vec::new();
     for name in &config.output.reporters {
-        if let Some(r) = create_reporter(name) {
+        if let Some(r) = create_reporter(name, config.output.output_file.as_deref()) {
             reporters.push(r);
         } else {
             tracing::warn!("Unknown reporter: {name}");

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -345,7 +345,7 @@ impl Engine {
         // flush() when the stream closes. This replaces the old
         // "extension reporter not supported" dead end.
         for name in &config.output.reporters {
-            if create_reporter(name).is_some() {
+            if create_reporter(name, None).is_some() {
                 continue; // built-in reporters handled above / at the end
             }
             if let Some(mut ext) = self.extension_registry.get_output(name) {
@@ -663,7 +663,7 @@ impl Engine {
     fn create_reporters(&self, config: &OutputConfig) -> Vec<Box<dyn Reporter>> {
         let mut reporters: Vec<Box<dyn Reporter>> = Vec::new();
         for name in &config.reporters {
-            if let Some(reporter) = create_reporter(name) {
+            if let Some(reporter) = create_reporter(name, config.output_file.as_deref()) {
                 reporters.push(reporter);
             } else if self
                 .extension_registry

--- a/crates/tropel-report/src/lib.rs
+++ b/crates/tropel-report/src/lib.rs
@@ -34,12 +34,17 @@ pub trait Reporter: Send + Sync {
     async fn report(&self, result: &MetricsResult) -> Result<()>;
 }
 
-/// Create reporters by name.
-pub fn create_reporter(name: &str) -> Option<Box<dyn Reporter>> {
+/// Create reporters by name, optionally with an output file path from
+/// `-o`/`--output`. Without a path, json/csv reporters write to stdout.
+pub fn create_reporter(name: &str, output_file: Option<&str>) -> Option<Box<dyn Reporter>> {
     match name {
         "stdout" => Some(Box::new(StdoutReporter)),
-        "json" => Some(Box::new(JsonReporter::new(None))),
-        "csv" => Some(Box::new(CsvReporter::new(None))),
+        "json" => Some(Box::new(JsonReporter::new(
+            output_file.map(|s| s.to_string()),
+        ))),
+        "csv" => Some(Box::new(CsvReporter::new(
+            output_file.map(|s| s.to_string()),
+        ))),
         _ => None,
     }
 }


### PR DESCRIPTION
The -o/--output flag was plumbed through OutputConfig.output_file but never passed to the reporter constructors — json and csv reporters hardcoded None, silently ignoring the flag.\n\nChanges:\n- create_reporter() now accepts an optional output_file parameter\n- JsonReporter and CsvReporter receive the file path when provided\n- Engine and distributed callers updated\n\nBacklog line 230.