### PR TITLE
perf(sandbox): skip serde_json parse for empty pm.test tags (P-E)

### DIFF
--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -999,6 +999,7 @@ impl TrpBridge {
                     move |name: String, passed: bool, tags_json: Option<String>| {
                         let extra = tags_json
                             .as_deref()
+                            .filter(|j| !j.is_empty())
                             .and_then(|j| serde_json::from_str::<HashMap<String, String>>(j).ok())
                             .unwrap_or_default();
                         let mut st = state_clone.lock().unwrap();


### PR DESCRIPTION
pm.js always passes empty string `''` as the `tags_json` argument to `__tropel_pm_test`. The old code called `serde_json::from_str("")` which fails every time, producing 60 failed parses per iteration. Short-circuit on empty string before attempting the parse.