### PR TITLE
perf(variables): Arc-wrap collection_vars/globals (line 346)

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -119,7 +119,7 @@ impl ScenarioRunner {
             // scenario.variables) so `{{var}}` references in URLs, headers,
             // and bodies resolve. CLI env vars were already merged into
             // scenario.variables by the engine before this point.
-            state.collection_vars.extend(scenario.variables.clone());
+            Arc::make_mut(&mut state.collection_vars).extend(scenario.variables.clone());
         }
         Self {
             scenario,
@@ -838,8 +838,8 @@ impl ScenarioRunner {
             local: state.local_vars.clone(),
             data,
             env,
-            collection: state.collection_vars.clone(),
-            globals: state.globals.clone(),
+            collection: Arc::clone(&state.collection_vars),
+            globals: Arc::clone(&state.globals),
         }
     }
 

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -463,9 +463,9 @@ impl TrpBridge {
                 Func::from(move |key: String| {
                     let mut st = state_clone.lock().unwrap();
                     st.local_vars.remove(&key);
-                    st.collection_vars.remove(&key);
+                    Arc::make_mut(&mut st.collection_vars).remove(&key);
                     st.environment.remove(&key);
-                    st.globals.remove(&key);
+                    Arc::make_mut(&mut st.globals).remove(&key);
                 }),
             );
 
@@ -529,7 +529,7 @@ impl TrpBridge {
                 "__tropel_pm_collection_vars_set",
                 Func::from(move |key: String, value: String| {
                     let mut st = state_clone.lock().unwrap();
-                    st.collection_vars.insert(key, decode_json_value(&value));
+                    Arc::make_mut(&mut st.collection_vars).insert(key, decode_json_value(&value));
                 }),
             );
 
@@ -538,7 +538,7 @@ impl TrpBridge {
                 "__tropel_pm_collection_vars_unset",
                 Func::from(move |key: String| {
                     let mut st = state_clone.lock().unwrap();
-                    st.collection_vars.remove(&key);
+                    Arc::make_mut(&mut st.collection_vars).remove(&key);
                 }),
             );
 
@@ -578,7 +578,7 @@ impl TrpBridge {
                 "__tropel_pm_globals_set",
                 Func::from(move |key: String, value: String| {
                     let mut st = state_clone.lock().unwrap();
-                    st.globals.insert(key, decode_json_value(&value));
+                    Arc::make_mut(&mut st.globals).insert(key, decode_json_value(&value));
                 }),
             );
 
@@ -587,7 +587,7 @@ impl TrpBridge {
                 "__tropel_pm_globals_unset",
                 Func::from(move |key: String| {
                     let mut st = state_clone.lock().unwrap();
-                    st.globals.remove(&key);
+                    Arc::make_mut(&mut st.globals).remove(&key);
                 }),
             );
 

--- a/crates/tropel-sandbox/src/state.rs
+++ b/crates/tropel-sandbox/src/state.rs
@@ -11,10 +11,11 @@ use tropel_sdk::types::{Request, Response, Sample, TagMap};
 pub struct PmState {
     /// Environment variables.
     pub environment: HashMap<String, String>,
-    /// Collection variables.
-    pub collection_vars: HashMap<String, Value>,
-    /// Global variables.
-    pub globals: HashMap<String, Value>,
+    /// Collection variables (backlog line 346: Arc-wrapped to avoid
+    /// deep-cloning the entire HashMap on every build_scope call).
+    pub collection_vars: Arc<HashMap<String, Value>>,
+    /// Global variables (same Arc optimization).
+    pub globals: Arc<HashMap<String, Value>>,
     /// Local variables (pm.variables) — Postman's highest-priority scope.
     /// Backlog line 137: pm.variables.set used to write to collection_vars
     /// while get read data > env > collection, so set-then-get could return
@@ -110,8 +111,8 @@ impl PmState {
     pub fn new() -> Self {
         Self {
             environment: HashMap::new(),
-            collection_vars: HashMap::new(),
-            globals: HashMap::new(),
+            collection_vars: Arc::new(HashMap::new()),
+            globals: Arc::new(HashMap::new()),
             local_vars: HashMap::new(),
             response: None,
             request: None,

--- a/crates/tropel-variables/src/resolver.rs
+++ b/crates/tropel-variables/src/resolver.rs
@@ -1,6 +1,7 @@
 use crate::catalog::DynamicCatalog;
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Variable scope.
 #[derive(Debug, Clone, Default)]
@@ -12,10 +13,11 @@ pub struct VariableScope {
     pub data: HashMap<String, serde_json::Value>,
     /// Environment variables.
     pub env: HashMap<String, String>,
-    /// Collection variables.
-    pub collection: HashMap<String, serde_json::Value>,
-    /// Global variables.
-    pub globals: HashMap<String, serde_json::Value>,
+    /// Collection variables (backlog line 346: wrapped in Arc to avoid
+    /// deep-cloning the entire HashMap on every build_scope call).
+    pub collection: Arc<HashMap<String, serde_json::Value>>,
+    /// Global variables (same Arc optimization).
+    pub globals: Arc<HashMap<String, serde_json::Value>>,
 }
 
 /// The `{{var}}` placeholder regex, compiled ONCE per process. `VariableResolver`
@@ -342,14 +344,14 @@ mod tests {
             local: HashMap::new(),
             data: HashMap::from([("key".into(), serde_json::Value::String("data-value".into()))]),
             env: HashMap::from([("key".into(), "env-value".into())]),
-            collection: HashMap::from([(
+            collection: Arc::new(HashMap::from([(
                 "key".into(),
                 serde_json::Value::String("col-value".into()),
-            )]),
-            globals: HashMap::from([(
+            )])),
+            globals: Arc::new(HashMap::from([(
                 "key".into(),
                 serde_json::Value::String("global-value".into()),
-            )]),
+            )])),
         };
 
         // Data takes priority
@@ -367,8 +369,14 @@ mod tests {
             local: HashMap::from([("key".into(), serde_json::Value::String("local".into()))]),
             data: HashMap::from([("key".into(), serde_json::Value::String("data".into()))]),
             env: HashMap::from([("key".into(), "env".into())]),
-            collection: HashMap::from([("key".into(), serde_json::Value::String("col".into()))]),
-            globals: HashMap::from([("key".into(), serde_json::Value::String("global".into()))]),
+            collection: Arc::new(HashMap::from([(
+                "key".into(),
+                serde_json::Value::String("col".into()),
+            )])),
+            globals: Arc::new(HashMap::from([(
+                "key".into(),
+                serde_json::Value::String("global".into()),
+            )])),
         };
         assert_eq!(resolver.resolve("{{key}}", &scope), "local");
     }
@@ -417,14 +425,14 @@ mod tests {
     fn test_collection_then_globals_priority() {
         let resolver = VariableResolver::new();
         let scope = VariableScope {
-            collection: HashMap::from([(
+            collection: Arc::new(HashMap::from([(
                 "key".into(),
                 serde_json::Value::String("col-value".into()),
-            )]),
-            globals: HashMap::from([(
+            )])),
+            globals: Arc::new(HashMap::from([(
                 "key".into(),
                 serde_json::Value::String("global-value".into()),
-            )]),
+            )])),
             ..Default::default()
         };
 
@@ -433,7 +441,7 @@ mod tests {
 
         // Collection value type is preserved through the value form.
         let scope_num = VariableScope {
-            collection: HashMap::from([("n".into(), serde_json::json!(42))]),
+            collection: Arc::new(HashMap::from([("n".into(), serde_json::json!(42))])),
             ..Default::default()
         };
         assert_eq!(resolver.resolve("n={{n}}", &scope_num), "n=42");


### PR DESCRIPTION
## Summary

`build_scope` was called per-item and deep-cloned five HashMaps each time. For `collection_vars` and `globals` — which are invariant for the entire run in virtually every collection — this wasted ~2,520 allocations per iteration for the 60 collection variables alone.

## Changes

- `tropel-variables/src/resolver.rs`: `VariableScope.collection` and `.globals` changed from `HashMap` to `Arc<HashMap>`
- `tropel-sandbox/src/state.rs`: `PmState.collection_vars` and `.globals` changed to `Arc<HashMap>`
- `tropel-sandbox/src/bindings/trp.rs`: Mutations use `Arc::make_mut()` (clone-on-write)
- `tropel-runtime/src/runner.rs`: `build_scope` uses `Arc::clone()` (refcount bump)

## Backlog item

Line 346: `build_scope` — 105 HashMap clones and ~3,885 allocations per iteration

## Validation

- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p tropel-variables -p tropel-sandbox -p tropel-runtime -p tropel-input-k6 --lib` ✅ (239/239)