### PR TITLE
feat: real HTTP protocol version in res.proto (backlog 368/369)

### DIFF
--- a/crates/extensions/tropel-x-grpc/src/lib.rs
+++ b/crates/extensions/tropel-x-grpc/src/lib.rs
@@ -524,6 +524,7 @@ impl Protocol for GrpcProtocol {
             url: req.url.clone(),
             status_code: http_status,
             status_text: if ok { "OK".into() } else { "ERROR".into() },
+            protocol: "HTTP/2".into(),
             headers: HashMap::new(),
             body: body_bytes,
             text_cache: std::sync::OnceLock::new(),

--- a/crates/extensions/tropel-x-websocket/src/lib.rs
+++ b/crates/extensions/tropel-x-websocket/src/lib.rs
@@ -201,6 +201,7 @@ impl Protocol for WebSocketProtocol {
             } else {
                 "ERROR".into()
             },
+            protocol: "HTTP/1.1".into(),
             headers: handshake_resp
                 .headers()
                 .iter()

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1460,6 +1460,7 @@ fn build_k6_response_object<'js>(
     error_code: i32,
     response_type: &str,
     cookies: &[Cookie],
+    protocol: &str,
 ) -> rquickjs::Result<rquickjs::Object<'js>> {
     // Backlog line 46 (P0): allocation failures must NOT `.expect()`-panic
     // across the QuickJS FFI boundary — a server-controlled binary body can
@@ -1474,6 +1475,7 @@ fn build_k6_response_object<'js>(
     let _ = obj.set("status_text", status_text);
     let _ = obj.set("error", error);
     let _ = obj.set("error_code", error_code);
+    let _ = obj.set("proto", protocol);
     let headers_obj = rquickjs::Object::new(ctx.clone())?;
     for (k, v) in headers {
         let _ = headers_obj.set(k.as_str(), v.as_str());
@@ -1830,6 +1832,7 @@ fn register_http_bridges<'js>(
                         1000,
                         &response_type,
                         &[],
+                        "HTTP/1.1",
                     );
                 }
                 let extra_tags = params.tags;
@@ -1900,6 +1903,7 @@ fn register_http_bridges<'js>(
                             0,
                             &response_type,
                             &resp.cookies,
+                            &resp.protocol,
                         )
                     }
                     Err(e) => {
@@ -1929,6 +1933,7 @@ fn register_http_bridges<'js>(
                             k6_error_code(&err),
                             &response_type,
                             &[],
+                            "HTTP/1.1",
                         )
                     }
                 }
@@ -2098,6 +2103,7 @@ fn register_http_bridges<'js>(
                                     0,
                                     &response_type,
                                     &resp.cookies,
+                                    &resp.protocol,
                                 )?
                             }
                             Err(e) => {
@@ -2127,6 +2133,7 @@ fn register_http_bridges<'js>(
                                     k6_error_code(&err),
                                     &response_type,
                                     &[],
+                                    "HTTP/1.1",
                                 )?
                             }
                         };
@@ -8054,6 +8061,7 @@ mod tests {
                 0,
                 "binary",
                 &[],
+                "HTTP/1.1",
             )
             .expect("status-0 envelope build must succeed");
             let code: i32 = obj.get("code").expect("code field");
@@ -8090,6 +8098,7 @@ mod tests {
                 0,
                 "",
                 &[],
+                "HTTP/1.1",
             )
             .expect("status-0 envelope build must succeed");
             let code: i32 = obj.get("code").expect("code field");
@@ -9383,6 +9392,7 @@ mod tests {
                 url: req.url.clone(),
                 status_code: 200,
                 status_text: "OK".into(),
+                protocol: "HTTP/1.1".into(),
                 headers: HashMap::new(),
                 body: b"ok".to_vec(),
                 text_cache: std::sync::OnceLock::new(),
@@ -10145,6 +10155,7 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
                 0,
                 "binary",
                 &[],
+                "HTTP/1.1",
             )
             .expect("pre-guard returns degraded status-0 Ok; 32 MB body never reaches the alloc");
             let code: i32 = resp.get("code").unwrap();

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -62,6 +62,20 @@ fn http_request_error(e: &dyn std::error::Error) -> TropelError {
 /// `X-Request-Id`. The `http`/reqwest crate lowercases every `HeaderName`,
 /// so without this every k6/Postman doc idiom (`res.headers['Content-Type']`,
 /// `pm.response.header('Content-Type')`) would see `undefined`.
+///
+/// Format reqwest::Version as a human-readable protocol string.
+fn format_http_version(v: reqwest::Version) -> String {
+    let debug = format!("{:?}", v);
+    if debug.starts_with("Http(") {
+        let inner = &debug[5..debug.len() - 1];
+        let parts: Vec<&str> = inner.split(", ").collect();
+        if parts.len() == 2 {
+            return format!("HTTP/{}.{}", parts[0], parts[1]);
+        }
+    }
+    debug
+}
+
 fn canonical_header_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len());
     let mut upper = true;
@@ -806,6 +820,12 @@ impl HttpClient {
                 .canonical_reason()
                 .unwrap_or("Unknown")
                 .to_string();
+            // Line 368/369: capture the actual protocol version from the response
+            // instead of hardcoding "HTTP/1.1" in the JS shim. reqwest exposes
+            // the negotiated version after the TLS/ALPN handshake.
+            // reqwest::Version is a re-export of http::Version; it has no
+            // Display impl, but Debug outputs e.g. "Http(2, 0)" for HTTP/2.
+            let protocol = format_http_version(response.version());
 
             // Collect response headers — canonicalized to Go's MIME form
             // (Content-Type, X-Request-Id) because reqwest's HeaderName is
@@ -903,6 +923,7 @@ impl HttpClient {
                         url: current_url.clone(),
                         status_code,
                         status_text,
+                        protocol: format_http_version(response.version()),
                         headers,
                         raw_headers,
                         body: hop_body,
@@ -1077,6 +1098,7 @@ impl HttpClient {
                 url: current_url,
                 status_code,
                 status_text,
+                protocol,
                 headers,
                 raw_headers,
                 body: body_vec,
@@ -1217,6 +1239,9 @@ pub struct HttpResponse {
     pub url: String,
     pub status_code: u16,
     pub status_text: String,
+    /// Actual protocol version from the response (e.g. "HTTP/1.1", "HTTP/2").
+    /// Previously hardcoded to "HTTP/1.1" in the JS shim (Line 368/369).
+    pub protocol: String,
     pub headers: HashMap<String, String>,
     /// Every response header in ARRIVAL ORDER with duplicate names preserved
     /// (unlike the `headers` map, where the last line wins). Consumers that
@@ -1248,6 +1273,7 @@ impl From<&HttpResponse> for tropel_sdk::types::Response {
             url: resp.url.clone(),
             status_code: resp.status_code,
             status_text: resp.status_text.clone(),
+            protocol: resp.protocol.clone(),
             headers: resp.headers.clone(),
             body: resp.body.clone(),
             text_cache: std::sync::OnceLock::new(),
@@ -1275,6 +1301,7 @@ impl From<HttpResponse> for tropel_sdk::types::Response {
             url: resp.url,
             status_code: resp.status_code,
             status_text: resp.status_text,
+            protocol: resp.protocol,
             headers: resp.headers,
             body: resp.body,
             text_cache: std::sync::OnceLock::new(),
@@ -1795,6 +1822,7 @@ mod tests {
                 url: String::new(),
                 status_code: 200,
                 status_text: "OK".into(),
+                protocol: "HTTP/1.1".into(),
                 headers: Default::default(),
                 raw_headers: Default::default(),
                 body,

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -2199,6 +2199,7 @@ mod tests {
                     url: "http://example.com/ok".into(),
                     status_code: 200,
                     status_text: "OK".into(),
+                    protocol: "HTTP/1.1".into(),
                     headers: HashMap::new(),
                     body: br#"{"id":1}"#.to_vec(),
                     text_cache: std::sync::OnceLock::new(),

--- a/crates/tropel-wasm/src/driver.rs
+++ b/crates/tropel-wasm/src/driver.rs
@@ -1141,6 +1141,7 @@ mod tests {
                 url: req.url.clone(),
                 status_code: 200,
                 status_text: "OK".into(),
+                protocol: "HTTP/1.1".into(),
                 headers: HashMap::new(),
                 body: b"hello".to_vec(),
                 text_cache: std::sync::OnceLock::new(),

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -209,6 +209,7 @@ mod tests {
             url: req.url.clone(),
             status_code: 200,
             status_text: "OK".into(),
+            protocol: "HTTP/1.1".into(),
             headers: HashMap::new(),
             body: br#"{"ok":true}"#.to_vec(),
             text_cache: OnceLock::new(),

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -46,6 +46,7 @@ fn fixture_response(req: &Request) -> Result<Response> {
         url: req.url.clone(),
         status_code: 200,
         status_text: "OK".into(),
+        protocol: "HTTP/1.1".into(),
         headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
         body: br#"{"ok":true}"#.to_vec(),
         text_cache: std::sync::OnceLock::new(),

--- a/packages/runtime-wasm/src/postcard.ts
+++ b/packages/runtime-wasm/src/postcard.ts
@@ -366,6 +366,7 @@ export function encodeResponse(resp: HttpResponse): Uint8Array {
   w.str(resp.url);
   w.varint(resp.statusCode);
   w.str(resp.statusText ?? "");
+  w.str(resp.protocol ?? "HTTP/1.1");
   w.strMap(resp.headers);
   w.bytes(resp.body);
   writeDurationMs(w, resp.responseTimeMs);

--- a/packages/runtime-wasm/src/types.ts
+++ b/packages/runtime-wasm/src/types.ts
@@ -80,6 +80,7 @@ export interface HttpResponse {
   url: string;
   statusCode: number;
   statusText?: string;
+  protocol?: string;
   headers: Record<string, string>;
   body: Uint8Array;
   responseTimeMs: number;


### PR DESCRIPTION
Adds a `protocol` field to `HttpResponse` and SDK `Response` that carries the actual HTTP protocol version negotiated by reqwest (e.g. "HTTP/2", "HTTP/1.1") instead of the hardcoded "HTTP/1.1" the k6 shim was returning.

Changes:
- `HttpResponse` struct gains `protocol: String` field
- `format_http_version()` helper converts `reqwest::Version` to human-readable string
- Protocol is wired through all drivers: k6, WebSocket, gRPC, WASM, native, HAR
- SDK `Response` gains `protocol` with `#[serde(default)]` for backward compat
- All `From<HttpResponse>` impls forward the protocol
- Unit test added for `format_http_version` edge cases