### PR TITLE
TR-008 TR-009 TR-010: input-wasm packaging fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,16 @@ on:
     # block bites.
     paths:
       - 'crates/**'
-      - 'js/**'
-      - 'examples/**'
-      - '.github/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - 'deny.toml'
+  - 'js/**'
+  - 'examples/**'
+  - '.github/**'
+  - 'Cargo.toml'
+  - 'Cargo.lock'
+  - 'rust-toolchain.toml'
+  - 'deny.toml'
+  - 'package.json'
+  - 'packages/**'
+
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref instead of paying for both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,15 @@ on:
     # block bites.
     paths:
       - 'crates/**'
-  - 'js/**'
-  - 'examples/**'
-  - '.github/**'
-  - 'Cargo.toml'
-  - 'Cargo.lock'
-  - 'rust-toolchain.toml'
-  - 'deny.toml'
-  - 'package.json'
-  - 'packages/**'
+      - 'js/**'
+      - 'examples/**'
+      - '.github/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'deny.toml'
+      - 'package.json'
+      - 'packages/**'
 
   workflow_dispatch:
 

--- a/packages/core-wasm/src/index.js
+++ b/packages/core-wasm/src/index.js
@@ -18,7 +18,20 @@
 // WebAssembly) the resolver degrades to a no-op passthrough — `{{$…}}`
 // survive literal and the embedder's own {{var}} map still resolves.
 
-import CATALOG_META from "../pkg/meta.js";
+// The name/description metadata for the predefined dynamic variables is
+// generated at package build time into `pkg/meta.js`. It is loaded lazily
+// (dynamic import) so the package can be imported in environments where the
+// wasm has not yet been built — CI runs `node -e "import('@tropel/core-wasm')"`
+// from a clean clone without a Rust toolchain, and a static top-level import
+// here would break module resolution with ENOENT before any consumer code
+// runs. The first call memoizes the result; subsequent calls are sync.
+let catalogMetaPromise = null;
+async function loadCatalogMeta() {
+  if (!catalogMetaPromise) {
+    catalogMetaPromise = import("../pkg/meta.js").then((m) => m.default ?? m);
+  }
+  return catalogMetaPromise;
+}
 
 let wasmInstance = null;
 let glue = null;
@@ -65,16 +78,19 @@ export function resolveDynamicVariables(template) {
 
 /**
  * Catalog metadata `[{"name":"$guid","description":…}]` for editor UIs.
- * Synchronous and init-free: extracted from the compiled catalog at package
- * build time (single source of truth — the Rust PREDEFINED_VARIABLE_META).
+ * Async and init-free: extracted from the compiled catalog at package build
+ * time (single source of truth — the Rust PREDEFINED_VARIABLE_META table in
+ * crates/tropel-core-wasm). Lazy because pkg/meta.js is build-generated and
+ * may be absent in dev / CI-from-a-clean-clone.
  */
-export function getPredefinedVariablesMeta() {
-  return CATALOG_META;
+export async function getPredefinedVariablesMeta() {
+  return await loadCatalogMeta();
 }
 
 /** Just the `$`-prefixed catalog names (autocomplete lists). */
-export function getPredefinedVariableNames() {
-  return CATALOG_META.map((m) => m.name);
+export async function getPredefinedVariableNames() {
+  const meta = await loadCatalogMeta();
+  return meta.map((m) => m.name);
 }
 
 // ── OAuth2 flows (RFC 6749 + RFC 7636 PKCE, pure — the embedder sends) ──────

--- a/packages/input-wasm/package.json
+++ b/packages/input-wasm/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@tropel/input-wasm",
+  "version": "0.1.0",
+  "description": "Tropel collection-import slice for browser embedders (KnockPort). Lazy sibling of @tropel/core-wasm: OpenAPI 3.x, Postman v2.x, and HAR parsers compiled to wasm32-unknown-unknown. See API_CLIENT_WEB_PAYLOAD.md §2.3 for the two-tier split.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./glue": {
+      "types": "./pkg/tropel_input_wasm.d.ts",
+      "default": "./pkg/tropel_input_wasm.js"
+    },
+    "./wasm/tropel_input_wasm_bg.wasm": "./pkg/tropel_input_wasm_bg.wasm"
+  },
+  "files": [
+    "src",
+    "pkg",
+    "LICENSE-APACHE"
+  ],
+  "scripts": {
+    "build": "bash scripts/build.sh",
+    "test": "node smoke.mjs",
+    "pack:dry": "bash scripts/build.sh && npm pack --dry-run"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/transithq/tropel.git",
+    "directory": "packages/input-wasm"
+  },
+  "homepage": "https://github.com/transithq/tropel/tree/main/packages/input-wasm",
+  "keywords": [
+    "openapi",
+    "postman",
+    "har",
+    "import",
+    "collection",
+    "wasm",
+    "webassembly",
+    "tropel"
+  ]
+}


### PR DESCRIPTION
- [TR-008] packages/input-wasm/package.json was missing
- [TR-009] packages/core-wasm/src/index.js now lazily imports pkg/meta.js
- [TR-010] ci.yml paths now include packages/** and root package.json

Closes #282