### PR TITLE
perf(report): TagPolicy clone on no-op path + hoist rebuild_merged (P-D lines 334/338)

### DIFF
--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1310,10 +1310,10 @@ impl Aggregator {
         if self.effective_thresholds.is_empty() && !snap.thresholds.is_empty() {
             self.effective_thresholds = snap.thresholds.clone();
         }
-        // Series arrive pre-aggregated here (not through `record()`), so the
-        // incremental merged accumulators must be rebuilt from `self.data` to
-        // keep `build_results`' pre-merged headlines correct.
-        self.rebuild_merged();
+        // NOTE: rebuild_merged() is NOT called here — it is hoisted out of
+        // absorb_snapshot and called once after all snapshots are absorbed
+        // in merge_snapshots (line 338 optimization). Calling it per-snapshot
+        // wasted ~25s CPU and ~30GB churn at 50 agents × 100k series.
         Ok(())
     }
 
@@ -1444,6 +1444,9 @@ pub fn merge_snapshots(
     for snap in &snapshots {
         agg.absorb_snapshot(snap)?;
     }
+    // P-D (line 338): rebuild merged accumulators once after all snapshots
+    // are absorbed, instead of per-snapshot inside absorb_snapshot.
+    agg.rebuild_merged();
     let mut result = agg.build_results();
     // W0 P0#2: the fresh Aggregator's `started` is the merge instant, so
     // build_results stamps run_duration = merge time. Override with the

--- a/crates/tropel-report/src/output.rs
+++ b/crates/tropel-report/src/output.rs
@@ -38,6 +38,12 @@ pub struct TagPolicy {
 impl TagPolicy {
     /// Apply the policy to a sample's tags: allowlist first, then the cap.
     pub fn apply(&self, tags: &TagMap) -> TagMap {
+        // P-D (line 334): when the policy is a no-op (empty allowlist, no cap),
+        // clone the original TagMap instead of copying each entry. Clone only
+        // bumps Arc refcounts (~10 allocs→0 allocs per sample per output).
+        if self.allowlist.is_empty() && self.max_tags.is_none() {
+            return tags.clone();
+        }
         let mut out = TagMap::new();
         if self.allowlist.is_empty() {
             for (k, v) in tags.iter() {


### PR DESCRIPTION
Two performance fixes from backlog lines 334 and 338:

1. **TagPolicy::apply returns clone on no-op** (line 334): When allowlist is empty and no cap is set (the default), returns `tags.clone()` instead of iterating and inserting each entry. Clone only bumps Arc refcounts, eliminating ~10 `Arc<str>` allocations per sample per output.

2. **Hoist rebuild_merged out of absorb loop** (line 338): `rebuild_merged()` was called inside `absorb_snapshot()`, which runs once per agent snapshot in the distributed merge path. Now called once after all snapshots are absorbed. Saves ~25s CPU and ~30GB churn at 50 agents × 100k series.

Both changes pass cargo check, clippy -D warnings, and all existing tests.