### PR TITLE
perf(crypto): wire native hex/base64 encoders in JS shims

### DIFF
--- a/js/cryptojs-shim/cryptojs.js
+++ b/js/cryptojs-shim/cryptojs.js
@@ -91,12 +91,14 @@ var CryptoJS = CryptoJS || {};
     // Hex
     CryptoJS.enc.Hex = {
         stringify: function (wordArray) {
-            var hex = '';
             var bytes = bytesFromWordArray(wordArray);
+            // Line 442: route through native hex encoder when available.
+            // The native check had an empty body, falling through to the
+            // per-byte JS loop every time (~2.7 µs wasted per call).
             if (typeof __tropel_native_hex_encode === 'function') {
-                // Use native hex encoding
-                // Native expects bytes, returns hex string
+                return __tropel_native_hex_encode(bytes);
             }
+            var hex = '';
             for (var i = 0; i < bytes.length; i++) {
                 hex += (bytes[i] >>> 4).toString(16);
                 hex += (bytes[i] & 0xF).toString(16);

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -324,6 +324,12 @@ function k6FileToBytes(file) {
 }
 
 function bytesToBase64(bytes) {
+    // Line 442: route through native base64 encoder when available.
+    // The shim always used the pure-JS loop even though
+    // __tropel_native_base64_encode is registered by tropel-native.
+    if (typeof __tropel_native_base64_encode === 'function') {
+        return __tropel_native_base64_encode(bytes);
+    }
     var out = '';
     for (var i = 0; i < bytes.length; i += 3) {
         var b0 = bytes[i];


### PR DESCRIPTION
## Summary

cryptojs.js had an empty body in the native hex_encode check, always falling through to the per-byte JS loop (~2.7 µs wasted per call). k6-shim.js bytesToBase64 always used the pure-JS loop even though `__tropel_native_base64_encode` is registered by tropel-native.

Both shims now route through native encoders when available, falling back to the JS implementation on platforms without tropel-native.

## TROPEL_MASTER_TODO line 442

> cryptojs.js:96-102 has a native feature-check with an empty body, falling through to a per-byte JS loop