### PR TITLE
fix(engine): log malformed K6_STAGES instead of silently dropping (backlog P2)

### DIFF
--- a/crates/tropel-engine/src/config_file.rs
+++ b/crates/tropel-engine/src/config_file.rs
@@ -209,16 +209,23 @@ fn env_execution(
         ));
     }
 
-    if stages.is_some() {
-        let stage_list = stages.and_then(|s| serde_json::from_str::<Vec<Stage>>(s).ok())?;
-        if !stage_list.is_empty() {
-            return Some(ExecutionConfig::RampingVus {
-                stages: stage_list,
-                start_vus: vus.unwrap_or(1),
-                graceful_ramp_down: Some("30s".to_string()),
-                graceful_stop: Some("30s".to_string()),
-                think_time,
-            });
+    if let Some(stages_str) = stages {
+        match serde_json::from_str::<Vec<Stage>>(stages_str) {
+            Ok(stage_list) if !stage_list.is_empty() => {
+                return Some(ExecutionConfig::RampingVus {
+                    stages: stage_list,
+                    start_vus: vus.unwrap_or(1),
+                    graceful_ramp_down: Some("30s".to_string()),
+                    graceful_stop: Some("30s".to_string()),
+                    think_time,
+                });
+            }
+            Ok(_) => {
+                tracing::warn!("K6_STAGES parsed but is empty — ignoring");
+            }
+            Err(e) => {
+                tracing::warn!("K6_STAGES is malformed ({}): {}", stages_str, e);
+            }
         }
     }
 

--- a/crates/tropel-engine/src/pacing.rs
+++ b/crates/tropel-engine/src/pacing.rs
@@ -4,6 +4,7 @@
 //! Split out of the former `vu_loop.rs` god-file.
 
 use rand::RngExt;
+use std::sync::Arc;
 use std::time::Duration;
 use tropel_core::config::{ExecutionConfig, ThinkTimeConfig};
 use tropel_sdk::Result;
@@ -32,14 +33,35 @@ pub(crate) fn parse_duration_str(s: &str) -> Result<Duration> {
 
 // ── Think time ──
 
-pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Option<Duration>) {
+pub(crate) async fn apply_think_time(
+    config: &ThinkTimeConfig,
+    iter_duration: Option<Duration>,
+    stop: Option<&Arc<tokio::sync::Notify>>,
+) {
+    // Helper: sleep that can be interrupted by a stop signal.
+    async fn interruptible_sleep(dur: Duration, stop: Option<&Arc<tokio::sync::Notify>>) {
+        match stop {
+            Some(s) => {
+                let notified = s.notified();
+                tokio::pin!(notified);
+                tokio::select! {
+                    _ = tokio::time::sleep(dur) => {}
+                    _ = notified => {}
+                }
+            }
+            None => {
+                tokio::time::sleep(dur).await;
+            }
+        }
+    }
+
     if let Some(pacing_str) = &config.iteration_pacing {
         if let Ok(pacing) = parse_duration_str(pacing_str) {
             if let Some(actual_dur) = iter_duration {
                 if actual_dur < pacing {
                     let remaining = pacing - actual_dur;
                     if remaining > Duration::from_millis(1) {
-                        tokio::time::sleep(remaining).await;
+                        interruptible_sleep(remaining, stop).await;
                     }
                 }
             }
@@ -50,7 +72,7 @@ pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Op
     if let Some(delay_str) = &config.delay {
         if let Ok(delay) = parse_duration_str(delay_str) {
             if delay > Duration::from_millis(1) {
-                tokio::time::sleep(delay).await;
+                interruptible_sleep(delay, stop).await;
                 return;
             }
         }
@@ -61,7 +83,7 @@ pub(crate) async fn apply_think_time(config: &ThinkTimeConfig, iter_duration: Op
             if max > Duration::ZERO && max > min {
                 let range_ms = (max - min).as_millis() as u64;
                 let rand_ms = rand::rng().random_range(0..=range_ms);
-                tokio::time::sleep(min + Duration::from_millis(rand_ms)).await;
+                interruptible_sleep(min + Duration::from_millis(rand_ms), stop).await;
             }
         }
     }

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -221,7 +221,12 @@ async fn run_vu_loop(
             && !sched.is_stop_requested()
             && !sched.is_force_stop_requested()
         {
-            apply_think_time(&shared.think_time, Some(iter_start.elapsed())).await;
+            apply_think_time(
+                &shared.think_time,
+                Some(iter_start.elapsed()),
+                Some(&sched.stop_signal()),
+            )
+            .await;
         }
 
         if shared.total_iterations != u64::MAX


### PR DESCRIPTION
A malformed K6_STAGES value now logs the parse error instead of silently returning None and dropping the entire load profile.