### PR TITLE
fix(jslib): add httpx and papaparse stubs with clear errors (line 279)

### DIFF
--- a/js/k6-shim/jslib-shim.js
+++ b/js/k6-shim/jslib-shim.js
@@ -214,3 +214,24 @@ if (typeof htmlReport === 'undefined') {
         );
     };
 }
+
+// ── Stub jslib modules (backlog line 279) ───────────────────────
+// httpx and papaparse imports are stripped by the transpiler but had
+// no binding, so scripts hit a raw ReferenceError. These stubs throw
+// a clear init-time error explaining the limitation.
+if (typeof httpx === 'undefined') {
+    var httpx = new Proxy({}, {
+        get: function(_, prop) {
+            if (prop === '__esModule') return false;
+            throw new Error('k6/httpx jslib is not supported by Tropel yet (import was stripped). Use k6/http instead.');
+        }
+    });
+}
+if (typeof papaparse === 'undefined') {
+    var papaparse = new Proxy({}, {
+        get: function(_, prop) {
+            if (prop === '__esModule') return false;
+            throw new Error('k6/papaparse jslib is not supported by Tropel yet (import was stripped). Use a JS CSV parser instead.');
+        }
+    });
+}


### PR DESCRIPTION
These jslib imports were stripped by the transpiler but had no binding, causing a raw ReferenceError every iteration. Now they throw a clear init-time error explaining the limitation and suggesting alternatives (k6/http for httpx, a JS CSV parser for papaparse).