### PR TITLE
perf(runtime): remove unused build_scope call at iteration start (line 346)

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -236,8 +236,7 @@ impl ScenarioRunner {
 
         // Walk through the flattened execution list (folders descended).
 
-        // Build variable scope for this iteration
-        let _scope = self.build_scope(data_row.clone(), env_vars);
+        // Variable scope is built per-item below (line 334).
         let resolver = tropel_variables::VariableResolver::new();
 
         // Walk through the flattened execution list in order


### PR DESCRIPTION
The iteration loop called `build_scope` at line 234 but never used the result. This wasted ~105 HashMap clones and ~3885 allocations per iteration — pure dead code. The actual scope is built per-item at line 334 where it is consumed.