### PR TITLE
fix(json-stream): truncate output file on start instead of appending

### DIFF
--- a/crates/tropel-report/src/json_stream.rs
+++ b/crates/tropel-report/src/json_stream.rs
@@ -169,7 +169,8 @@ impl JsonStreamOutput {
             if wguard.is_none() {
                 let file = std::fs::OpenOptions::new()
                     .create(true)
-                    .append(true)
+                    .truncate(true)
+                    .write(true)
                     .open(&self.path)
                     .map_err(|e| {
                         TropelError::Report(format!("json-stream open '{}' failed: {e}", self.path))


### PR DESCRIPTION
## Problem

The `--json-stream` flag used append mode (`append(true)`), so re-runs would concatenate with previous output. This created duplicate `Metric` records and caused aggregations to double-count.

## Fix

Changed to `truncate(true) + write(true)` on first open, matching k6's `--out json` behavior. Each run starts with a clean file.

From backlog line 231.