### PR TITLE
perf(http): parse URL once per hop instead of 3x per request

### DIFF
--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -553,6 +553,8 @@ impl HttpClient {
             // Each redirect hop is checked too — a Location header pointing
             // at a blacklisted literal must not slip past the resolver.
             check_literal_blacklist(&self.blacklist, &current_url)?;
+            // Line 454: parse once per hop, reuse for cookie jar + redirect.
+            let hop_url = reqwest::Url::parse(&current_url).ok();
             let hop_start = std::time::Instant::now();
             // Per-request slot: concurrent requests (http.batch) interleave on
             // one thread and futures migrate threads on the shared io_rt, so
@@ -644,8 +646,8 @@ impl HttpClient {
                         .iter()
                         .any(|(k, _)| k.eq_ignore_ascii_case("cookie"));
                     if !has_explicit_cookie {
-                        if let Ok(url) = reqwest::Url::parse(&current_url) {
-                            if let Some(value) = jar.cookies(&url) {
+                        if let Some(ref url) = hop_url {
+                            if let Some(value) = jar.cookies(url) {
                                 req_builder = req_builder.header(reqwest::header::COOKIE, value);
                             }
                         }
@@ -821,10 +823,10 @@ impl HttpClient {
             // EVERY hop (including redirect hops), so a session cookie set by
             // an intermediate redirect is available to the next hop.
             if let Some(jar) = jar {
-                if let Ok(url) = reqwest::Url::parse(&current_url) {
+                if let Some(ref url) = hop_url {
                     for v in response.headers().get_all(reqwest::header::SET_COOKIE) {
                         if let Ok(s) = v.to_str() {
-                            jar.add_cookie_str(s, &url);
+                            jar.add_cookie_str(s, url);
                         }
                     }
                 }
@@ -901,8 +903,8 @@ impl HttpClient {
                     });
 
                     // Resolve the Location header against the current URL.
-                    let base = reqwest::Url::parse(&current_url).map_err(|e| {
-                        TropelError::Http(format!("Invalid request URL '{}': {}", current_url, e))
+                    let base = hop_url.ok_or_else(|| {
+                        TropelError::Http(format!("Invalid request URL '{}'", current_url))
                     })?;
                     let next = base.join(&location).map_err(|e| {
                         TropelError::Http(format!(


### PR DESCRIPTION
## Summary

Hoists the `reqwest::Url::parse()` call to the top of the redirect loop and reuses the parsed URL for all three use sites per hop:

1. Cookie jar injection (`jar.cookies()`)
2. Set-Cookie storage (`jar.add_cookie_str()`)
3. Redirect Location resolution (`base.join()`)

This eliminates 2 redundant URL parses per request hop.

## TROPEL_MASTER_TODO line 454

> Parse the URL once per hop — currently 3 parses per request (`client.rs:556` RequestBuilder, `:626` jar-inject, `:804` jar-store) and 5 per redirect hop.

## Changes

- `crates/tropel-http/src/client.rs`: Added `hop_url` variable parsed once at loop top, replaced 3 individual `Url::parse` calls with references to `hop_url`.