### PR TITLE
perf(report): spawn_blocking for OTLP/Prometheus flush + raise default workers to 4 (P1 line 335)

### DIFF
--- a/crates/tropel-build/src/lib.rs
+++ b/crates/tropel-build/src/lib.rs
@@ -790,7 +790,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {{
     let workers: usize = std::env::var("TROPEL_TOKIO_WORKERS")
         .ok()
         .and_then(|v| v.trim().parse().ok())
-        .unwrap_or(2)
+        .unwrap_or(4)
         .clamp(1, 128);
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)

--- a/crates/tropel-report/src/otlp.rs
+++ b/crates/tropel-report/src/otlp.rs
@@ -130,6 +130,10 @@ impl OtlpOutput {
 
     /// Drain the buffer, build an `ExportMetricsServiceRequest` JSON payload,
     /// and POST it to `/v1/metrics`. Non-2xx responses are logged, not fatal.
+    ///
+    /// P1 line 335: the CPU-heavy payload build (tag expansion, JSON
+    /// serialization) runs on spawn_blocking to avoid parking the async
+    /// worker while the aggregator needs to drain its channel.
     async fn flush_buffered(&self) -> Result<()> {
         let metrics = {
             let mut guard = self.metrics.lock().unwrap();
@@ -143,12 +147,19 @@ impl OtlpOutput {
             return Ok(());
         }
 
-        let body = build_export_request(&metrics);
+        // Move the CPU-heavy payload build off the async worker.
+        let body_str = tokio::task::spawn_blocking(move || {
+            let body = build_export_request(&metrics);
+            body.to_string()
+        })
+        .await
+        .map_err(|e| TropelError::Other(format!("otlp payload build panicked: {e}")))?;
+
         let resp = self
             .client
             .post(&self.endpoint)
             .header("Content-Type", "application/json")
-            .body(body.to_string())
+            .body(body_str)
             .send()
             .await
             .map_err(|e| TropelError::Http(format!("otlp POST failed: {e}")))?;

--- a/crates/tropel-report/src/prometheus.rs
+++ b/crates/tropel-report/src/prometheus.rs
@@ -251,10 +251,16 @@ impl PrometheusRemoteWriteOutput {
                 .collect()
         };
 
-        let payload = encode_write_request(&wire_series);
-        let compressed = snap::raw::Encoder::new()
-            .compress_vec(&payload)
-            .map_err(|e| TropelError::Report(format!("snappy compress failed: {e}")))?;
+        // P1 line 335: move the CPU-heavy encode + compress off the async
+        // worker so the aggregator can keep draining while we serialize.
+        let compressed = tokio::task::spawn_blocking(move || {
+            let payload = encode_write_request(&wire_series);
+            snap::raw::Encoder::new()
+                .compress_vec(&payload)
+                .map_err(|e| TropelError::Report(format!("snappy compress failed: {e}")))
+        })
+        .await
+        .map_err(|e| TropelError::Other(format!("prometheus encode panicked: {e}")))??;
 
         let resp = self
             .client

--- a/crates/tropel/src/main.rs
+++ b/crates/tropel/src/main.rs
@@ -18,14 +18,20 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 ///
 /// VUs run on the thread-per-core `VUWorkerPool` (current-thread runtimes,
 /// one per CPU core), so the outer orchestrator only needs minimal workers
-/// for scenario coordination and final metric collection. Default 2; override
-/// with `TROPEL_TOKIO_WORKERS` (clamped to [1, 128] — more than the core
-/// count would only add contention).
+/// for scenario coordination and final metric collection. Default 4;
+/// override with `TROPEL_TOKIO_WORKERS` (clamped to [1, 128]).
+///
+/// P1 line 335: the old default of 2 was insufficient — the aggregator,
+/// abort coordinator, VU sampler, control API, and 5+ output consumers
+/// all share this runtime. Two workers caused flush_buffered() to park
+/// a worker while build_results() had no .await inside, blocking the
+/// entire runtime. Four workers give headroom for concurrent output
+/// flushes without starving the aggregator.
 fn outer_worker_threads() -> usize {
     std::env::var("TROPEL_TOKIO_WORKERS")
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
-        .unwrap_or(2)
+        .unwrap_or(4)
         .clamp(1, 128)
 }
 


### PR DESCRIPTION
The outer tokio runtime defaults to 2 workers shared by the aggregator, VU sampler, control API, and 5+ output consumers. Two workers caused `flush_buffered()` to park the runtime while `build_results()` had no `.await` inside, starving the aggregator and blocking every VU.

- Raise default worker count from 2 to 4 (override via `TROPEL_TOKIO_WORKERS`)
- OTLP: wrap payload build (tag expansion + JSON serialization) in `spawn_blocking`
- Prometheus: wrap encode + snappy compress in `spawn_blocking`

All existing tests pass, clippy clean.