### PR TITLE
perf(http): eliminate body.clone() just to measure length (line 317)

### DIFF
--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -992,14 +992,16 @@ impl HttpClient {
                     }
                     body.extend_from_slice(&chunk);
                 }
-                (body.clone(), body.len() as u64)
+                let len = body.len() as u64;
+                (body, len)
             } else {
                 let body = response
                     .bytes()
                     .await
                     .map_err(|e| TropelError::Http(format!("Failed to read response body: {}", e)))?
                     .to_vec();
-                (body.clone(), body.len() as u64)
+                let len = body.len() as u64;
+                (body, len)
             };
             let receiving_duration = receiving_start.elapsed();
 


### PR DESCRIPTION
Two instances of `body.clone()` existed only to call `body.len()` on the clone while the original was discarded. Compute length first, then move the body directly — eliminates one full body copy per response.