### PR TITLE
perf(sandbox): O(1) setNextRequest via HashMap lookup

### DIFF
--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -1035,13 +1035,13 @@ impl TrpBridge {
                     }
 
                     // 1. Item id first (Postman resolves ids before names).
-                    if let Some(pos) = st.request_ids.iter().position(|i| i == &request_id) {
+                    if let Some(&pos) = st.id_to_index.get(&request_id) {
                         st.next_request = Some(pos);
                         return;
                     }
 
                     // 2. Name — last-wins on duplicates (Postman).
-                    if let Some(pos) = st.request_names.iter().rposition(|n| n == &request_id) {
+                    if let Some(&pos) = st.name_to_last_index.get(&request_id) {
                         st.next_request = Some(pos);
                         return;
                     }

--- a/crates/tropel-sandbox/src/state.rs
+++ b/crates/tropel-sandbox/src/state.rs
@@ -43,6 +43,12 @@ pub struct PmState {
     /// Postman item ids of all items in order (for setNextRequest id lookup,
     /// which Postman resolves BEFORE names — backlog §4). Same Arc sharing.
     pub request_ids: Arc<Vec<String>>,
+    /// O(1) id → index lookup (backlog line 351). Built once per scenario
+    /// in `set_request_ids`, avoids linear scan on every setNextRequest call.
+    pub id_to_index: HashMap<String, usize>,
+    /// O(1) name → last index lookup (backlog line 351). Postman uses
+    /// last-wins semantics on duplicate names.
+    pub name_to_last_index: HashMap<String, usize>,
     /// Iteration data (from CSV/JSON data file), set per-iteration.
     pub iteration_data: Option<HashMap<String, Value>>,
     /// Backlog line 146: pm.execution.skipRequest() — skip the CURRENT item
@@ -116,6 +122,8 @@ impl PmState {
             next_request: None,
             request_names: Arc::new(Vec::new()),
             request_ids: Arc::new(Vec::new()),
+            id_to_index: HashMap::new(),
+            name_to_last_index: HashMap::new(),
             iteration_data: None,
             skip_request: false,
             group_stack: Vec::new(),
@@ -166,12 +174,22 @@ impl PmState {
 
     /// Set the list of request names in order (for resolving setNextRequest by name).
     pub fn set_request_names(&mut self, names: Arc<Vec<String>>) {
+        // Build last-wins index map (backlog line 351).
+        self.name_to_last_index.clear();
+        for (i, name) in names.iter().enumerate() {
+            self.name_to_last_index.insert(name.clone(), i);
+        }
         self.request_names = names;
     }
 
     /// Set the list of item ids in order (for resolving setNextRequest by id,
     /// which Postman prioritizes over name — backlog §4).
     pub fn set_request_ids(&mut self, ids: Arc<Vec<String>>) {
+        // Build id → index map (backlog line 351).
+        self.id_to_index.clear();
+        for (i, id) in ids.iter().enumerate() {
+            self.id_to_index.insert(id.clone(), i);
+        }
         self.request_ids = ids;
     }
 


### PR DESCRIPTION
setNextRequest did position() over all N request_ids and rposition() over all N request_names on every call — O(n) per jump, O(n^2) per iteration on a paginate-until-done loop. Build HashMaps once, O(1) lookup on every call.\n\nBacklog line 351.