### PR TITLE
fix(engine): reporter failures no longer abort handleSummary (backlog P2)

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -634,7 +634,9 @@ impl Engine {
         if !config.distributed_worker {
             let reporters = self.create_reporters(&config.output);
             for reporter in &reporters {
-                reporter.report(&results).await?;
+                if let Err(e) = reporter.report(&results).await {
+                    tracing::error!("Reporter '{}' failed: {} — continuing with remaining reporters and handleSummary", reporter.name(), e);
+                }
             }
 
             // k6 `handleSummary(data)`: let the script emit custom summaries


### PR DESCRIPTION
A failing reporter now logs the error and continues with remaining reporters and handleSummary, matching k6 behavior.