### PR TITLE
perf(engine): make think-time sleep interruptible by stop signal (backlog P3)

### DIFF
--- a/crates/tropel-engine/src/pacing.rs
+++ b/crates/tropel-engine/src/pacing.rs
@@ -4,6 +4,7 @@
 //! Split out of the former `vu_loop.rs` god-file.
 
 use rand::RngExt;
+use std::sync::Arc;
 use std::time::Duration;
 use tropel_core::config::{ExecutionConfig, ThinkTimeConfig};
 use tropel_sdk::Result;
@@ -32,14 +33,35 @@ pub(crate) fn parse_duration_str(s: &str) -> Result<Duration> {
 
 // ── Think time ──
 
-pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Option<Duration>) {
+pub(crate) async fn apply_think_time(
+    config: &ThinkTimeConfig,
+    iter_duration: Option<Duration>,
+    stop: Option<&Arc<tokio::sync::Notify>>,
+) {
+    // Helper: sleep that can be interrupted by a stop signal.
+    async fn interruptible_sleep(dur: Duration, stop: Option<&Arc<tokio::sync::Notify>>) {
+        match stop {
+            Some(s) => {
+                let notified = s.notified();
+                tokio::pin!(notified);
+                tokio::select! {
+                    _ = tokio::time::sleep(dur) => {}
+                    _ = notified => {}
+                }
+            }
+            None => {
+                tokio::time::sleep(dur).await;
+            }
+        }
+    }
+
     if let Some(pacing_str) = &config.iteration_pacing {
         if let Ok(pacing) = parse_duration_str(pacing_str) {
             if let Some(actual_dur) = iter_duration {
                 if actual_dur < pacing {
                     let remaining = pacing - actual_dur;
                     if remaining > Duration::from_millis(1) {
-                        tokio::time::sleep(remaining).await;
+                        interruptible_sleep(remaining, stop).await;
                     }
                 }
             }
@@ -50,7 +72,7 @@ pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Op
     if let Some(delay_str) = &config.delay {
         if let Ok(delay) = parse_duration_str(delay_str) {
             if delay > Duration::from_millis(1) {
-                tokio::time::sleep(delay).await;
+                interruptible_sleep(delay, stop).await;
                 return;
             }
         }
@@ -61,7 +83,7 @@ pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Op
             if max > Duration::ZERO && max > min {
                 let range_ms = (max - min).as_millis() as u64;
                 let rand_ms = rand::rng().random_range(0..=range_ms);
-                tokio::time::sleep(min + Duration::from_millis(rand_ms)).await;
+                interruptible_sleep(min + Duration::from_millis(rand_ms), stop).await;
             }
         }
     }

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -221,7 +221,12 @@ async fn run_vu_loop(
             && !sched.is_stop_requested()
             && !sched.is_force_stop_requested()
         {
-            apply_think_time(&shared.think_time, Some(iter_start.elapsed())).await;
+            apply_think_time(
+                &shared.think_time,
+                Some(iter_start.elapsed()),
+                Some(&sched.stop_signal()),
+            )
+            .await;
         }
 
         if shared.total_iterations != u64::MAX


### PR DESCRIPTION
Bare tokio::time::sleep in apply_think_time is now interrupted by the scheduler's stop_signal Notify, so Ctrl-C cancels mid-sleep think-time immediately.