### PR TITLE
perf(http): by-value Response conversion eliminates 16 clones per request (line 312)

### DIFF
--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -482,7 +482,8 @@ impl DriverHttpClient for DriverHttpClientImpl {
         // digest on ONE request don't need the whole scenario to share it.
         let signer = req.auth.as_ref().and_then(|a| self.client.get_signer(a));
         let http_resp = self.client.execute(req, signer.as_deref()).await?;
-        Ok(Response::from(&http_resp))
+        // Backlog line 312: use by-value conversion to avoid 16 clones.
+        Ok(Response::from(http_resp))
     }
 }
 /// Pick the per-VU HTTP client for a VU spawn.

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -1246,6 +1246,31 @@ impl From<&HttpResponse> for tropel_sdk::types::Response {
     }
 }
 
+/// By-value conversion: moves all fields instead of cloning them.
+/// Backlog line 312: the hot path (vu_loop.rs:485) drops HttpResponse
+/// immediately after converting, so all the `.clone()`s in the by-ref
+/// impl are pure waste — 16 allocations and two full body copies per
+/// request. Use this instead where ownership is transferred.
+impl From<HttpResponse> for tropel_sdk::types::Response {
+    fn from(resp: HttpResponse) -> Self {
+        tropel_sdk::types::Response {
+            url: resp.url,
+            status_code: resp.status_code,
+            status_text: resp.status_text,
+            headers: resp.headers,
+            body: resp.body,
+            text_cache: std::cell::OnceCell::new(),
+            json_cache: std::cell::OnceCell::new(),
+            response_time: resp.response_time,
+            timings: resp.timings,
+            cookies: resp.cookies,
+            size: resp.size,
+            request_body_size: resp.request_body_size,
+            redirects: resp.redirects.into_iter().map(Response::from).collect(),
+        }
+    }
+}
+
 impl HttpResponse {
     /// Decode the body as UTF-8 text (lazy — decodes once, then memoized).
     ///

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1123,7 +1123,8 @@ mod tests {
         ) -> Result<tropel_sdk::types::Response> {
             let signer = req.auth.as_ref().and_then(|a| self.0.get_signer(a));
             let resp = self.0.execute(req, signer.as_deref()).await?;
-            Ok(tropel_sdk::types::Response::from(&resp))
+            // Backlog line 312: use by-value conversion to avoid 16 clones.
+            Ok(tropel_sdk::types::Response::from(resp))
         }
     }
 


### PR DESCRIPTION
Added `From<HttpResponse>` (by value) alongside the existing `From<&HttpResponse>`. The hot path (`vu_loop.rs:485`) drops `HttpResponse` immediately after converting, so all the `.clone()`s in the by-ref impl were pure waste: 16 allocations and two full body copies per request. Updated both callers to use the by-value conversion.