### PR TITLE
fix(build): respect TROPEL_TOKIO_WORKERS in generated binaries

### DIFF
--- a/crates/tropel-build/src/lib.rs
+++ b/crates/tropel-build/src/lib.rs
@@ -786,11 +786,17 @@ fn generate_main_rs(config: &BuildConfig) -> String {
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {{
-    // Delegate to the shared CLI entry point.
-    tropel_engine::cli::run_cli().await?;
-    Ok(())
+fn main() -> Result<(), Box<dyn std::error::Error>> {{
+    let workers: usize = std::env::var("TROPEL_TOKIO_WORKERS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(2)
+        .clamp(1, 128);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()?;
+    rt.block_on(tropel_engine::cli::run_cli())
 }}
 "#,
         imports = imports.trim_end(),


### PR DESCRIPTION
The main binary reads TROPEL_TOKIO_WORKERS to override the default tokio worker thread count, but tropel build generated binaries hardcoded worker_threads = 2. Generated binaries now use the same runtime builder as the main binary.\n\nBacklog line 363.