### PR TITLE
perf(grpc,websocket): eliminate unnecessary body clone before len()

### DIFF
--- a/crates/extensions/tropel-x-grpc/src/lib.rs
+++ b/crates/extensions/tropel-x-grpc/src/lib.rs
@@ -503,18 +503,19 @@ impl Protocol for GrpcProtocol {
 
         // ── Build the outcome: response + samples ──
         let body_bytes = serde_json::to_vec(&response_value).unwrap_or_default();
+        let body_size = body_bytes.len() as u64;
         let response = Response {
             url: req.url.clone(),
             status_code: http_status,
             status_text: if ok { "OK".into() } else { "ERROR".into() },
             headers: HashMap::new(),
-            body: body_bytes.clone(),
+            body: body_bytes,
             text_cache: std::sync::OnceLock::new(),
             json_cache: std::sync::OnceLock::new(),
             response_time: duration,
             timings: None,
             cookies: vec![],
-            size: body_bytes.len() as u64,
+            size: body_size,
             request_body_size: 0,
             redirects: vec![],
         };
@@ -565,7 +566,7 @@ impl Protocol for GrpcProtocol {
             },
             Sample {
                 metric: "data_received".into(),
-                value: body_bytes.len() as f64,
+                value: body_size as f64,
                 tags,
                 timestamp: now,
                 sample_type: SampleType::Counter,

--- a/crates/extensions/tropel-x-websocket/src/lib.rs
+++ b/crates/extensions/tropel-x-websocket/src/lib.rs
@@ -192,6 +192,7 @@ impl Protocol for WebSocketProtocol {
 
         // ── Build the response for pm.response ──
         let body = serde_json::to_vec(&received).unwrap_or_default();
+        let body_size = body.len() as u64;
         let response = Response {
             url: req.url.clone(),
             status_code: session_status,
@@ -205,13 +206,13 @@ impl Protocol for WebSocketProtocol {
                 .iter()
                 .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
                 .collect(),
-            body: body.clone(),
+            body,
             text_cache: std::sync::OnceLock::new(),
             json_cache: std::sync::OnceLock::new(),
             response_time: duration,
             timings: None,
             cookies: vec![],
-            size: body.len() as u64,
+            size: body_size,
             request_body_size: 0,
             redirects: vec![],
         };


### PR DESCRIPTION
## Summary

In both gRPC and WebSocket response construction, the serialized body was cloned into `Response.body` and then `body.len()` was read from the original — a wasteful full-body memcpy.

**Fix**: Compute the size first, then move the body directly into the Response.

## TROPEL_MASTER_TODO line 359

> response body cloned immediately before `.len()` (same in WebSocket)