### PR TITLE
perf(metrics): use static interned tag keys (line 352)

### DIFF
--- a/crates/extensions/tropel-x-grpc/src/lib.rs
+++ b/crates/extensions/tropel-x-grpc/src/lib.rs
@@ -35,8 +35,8 @@ use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tonic::{Code as GrpcCode, Request as TonicRequest, Status};
 use tropel_sdk::{
-    Body, Protocol, ProtocolOutcome, ProtocolRegistration, Request, Response, Result, Sample,
-    SampleType, TagMap, TropelError,
+    tag_keys, Body, Protocol, ProtocolOutcome, ProtocolRegistration, Request, Response, Result,
+    Sample, SampleType, TagMap, TropelError,
 };
 
 /// Default gRPC port when the URL omits it.
@@ -517,11 +517,17 @@ impl Protocol for GrpcProtocol {
 
         let now = std::time::SystemTime::now();
         let mut tags = TagMap::with_capacity(5);
-        tags.insert("url", req.url.clone());
-        tags.insert("method", format!("{service_full}/{method_name}"));
-        tags.insert("status", grpc_status.to_string());
-        tags.insert("name", format!("{service_full}/{method_name}"));
-        tags.insert("group", "grpc");
+        tags.insert(Arc::clone(&tag_keys::URL), req.url.clone());
+        tags.insert(
+            Arc::clone(&tag_keys::METHOD),
+            format!("{service_full}/{method_name}"),
+        );
+        tags.insert(Arc::clone(&tag_keys::STATUS), grpc_status.to_string());
+        tags.insert(
+            Arc::clone(&tag_keys::NAME),
+            format!("{service_full}/{method_name}"),
+        );
+        tags.insert(Arc::clone(&tag_keys::GROUP), "grpc");
         let tags = std::sync::Arc::new(tags);
 
         let sent = body_to_json(req)

--- a/crates/extensions/tropel-x-websocket/src/lib.rs
+++ b/crates/extensions/tropel-x-websocket/src/lib.rs
@@ -31,12 +31,13 @@
 
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 use tropel_sdk::{
-    Body, Protocol, ProtocolOutcome, ProtocolRegistration, Request, Response, Result, Sample,
-    SampleType, TagMap, TropelError,
+    tag_keys, Body, Protocol, ProtocolOutcome, ProtocolRegistration, Request, Response, Result,
+    Sample, SampleType, TagMap, TropelError,
 };
 
 /// Default time to wait for responses after sending messages.
@@ -218,11 +219,11 @@ impl Protocol for WebSocketProtocol {
         // ── Metrics ──
         let now = std::time::SystemTime::now();
         let mut tags = TagMap::with_capacity(5);
-        tags.insert("url", req.url.clone());
-        tags.insert("method", "GET");
-        tags.insert("status", session_status.to_string());
-        tags.insert("name", req.url.clone());
-        tags.insert("group", "ws");
+        tags.insert(Arc::clone(&tag_keys::URL), req.url.clone());
+        tags.insert(Arc::clone(&tag_keys::METHOD), "GET");
+        tags.insert(Arc::clone(&tag_keys::STATUS), session_status.to_string());
+        tags.insert(Arc::clone(&tag_keys::NAME), req.url.clone());
+        tags.insert(Arc::clone(&tag_keys::GROUP), "ws");
         let tags = std::sync::Arc::new(tags);
 
         let samples = vec![

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -10,7 +10,7 @@ use tropel_sandbox::state::{PmState, SharedPmState};
 use tropel_sdk::config::ExpectedStatus;
 use tropel_sdk::scenario::{Scenario, ScenarioItem};
 use tropel_sdk::traits::{DriverHttpClient, Protocol};
-use tropel_sdk::types::{Sample, SampleType, TagMap};
+use tropel_sdk::types::{tag_keys, Sample, SampleType, TagMap};
 use tropel_sdk::Result;
 
 /// Result of running a VU iteration.
@@ -574,13 +574,22 @@ impl ScenarioRunner {
                                     .iter()
                                     .chain(std::iter::once(&http_response));
                                 for resp in chain {
-                                    // Build tags for all request-level metrics
+                                    // Build tags for all request-level metrics.
+                                    // Use static interned keys (tropel_sdk::types::tag_keys)
+                                    // to avoid re-allocating Arc<str> from &str literals
+                                    // on every hop (backlog line 352).
                                     let mut tags = TagMap::with_capacity(5);
-                                    tags.insert("url", resp.url.clone());
-                                    tags.insert("method", resolved_req.method.to_string());
-                                    tags.insert("status", resp.status_code.to_string());
-                                    tags.insert("name", resp.url.clone());
-                                    tags.insert("group", "http");
+                                    tags.insert(Arc::clone(&tag_keys::URL), resp.url.clone());
+                                    tags.insert(
+                                        Arc::clone(&tag_keys::METHOD),
+                                        resolved_req.method.to_string(),
+                                    );
+                                    tags.insert(
+                                        Arc::clone(&tag_keys::STATUS),
+                                        resp.status_code.to_string(),
+                                    );
+                                    tags.insert(Arc::clone(&tag_keys::NAME), resp.url.clone());
+                                    tags.insert(Arc::clone(&tag_keys::GROUP), "http");
                                     // Share one Arc so all ~12 per-request samples bump a
                                     // refcount instead of copying the whole map.
                                     let tags = Arc::new(tags);


### PR DESCRIPTION
## Summary

TagMap::insert(key, value) allocates an Arc<str> from &str on every call. For compile-time constant keys ("url", "method", "status", "name", "group") inserted on every HTTP/gRPC/WS request hop, this wastes an allocation per key per hop.

Uses static `LazyLock<Arc<str>>` interned keys so the Arc is allocated once and shared via refcount across all VUs.

## Changes

- `tropel-sdk/src/types.rs`: Add `tag_keys` module with static interned keys
- `tropel-sdk/src/lib.rs`: Re-export `tag_keys`
- `tropel-runtime/src/runner.rs`: Use `tag_keys::*` for HTTP request tags
- `tropel-x-grpc/src/lib.rs`: Use `tag_keys::*` for gRPC request tags
- `tropel-x-websocket/src/lib.rs`: Use `tag_keys::*` for WS request tags

## Backlog item

Line 352: TagMap construction allocates ~15× per hop where ~6 would do

## Validation

- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p tropel-runtime -p tropel-input-k6 --lib` ✅ (178/178)