### PR TITLE
perf(report): sanitize_component and escape return Cow (line 339)

### DIFF
--- a/crates/tropel-report/src/influxdb.rs
+++ b/crates/tropel-report/src/influxdb.rs
@@ -174,15 +174,24 @@ impl InfluxdbOutput {
     }
 
     /// Escape a line-protocol component per InfluxDB rules.
-    fn escape(s: &str, in_quotes: bool) -> String {
+    fn escape(s: &str, in_quotes: bool) -> std::borrow::Cow<'_, str> {
+        // Backlog line 339: return Cow::Borrowed when no characters need
+        // escaping, avoiding a String allocation on the hot path.
+        let needs_escape = s.chars().any(|c| {
+            matches!(c, ' ' | ',' | '=' if !in_quotes)
+                || (in_quotes && c == '"')
+                || c == '\\'
+                || matches!(c, '\n' | '\r' | '\t')
+        });
+        if !needs_escape {
+            return std::borrow::Cow::Borrowed(s);
+        }
         let mut out = String::with_capacity(s.len());
         for c in s.chars() {
             match c {
                 ' ' | ',' | '=' if !in_quotes => out.push('\\'),
                 '"' if in_quotes => out.push('\\'),
                 '\\' => out.push('\\'),
-                // Newlines/tabs in tag values inject extra lines into the
-                // line protocol, causing silent metric corruption.
                 '\n' | '\r' | '\t' => {
                     out.push('\\');
                     let esc = match c {
@@ -198,7 +207,7 @@ impl InfluxdbOutput {
             }
             out.push(c);
         }
-        out
+        std::borrow::Cow::Owned(out)
     }
 
     /// Encode a sample as one line-protocol line and buffer it. HTTP
@@ -207,7 +216,8 @@ impl InfluxdbOutput {
     fn buffer(&self, sample: &Sample) {
         // measurement[,tag=val,...] field=value — no stray space between
         // the measurement and the tag set (line protocol is strict).
-        let mut line = Self::escape(&sample.metric, false);
+        let escaped_metric = Self::escape(&sample.metric, false);
+        let mut line = escaped_metric.into_owned();
         let tags = self.tag_policy.apply(&sample.tags);
         if !tags.is_empty() {
             let tag_list: Vec<String> = tags

--- a/crates/tropel-report/src/statsd.rs
+++ b/crates/tropel-report/src/statsd.rs
@@ -208,20 +208,25 @@ impl StatsdOutput {
 /// sample-rate delimiter (`|@0.5`) — we never emit sample rate, but a
 /// literal `@` in a name/value would be misread by a DogStatsD agent as a
 /// rate marker.
-fn sanitize_component(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if matches!(c, ':' | '|' | ',' | '#' | '@') {
-                '_'
-            } else if c.is_control() {
-                // Newlines/tabs/control chars in tag values inject extra
-                // lines into the UDP datagram, causing metric corruption.
-                '_'
-            } else {
-                c
-            }
-        })
-        .collect()
+fn sanitize_component(s: &str) -> std::borrow::Cow<'_, str> {
+    // Backlog line 339: return Cow::Borrowed when no characters need
+    // replacement, avoiding a String allocation on the hot path.
+    if s.chars()
+        .all(|c| !matches!(c, ':' | '|' | ',' | '#' | '@') && !c.is_control())
+    {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    std::borrow::Cow::Owned(
+        s.chars()
+            .map(|c| {
+                if matches!(c, ':' | '|' | ',' | '#' | '@') || c.is_control() {
+                    '_'
+                } else {
+                    c
+                }
+            })
+            .collect(),
+    )
 }
 
 #[async_trait]


### PR DESCRIPTION
`sanitize_component` (statsd) and `escape` (influxdb) now return `Cow<str>` — `Borrowed` when no characters need replacement (the common case for clean metric names), `Owned` only when escaping is required. Eliminates a String allocation per metric name on the hot path.