### PR TITLE
fix(k6): add missing SharedArrayView methods and JSON.stringify

### DIFF
--- a/js/k6-shim/open-data-shim.js
+++ b/js/k6-shim/open-data-shim.js
@@ -69,7 +69,7 @@ function SharedArray(name, fn) {
         // Absent: first VU runs the factory, normalizes to a plain array and
         // stores it natively (parsed once, shared as an Arc).
         var data = fn();
-        if (data === null || data === undefined || typeof data.length !== 'number') {
+        if (data === null || data === undefined || typeof data.length !== 'number' || typeof data === 'string') {
             throw new Error('SharedArray: factory function must return an array-like object');
         }
         // Normalize array-like (incl. non-indexed keys) to a plain array.
@@ -164,16 +164,69 @@ SharedArrayView.prototype.join = function (sep) {
         parts.push(this._get(i));
     }
     return parts.join(sep === undefined ? ',' : sep);
-};
-
-SharedArrayView.prototype.slice = function (start, end) {
+};SharedArrayView.prototype.slice = function (start, end) {
     var s = start === undefined ? 0 : Number(start);
     if (s < 0) s = Math.max(this.length + s, 0);
     var e = end === undefined ? this.length : Number(end);
     if (e < 0) e = Math.max(this.length + e, 0);
     var n = Math.max(Math.min(e, this.length) - s, 0);
+
     var view = new SharedArrayView(this._name, this._offset + s, n);
     return view;
+};
+
+// Backlog line 284: missing filter/reduce/sort/concat + JSON.stringify.
+SharedArrayView.prototype.filter = function (cb, thisArg) {
+    var out = [];
+    for (var i = 0; i < this.length; i++) {
+        var v = this._get(i);
+        if (cb.call(thisArg, v, i, this)) out.push(v);
+    }
+    return out;
+};
+
+SharedArrayView.prototype.reduce = function (cb, initialValue) {
+    var i = 0;
+    var acc;
+    if (arguments.length > 1) {
+        acc = initialValue;
+    } else {
+        if (this.length === 0) throw new TypeError('Reduce of empty SharedArray with no initial value');
+        acc = this._get(0);
+        i = 1;
+    }
+    for (; i < this.length; i++) {
+        acc = cb(acc, this._get(i), i, this);
+    }
+    return acc;
+};
+
+SharedArrayView.prototype.sort = function (compareFn) {
+    // SharedArray is read-only — sort returns a plain sorted array copy.
+    var arr = [];
+    for (var i = 0; i < this.length; i++) arr.push(this._get(i));
+    return arr.sort(compareFn);
+};
+
+SharedArrayView.prototype.concat = function () {
+    var out = [];
+    for (var i = 0; i < this.length; i++) out.push(this._get(i));
+    for (var a = 0; a < arguments.length; a++) {
+        var other = arguments[a];
+        if (other && typeof other.length === 'number') {
+            for (var j = 0; j < other.length; j++) out.push(other[j]);
+        } else {
+            out.push(other);
+        }
+    }
+    return out;
+};
+
+// JSON.stringify(view) must produce a JSON array, not {"length":N}.
+SharedArrayView.prototype.toJSON = function () {
+    var arr = [];
+    for (var i = 0; i < this.length; i++) arr.push(this._get(i));
+    return arr;
 };
 
 function makeSharedIterator(nextFn) {


### PR DESCRIPTION
SharedArrayView was missing filter, reduce, sort, concat — all threw TypeError. JSON.stringify(view) produced {"length":N} instead of an array. Strings were accepted as array-like.\n\nChanges:\n- Add filter, reduce, sort, concat methods\n- Add toJSON for JSON.stringify support\n- Reject strings in factory return check\n\nBacklog line 284.