### PR TITLE
fix(k6): warn on unrecognized k6 root options [TR-201]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/options.rs
+++ b/crates/inputs/tropel-input-k6/src/options.rs
@@ -74,6 +74,10 @@ pub struct K6Options {
     /// config. Previously unmodelled, so it was silently dropped.
     #[serde(alias = "insecureSkipTLSVerify")]
     pub insecure_skip_tls_verify: Option<bool>,
+    // TR-201: catch unrecognized options — ~20 k6 root options are currently
+    // silently dropped. This field collects them so we can warn per-key.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_json::Value>,
 }
 
 /// k6 `options.dns` — DNS cache TTL, address selection and family policy.
@@ -171,6 +175,13 @@ impl K6Options {
     /// Named scenarios take precedence over the top-level executor, matching
     /// k6 semantics. Returns `None` when nothing usable is declared.
     pub fn to_declared(&self) -> Option<DriverDeclaredOptions> {
+        // TR-201: warn on every unrecognized option — ~20 k6 root options
+        // were silently dropped before this.
+        if !self.unknown.is_empty() {
+            for key in self.unknown.keys() {
+                tracing::warn!("k6 option '{}' is not recognized by tropel — ignored", key);
+            }
+        }
         let thresholds = self.convert_thresholds();
 
         if let Some(scenarios) = &self.scenarios {


### PR DESCRIPTION
## What
Add `#[serde(flatten)] unknown` field to `K6Options` to catch ~20 k6 root options that were previously silently dropped (minIterationDuration, userAgent, batch, tags, throw, setupTimeout/teardownTimeout, etc). Each unrecognized key now emits a `tracing::warn` at parse time.

## Task
TR-201 — the cheapest item in the parity document. ~20 options accepted and silently ignored.

## Acceptance
- [x] Unknown k6 root options collected via `#[serde(flatten)]`
- [x] Each unknown key emits a warning at parse time
- [x] No false positives for recognized options
- [x] Deliberate divergence documented: k6 itself silently discards misspelled keys; warning is better

## Tests
- All 156 k6 input lib tests pass

## Twin check
- Scenario config already has `deny_unknown_fields` (line 66)
- This extends the same principle to the k6 root options

## Evidence
READ: verified at `2099cbe`

## Risk
Very low — adds a warning for previously ignored options. No behavior change.