### PR TITLE
perf(collection): filter whitespace-only exec lines at parse

### DIFF
--- a/crates/tropel-collection/src/model.rs
+++ b/crates/tropel-collection/src/model.rs
@@ -260,10 +260,14 @@ where
         Lines(Vec<String>),
         Single(String),
     }
-    Ok(match ExecForm::deserialize(deserializer)? {
+    let lines = match ExecForm::deserialize(deserializer)? {
         ExecForm::Lines(lines) => lines,
         ExecForm::Single(s) => vec![s],
-    })
+    };
+    // Backlog line 348: Postman's very common ["",""] becomes "\n"
+    // after join, which passes !is_empty() and pays a full dispatch.
+    // Filter out whitespace-only lines at parse time.
+    Ok(lines.into_iter().filter(|l| !l.trim().is_empty()).collect())
 }
 
 /// Accept `responseTime` as either a numeric milliseconds value (as


### PR DESCRIPTION
Postman's very common ["",""] exec becomes "\n" after join, which passes !is_empty() and pays a full dispatch. Filter whitespace-only lines at deserialization time.\n\nBacklog line 348 sub-item.