### PR TITLE
fix(scheduler): prevent externally-controlled shrink wedge (backlog 259)

### DIFF
--- a/crates/tropel-scheduler/src/scheduler.rs
+++ b/crates/tropel-scheduler/src/scheduler.rs
@@ -1618,11 +1618,34 @@ impl VUScheduler {
                 // Shrink: reuse the ramp-down claim mechanism so exactly
                 // `spawned - target` VUs exit. Each claim decrements
                 // `control_spawned`, so this is armed ONLY while the previous
-                // surplus is fully drained (remaining == 0) — re-arming every
+                // surplus is fully drained (remaining == 0) — rearming every
                 // tick against the lagging `active` counter used to inflate
                 // the surplus and overshoot below target.
-                if self.ramp_down_remaining.load(Ordering::Relaxed) == 0 {
+                let remaining = self.ramp_down_remaining.load(Ordering::Relaxed);
+                if remaining == 0 {
                     self.set_ramp_down_target(target, spawned);
+                } else {
+                    // Backlog line 259: if VUs died for unrelated reasons
+                    // (crash, OOM, JS error), they never claimed a ramp-down
+                    // slot so `remaining` stays inflated and the shrink wedges
+                    // permanently. Detect this by checking if the live pool
+                    // has already dropped below what `remaining` expects:
+                    //   remaining = spawned_at_arm - claimed
+                    //   actual_active = spawned_at_arm - (claimed + crashed)
+                    // If actual_active <= target, all surplus VUs are already
+                    // gone (crashed + claimed = spawned - target) and we can
+                    // safely reset.
+                    let active = self.active_vus.load(Ordering::Acquire);
+                    if active <= target {
+                        tracing::debug!(
+                            "Externally-controlled: VU pool already at or below target 
+                             (active={}, target={}, remaining={}) — resetting stale ramp-down",
+                            active,
+                            target,
+                            remaining
+                        );
+                        self.clear_ramp_down();
+                    }
                 }
                 tracing::debug!(
                     "Externally-controlled: shrinking pool {} → {}",


### PR DESCRIPTION
When VUs die for unrelated reasons (crash, OOM, JS error), they never claim a ramp-down slot, so `ramp_down_remaining` stays inflated and future shrink attempts are gated forever (`remaining != 0`). The control loop logs "shrinking N → M" every 100ms but never actually shrinks.

**Fix:** If `active_vus` has already dropped to or below the target, all surplus VUs are already gone (crashed + claimed = spawned - target), so we can safely reset the stale ramp-down state.

- 27/27 scheduler tests pass
- 39/39 engine tests pass
- Clippy clean, fmt clean