### PR TITLE
docs: fix lying noVUConnectionReuse comments

### DIFF
--- a/crates/inputs/tropel-input-k6/src/options.rs
+++ b/crates/inputs/tropel-input-k6/src/options.rs
@@ -55,8 +55,8 @@ pub struct K6Options {
     /// Close the connection after every request (k6 `noConnectionReuse`).
     #[serde(alias = "noConnectionReuse")]
     pub no_connection_reuse: Option<bool>,
-    /// k6 `noVUConnectionReuse` — accepted for compatibility; Tropel already
-    /// gives each VU its own client/pool, so it is effectively always on.
+    /// k6 `noVUConnectionReuse` — when true, forces a fresh client (own
+    /// connection pool) per VU. Default false: VUs share one pooled client.
     #[serde(alias = "noVUConnectionReuse")]
     pub no_vu_connection_reuse: Option<bool>,
     /// Global request-rate cap in requests/second (k6 `rps`).

--- a/crates/tropel-http/src/config.rs
+++ b/crates/tropel-http/src/config.rs
@@ -80,10 +80,10 @@ pub struct HttpConfig {
     /// connection, which trades latency for isolation.
     #[serde(default, alias = "noConnectionReuse")]
     pub no_connection_reuse: bool,
-    /// k6 `noVUConnectionReuse` parity. Tropel already gives every VU its own
-    /// client with its own connection pool, so connections are never shared
-    /// across VUs regardless of this flag; it is accepted for script
-    /// compatibility and currently a no-op.
+    /// k6 `noVUConnectionReuse` parity. When true, forces a fresh client
+    /// (own connection pool) per VU. Default false: every VU shares one
+    /// pooled client via Arc clone, keeping connections warm and TLS
+    /// sessions reusable.
     #[serde(default, alias = "noVUConnectionReuse")]
     pub no_vu_connection_reuse: bool,
     /// Global request-rate cap in requests/second (k6 `rps`). When set, the


### PR DESCRIPTION
The doc comment claimed noVUConnectionReuse is 'currently a no-op' and 'effectively always on', but the code in vu_loop.rs actually creates a fresh client (own connection pool) per VU when the flag is true. Default is false: VUs share one pooled client.