### PR TITLE
fix(js): deep-equal Date comparison guards both operands [TR-013]

### DIFF
--- a/js/shared/deep-equal.js
+++ b/js/shared/deep-equal.js
@@ -28,8 +28,10 @@ if (typeof globalThis.__tropelDeepEqual !== 'function') {
         if (a === null || b === null || a === undefined || b === undefined) return a === b;
         if (typeof a !== typeof b) return false;
         // Date: compare by epoch time; two invalid dates compare equal.
+        // TR-013: guard that BOTH are Date before calling getTime() —
+        // the old code threw TypeError when a was non-Date and b was Date.
         if (a instanceof Date || b instanceof Date) {
-            if (!(b instanceof Date)) return false;
+            if (!(a instanceof Date && b instanceof Date)) return false;
             var ta = a.getTime(), tb = b.getTime();
             return (isNaN(ta) && isNaN(tb)) || ta === tb;
         }


### PR DESCRIPTION
## What
Fix the Date comparison in the shared deep-equal. The branch entered when EITHER operand was a Date, but then called `getTime()` on `a` which could be a non-Date value (e.g. `deepEqual(42, new Date())`), throwing TypeError.

## Task
TR-013 — the shared deep-equal is structurally blind (one of several issues).

## Acceptance
- [x] `a instanceof Date || b instanceof Date` branch now requires BOTH to be Date
- [x] Mixed type comparison (number vs Date) returns false instead of throwing

## Tests
- Existing deep-equal regression tests still pass
- The fix is mechanical — guard both operands before calling Date methods

## Twin check
- `pm.js` deepEqual — delegates to `__tropelDeepEqual`
- `chai-shim.js` jsDeepEqual/nativeDeepEqual — delegates to `__tropelDeepEqual`
- Only one copy of the implementation (the canonical one in `js/shared/deep-equal.js`)

## Evidence
READ: verified at `2099cbe`

## Risk
Very low — adds a guard that prevents a TypeError. No behavior change for correct inputs.