### PR TITLE
fix(sdk): hand-write Response::Clone to skip memoized caches + document 4096 ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Notable limitations today:
   use host-imported http/sleep/metrics, but the API is a subset of the
   in-process k6 driver's (no full scripting runtime inside the module).
 - **JMeter and Locust adapters are not started** (planned §11.6).
+- **4096 VU concurrency ceiling** — each VU owns a dedicated OS thread
+  (thread-per-core model), capped at `MAX_WORKERS = 4096`. A run requesting
+  10,000 VUs wraps onto existing workers past the cap, delivering the
+  throughput of 4,096 effective VUs. This is a structural limit of the
+  synchronous QuickJS host-call bridge (host functions must be synchronous
+  and park the calling thread). Lifting it requires async host-call support
+  (Promise-returning host functions + job-queue pumping) or a fiber VU model.
 
 ## Architecture
 


### PR DESCRIPTION
The derived `Clone` copies `OnceLock` caches (`text_cache`, `json_cache`), so a clone-then-mutate-body returns the stale text from the original body. Hand-written `Clone` skips the caches, letting them be rebuilt on demand by the cloned `Response`'s own body.

Also documents the 4096 VU concurrency ceiling in `README.md`.