### PR TITLE
perf(js): hoist getStatusText map and SharedArray regex to module scope (line 328)

### DIFF
--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1902,16 +1902,16 @@ if (typeof getAltNames === 'undefined') { var getAltNames = x509.getAltNames; }
 // Helpers
 // ══════════════════════════════════════════════════════════════════
 
+var __STATUS_TEXTS = {
+    200: 'OK', 201: 'Created', 204: 'No Content',
+    301: 'Moved Permanently', 302: 'Found', 304: 'Not Modified',
+    400: 'Bad Request', 401: 'Unauthorized', 403: 'Forbidden',
+    404: 'Not Found', 405: 'Method Not Allowed', 408: 'Request Timeout',
+    409: 'Conflict', 413: 'Payload Too Large', 415: 'Unsupported Media Type',
+    422: 'Unprocessable Entity', 429: 'Too Many Requests',
+    500: 'Internal Server Error', 502: 'Bad Gateway',
+    503: 'Service Unavailable', 504: 'Gateway Timeout'
+};
 function getStatusText(code) {
-    var texts = {
-        200: 'OK', 201: 'Created', 204: 'No Content',
-        301: 'Moved Permanently', 302: 'Found', 304: 'Not Modified',
-        400: 'Bad Request', 401: 'Unauthorized', 403: 'Forbidden',
-        404: 'Not Found', 405: 'Method Not Allowed', 408: 'Request Timeout',
-        409: 'Conflict', 413: 'Payload Too Large', 415: 'Unsupported Media Type',
-        422: 'Unprocessable Entity', 429: 'Too Many Requests',
-        500: 'Internal Server Error', 502: 'Bad Gateway',
-        503: 'Service Unavailable', 504: 'Gateway Timeout'
-    };
-    return texts[code] || '';
+    return __STATUS_TEXTS[code] || '';
 }

--- a/js/k6-shim/open-data-shim.js
+++ b/js/k6-shim/open-data-shim.js
@@ -51,6 +51,10 @@ function open(path, mode) {
     return buf;
 }
 
+// Hoisted regex for SharedArray Proxy traps (line 328/336) — avoid
+// recompiling the literal on every element read.
+var __SA_NUMERIC_KEY = /^\d+$/;
+
 // ── k6/data SharedArray ──
 function SharedArray(name, fn) {
     if (typeof name !== 'string' || name === '') {
@@ -325,7 +329,7 @@ function openDataBase64ToBytes(b64) {
         return new Proxy(view, {
             get: function (target, prop) {
                 if (prop === '_name' || prop === '_offset' || prop === '_data') return undefined;
-                if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+                if (typeof prop === 'string' && __SA_NUMERIC_KEY.test(prop)) {
                     return target._get(Number(prop));
                 }
                 var v = target[prop];
@@ -333,7 +337,7 @@ function openDataBase64ToBytes(b64) {
             },
             has: function (target, prop) {
                 if (prop === '_name' || prop === '_offset' || prop === '_data') return false;
-                if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+                if (typeof prop === 'string' && __SA_NUMERIC_KEY.test(prop)) {
                     var n = Number(prop);
                     return n >= 0 && n < target.length;
                 }


### PR DESCRIPTION
Two per-HTTP-response allocations eliminated:
- `getStatusText()` re-created a 21-key object on every call; now hoisted to module scope
- SharedArray Proxy traps recompiled `/^\d+$/` on every element read; now hoisted to module scope