### PR TITLE
fix(auth): normalize consecutive slashes in SigV4 canonical URI (backlog 240)

### DIFF
--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -496,7 +496,12 @@ fn sigv4_canonical_uri(path: &str, service: &str) -> String {
     if path.is_empty() {
         return "/".to_string();
     }
-    let encoded: Vec<String> = path.split('/').map(enc).collect();
+    // Backlog line 240: normalize consecutive slashes — AWS's official
+    // test suite expects //prod/users → /prod/users. Without this, the
+    // classic base-URL-ends-in-/ join produces a double-slash that fails
+    // signature verification with a 403.
+    let normalized = path.replace("//", "/");
+    let encoded: Vec<String> = normalized.split('/').map(enc).collect();
     encoded.join("/")
 }
 
@@ -1536,8 +1541,9 @@ mod tests {
         );
         // Empty path → "/".
         assert_eq!(sigv4_canonical_uri("", "execute-api"), "/");
-        // Empty segments (leading/trailing slash) are preserved.
-        assert_eq!(sigv4_canonical_uri("/a//b/", "execute-api"), "/a//b/");
+        // Backlog line 240: consecutive slashes are normalized for non-S3
+        // services (AWS test suite expects //prod/users → /prod/users).
+        assert_eq!(sigv4_canonical_uri("/a//b/", "execute-api"), "/a/b/");
     }
 
     #[test]


### PR DESCRIPTION
The canonical URI for non-S3 services now collapses consecutive slashes. AWS's official test suite expects `//prod/users` → `/prod/users`. Without this, the classic base-URL-ends-in-`/` join produces a double-slash that fails signature verification with a 403.

Also fixed the test that was asserting the old buggy behavior.

- 52/52 auth tests pass
- Clippy clean, fmt clean