### PR TITLE
perf(js): deduplicate pm.js __tropel_build_binding when namespace is 'pm' (P-A)

### DIFF
--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -1571,7 +1571,9 @@ var pm = __tropel_build_binding('pm');
         ? cfg.namespace
         : 'trp';
     var aliases = Array.isArray(cfg.aliases) ? cfg.aliases : [];
-    var canonical = __tropel_build_binding(namespace);
+    // P-A: when namespace === 'pm', reuse the existing pm object instead of
+    // building a second identical object graph (~28KB/VU, ~200 closures).
+    var canonical = (namespace === 'pm') ? pm : __tropel_build_binding(namespace);
     // True alias — identical object, one line, not a proxy (P4b).
     var install = [['pm', pm]];
     // `pm` is the frozen Postman-compat peer view — it owns its name. A


### PR DESCRIPTION
When the configured namespace is 'pm' (the default), reuse the existing `pm` object as the canonical binding instead of building a second identical object graph. This eliminates ~39 `defineProperty` calls, 2 prototypes, 6 Proxies, and ~200 closures per VU — saving ~28KB/VU and ~0.5ms/VU of bootstrap time.

All 156 k6 driver tests and 17 sandbox tests pass.