### PR TITLE
fix(engine): observe panics from output tasks instead of discarding

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -609,7 +609,14 @@ impl Engine {
         metrics.set_sample_sink(None);
         drop(sample_tx);
         for handle in output_handles {
-            let _ = handle.await;
+            match handle.await {
+                Ok(()) => {}
+                Err(e) => {
+                    if e.is_panic() {
+                        tracing::error!("Output task panicked: {e} — some samples may be lost");
+                    }
+                }
+            }
         }
 
         // Raw snapshot (build_results now clones the summary config into


### PR DESCRIPTION
The 'let _ = handle.await' pattern on output task JoinHandles silently dropped panics, making output failures invisible. Now logs an error when a task panics, so lost samples are observable.