### PR TITLE
fix(runtime): clear group_stack at iteration start to prevent soak leaks

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -246,6 +246,12 @@ impl ScenarioRunner {
             // local_vars from the previous iteration so they don't grow
             // monotonically (backlog line 353).
             state.local_vars.clear();
+            // Line 445: clear group_stack at iteration start — a throw
+            // inside a group() callback, test.abort(), or interrupt unwind
+            // leaks a frame permanently. The joined path is stamped as a
+            // tag value onto every emitted sample, so per-sample memory
+            // AND downstream cardinality grow without bound.
+            state.group_stack.clear();
         }
 
         // Walk through the flattened execution list (folders descended).


### PR DESCRIPTION
## Summary

A throw inside a `group()` callback, `test.abort()`, or interrupt unwind leaks a frame permanently. The joined path is stamped as a tag value onto every emitted sample, so per-sample memory AND downstream cardinality grow without bound in a 24h soak.

**Fix**: Clear `group_stack` at iteration start alongside `local_vars`.

## TROPEL_MASTER_TODO line 445

> group_stack push is unconditional, pop is conditional, and there is no clear() anywhere — a throw inside a group() callback, a test.abort(), or an interrupt unwind leaks a frame permanently