### PR TITLE
perf(variables): skip 44 marker scans when bare $ has no {{

### DIFF
--- a/crates/tropel-variables/src/catalog.rs
+++ b/crates/tropel-variables/src/catalog.rs
@@ -252,6 +252,13 @@ impl DynamicCatalog {
         if !s.contains('$') {
             return s.to_string();
         }
+        // Second fast path: a bare `$` without `{{` cannot be a dynamic
+        // variable (all Postman dynamic vars use `{{$...}}` syntax), so
+        // skip the 44 marker scans. Common in URLs with prices, JSONPath
+        // refs, and Stripe/GitHub-style query params.
+        if !s.contains("{{") {
+            return s.to_string();
+        }
         let mut result = s.to_string();
         let mut rng = rand::rng();
 


### PR DESCRIPTION
A string containing  but no  cannot be a Postman dynamic variable (all use  syntax), yet the resolver ran all 44 contains() scans. Add a second fast path: bare  without  returns unchanged.\n\nBacklog line 349 sub-item.