### PR TITLE
perf(variables): skip allocation in resolve_deep_with when no {{ present (P-E)

### DIFF
--- a/crates/tropel-variables/src/resolver.rs
+++ b/crates/tropel-variables/src/resolver.rs
@@ -206,6 +206,11 @@ impl VariableResolver {
         max_passes: usize,
         mode: EscapeMode,
     ) -> String {
+        // Fast path: no {{ means no variable reference — return unchanged
+        // without allocating.
+        if !input.contains("{{") {
+            return input.to_string();
+        }
         let mut result = input.to_string();
         for _ in 0..max_passes {
             if !result.contains("{{") {


### PR DESCRIPTION
Add early-return fast path before the unconditional `to_string()` allocation in `resolve_deep_with`. When the input contains no `{{` (the common case for plain URLs, headers, and bodies with only scoped `{{var}}` refs), return immediately without allocating.