### PR TITLE
fix(openapi): remove unused tracing dependency (backlog line 219)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,7 +4545,6 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "tracing",
  "tropel-sdk",
  "yaml_serde",
 ]

--- a/crates/inputs/tropel-input-openapi/Cargo.toml
+++ b/crates/inputs/tropel-input-openapi/Cargo.toml
@@ -14,4 +14,3 @@ inventory.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 yaml_serde = "0.10.4"
-tracing.workspace = true


### PR DESCRIPTION
tracing is declared but has zero uses across ~8 silent-drop paths in the OpenAPI crate.