### PR TITLE
fix(report): always print drop counters even when zero [TR-001]

### DIFF
--- a/crates/tropel-engine/src/summary.rs
+++ b/crates/tropel-engine/src/summary.rs
@@ -129,6 +129,7 @@ pub(crate) fn build_summary_data(
             "checksPassed": results.checks_passed,
             "checksFailed": results.checks_failed,
             "seriesDropped": results.series_dropped,
+            "samplesDropped": results.output_samples_dropped,
         },
     })
 }

--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -83,24 +83,17 @@ impl StdoutReporter {
             ("Max VUs", result.vus_max.to_string()),
             ("Dropped", result.dropped_iterations.to_string()),
         ];
-        if result.output_samples_dropped > 0 {
-            exec_rows.push(("Samples lost", result.output_samples_dropped.to_string()));
-        }
         for (label, value) in exec_rows {
             out.push_str(&format!("    {:<14}{}\n", label, value));
         }
-        if result.output_samples_dropped > 0 {
-            out.push_str(&format!(
-                "    {:<14}{}\n",
-                "Samples dropped", result.output_samples_dropped
-            ));
-        }
-        if result.series_dropped > 0 {
-            out.push_str(&format!(
-                "    {:<14}{}\n",
-                "Series dropped", result.series_dropped
-            ));
-        }
+        out.push_str(&format!(
+            "    {:<14}{}\n",
+            "Samples dropped", result.output_samples_dropped
+        ));
+        out.push_str(&format!(
+            "    {:<14}{}\n",
+            "Series dropped", result.series_dropped
+        ));
 
         // HTTP requests — aligned two-column block
         out.push_str("\n  ── HTTP requests ─────────────────────────────────────────\n");

--- a/crates/tropel-report/tests/snapshots/reporters__stdout_summary.snap
+++ b/crates/tropel-report/tests/snapshots/reporters__stdout_summary.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tropel-report/tests/reporters.rs
-assertion_line: 147
+assertion_line: 148
 expression: rendered
 ---
 
@@ -11,6 +11,8 @@ expression: rendered
     Iterations    1024
     Max VUs       4
     Dropped       2
+    Samples dropped0
+    Series dropped0
 
   ── HTTP requests ─────────────────────────────────────────
     Total         1000 (33.33/s)


### PR DESCRIPTION
## What
Always print Samples dropped and Series dropped in the stdout summary, even when both are zero. Previously they were only shown when non-zero, making it impossible to distinguish "no drops" from "counter not wired". Also adds `samplesDropped` to the JSON summary alongside `seriesDropped`.

## Task
TR-001 — the measurement floor. Every downstream throughput task is unverifiable without this.

## Acceptance
- [x] Samples dropped printed always, even when zero
- [x] Series dropped printed always, even when zero
- [x] JSON summary includes samplesDropped
- [x] Snapshot test updated to match

## Tests
- Updated `stdout_summary_snapshot` insta test to expect the new always-visible format

## Twin check
- stdout.rs — only one code path for summary rendering
- summary.rs — JSON summary is the only other consumer of drop counts

## Evidence
READ: verified at `2099cbe`

## Risk
Very low — formatting change only. No logic or metric behavior changed.