### PR TITLE
fix(wasm): validate varint inputs + bridge error path (backlog 247)

### DIFF
--- a/packages/runtime-wasm/src/index.ts
+++ b/packages/runtime-wasm/src/index.ts
@@ -198,22 +198,29 @@ export async function createExecWasm(options: ExecWasmOptions): Promise<ExecWasm
   };
 
   const hostHttp = (reqPtr: number, reqLen: number): bigint => {
-    const instance = instanceRef!;
-    const exports = instance.exports as unknown as WasmExports;
-    const mem = () => new Uint8Array(exports.memory.buffer);
+    // Backlog line 247: try/catch so decoder or transport errors return
+    // 0 (the wasm contract for "error") instead of trapping the instance.
+    try {
+      const instance = instanceRef!;
+      const exports = instance.exports as unknown as WasmExports;
+      const mem = () => new Uint8Array(exports.memory.buffer);
 
-    // Copy the postcard Request out of linear memory.
-    const reqBytes = mem().slice(reqPtr, reqPtr + reqLen);
-    const req: HttpRequest = decodeHttpRequest(reqBytes);
+      // Copy the postcard Request out of linear memory.
+      const reqBytes = mem().slice(reqPtr, reqPtr + reqLen);
+      const req: HttpRequest = decodeHttpRequest(reqBytes);
 
-    const resp: HttpResponse = options.transport(req);
-    const respBytes = encodeResponse(resp);
+      const resp: HttpResponse = options.transport(req);
+      const respBytes = encodeResponse(resp);
 
-    // Allocate the reply via the module's own tropel_alloc (re-entrant call,
-    // the same pattern the Rust harness and the JS host use) and write it.
-    const outPtr = exports.tropel_alloc(respBytes.length);
-    mem().set(respBytes, outPtr);
-    return (BigInt(outPtr) << 32n) | BigInt(respBytes.length);
+      // Allocate the reply via the module's own tropel_alloc (re-entrant call,
+      // the same pattern the Rust harness and the JS host use) and write it.
+      const outPtr = exports.tropel_alloc(respBytes.length);
+      mem().set(respBytes, outPtr);
+      return (BigInt(outPtr) << 32n) | BigInt(respBytes.length);
+    } catch (e) {
+      console.error("[tropel-wasm] hostHttp bridge error:", e);
+      return 0n;
+    }
   };
 
   const imports: WebAssembly.Imports = {

--- a/packages/runtime-wasm/src/postcard.ts
+++ b/packages/runtime-wasm/src/postcard.ts
@@ -31,6 +31,11 @@ export class Writer {
   private out: number[] = [];
 
   varint(v: number): void {
+    // Backlog line 247: NaN/undefined coerce to 0 silently, Infinity
+    // hangs the loop forever. Validate before truncation.
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      throw new Error(`postcard: varint requires a finite number, got ${v}`);
+    }
     let x = Math.trunc(v);
     if (x < 0) throw new Error("postcard: negative varint");
     while (x >= 0x80) {


### PR DESCRIPTION
Two fixes for the wasm host-side postcard bridge:

1. **Writer.varint validation**: NaN/undefined silently coerce to 0 (corrupting timings), and Infinity hangs the loop forever (OOM-killed). Now throws with a descriptive error.

2. **hostHttp try/catch**: Decoder or transport errors now return 0 (the wasm C ABI contract for "error") instead of escaping into the wasm call and trapping the instance.

- TypeScript builds clean
- No Rust changes (wasm host-side only)