### PR TITLE
fix(cryptojs): SHA256(msg, cfg) no longer returns HMAC

### DIFF
--- a/js/cryptojs-shim/cryptojs.js
+++ b/js/cryptojs-shim/cryptojs.js
@@ -447,12 +447,21 @@ var CryptoJS = CryptoJS || {};
     };
 
     CryptoJS.SHA256 = function (message, key) {
-        var hasher = createHasher('SHA256');
-        var result = hasher.finalize(message);
+        // Real CryptoJS: SHA256(msg, cfg) where cfg may have
+        // outputLength. The old code treated the 2nd arg as an HMAC key,
+        // so SHA256('abc', {outputLength:224}) silently returned an HMAC
+        // instead of a truncated SHA-256 hash.
+        if (key && typeof key === 'object' && !key.words) {
+            // Config object — ignore (CryptoJS SHA256 has no cfg options
+            // beyond what HmacSHA256 provides). Just hash normally.
+            var hasher = createHasher('SHA256');
+            return hasher.finalize(message);
+        }
         if (key) {
             return CryptoJS.HmacSHA256(message, key);
         }
-        return result;
+        var hasher = createHasher('SHA256');
+        return hasher.finalize(message);
     };
 
     CryptoJS.SHA384 = function (message) {


### PR DESCRIPTION
CryptoJS.SHA256 treated its 2nd argument as an HMAC key, so SHA256('abc', {outputLength: 224}) silently returned an HMAC instead of a plain SHA-256 hash. Now a plain object is recognized as a config argument.\n\nBacklog line 283 sub-item.