### PR TITLE
perf(ext): short-circuit detect() when priority 0 match found

### DIFF
--- a/crates/tropel-ext/src/registry.rs
+++ b/crates/tropel-ext/src/registry.rs
@@ -251,6 +251,14 @@ impl ExtensionRegistry {
                     .unwrap_or(true)
             {
                 best = Some((registration.priority, driver));
+                // Line 361: short-circuit — priority 0 is the maximum;
+                // no later registration can beat it, so stop scanning.
+                // Without this, a 400 MB HAR is parsed by har's detect,
+                // then again by openapi's (it IS valid JSON), then
+                // postman's, then a fourth time by the winner's parse().
+                if registration.priority == 0 {
+                    break;
+                }
             }
         }
         best.map(|(_, driver)| driver)


### PR DESCRIPTION
## Summary

The registry probes every adapter even after finding a match (to find the highest priority). With priority 0 being the maximum, a match at priority 0 can't be beaten — stop scanning.

Without this, a 400 MB HAR is parsed by har's detect, then again by openapi's (valid JSON succeeds before key check fails), then postman's, then a fourth time by the winner's parse() — ~4×3s plus a multi-GB transient tree.

## TROPEL_MASTER_TODO line 361

> registry.rs:211-237 probes every adapter and keeps scanning after a match