### PR TITLE
perf(sdk): pre-parse ExpectedStatus::Range into bounds (line 353)

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -165,7 +165,9 @@ impl ScenarioRunner {
 
     /// Set expected status codes/ranges for http_req_failed evaluation.
     pub fn with_expected_statuses(mut self, expected: Vec<ExpectedStatus>) -> Self {
-        self.expected_statuses = expected;
+        // Backlog line 353: pre-parse Range strings into bounds so
+        // matches() avoids re-parsing on every HTTP response.
+        self.expected_statuses = expected.iter().map(|e| e.pre_parse()).collect();
         self
     }
 


### PR DESCRIPTION
Pre-parses ExpectedStatus::Range("200-299") into (lo, hi) bounds at config load time.

Before: every HTTP response triggered `status.parse::<u16>()` and two string-to-int conversions inside the hot loop.

After: bounds are computed once during config init, eliminating per-request string allocations and comparisons.