### PR TITLE
fix(auth): SigV4 canonical URI normalizes 3+ consecutive slashes [TR-135][TR-603]

### DIFF
--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -513,7 +513,12 @@ fn sigv4_canonical_uri(path: &str, service: &str) -> String {
     // test suite expects //prod/users → /prod/users. Without this, the
     // classic base-URL-ends-in-/ join produces a double-slash that fails
     // signature verification with a 403.
-    let normalized = path.replace("//", "/");
+    // TR-603: single replace("//","/") only handles pairs; use a loop
+    // for runs of 3+ consecutive slashes.
+    let mut normalized = path.to_string();
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
     let encoded: Vec<String> = normalized.split('/').map(enc).collect();
     encoded.join("/")
 }
@@ -1566,6 +1571,9 @@ mod tests {
         // Backlog line 240: consecutive slashes are normalized for non-S3
         // services (AWS test suite expects //prod/users → /prod/users).
         assert_eq!(sigv4_canonical_uri("/a//b/", "execute-api"), "/a/b/");
+        // TR-603: 3+ consecutive slashes must also be normalized.
+        assert_eq!(sigv4_canonical_uri("/a///b/", "execute-api"), "/a/b/");
+        assert_eq!(sigv4_canonical_uri("/a////b/", "execute-api"), "/a/b/");
     }
 
     #[test]


### PR DESCRIPTION
## What
Fix SigV4 canonical URI normalization for 3+ consecutive slashes. The old `path.replace('//', '/')` was a single pass, so runs of 3+ slashes were not fully normalized. A real 403 on `//prod/users` (the classic base-URL-ends-in-`/` join).

## Task
TR-135 / TR-603 — sweep lying comments and fix the SigV4 slash normalization.

## Acceptance
- [x] `sigv4_canonical_uri` normalizes all consecutive slashes (not just pairs)
- [x] Tests for 2, 3, and 4 consecutive slashes
- [x] All 52 auth tests pass

## Tests
- Added tests for `/a///b/` → `/a/b/` and `/a////b/` → `/a/b/`
- Existing test for `/a//b/` → `/a/b/` still passes

## Twin check
- S3 family paths are excluded (correct behavior)
- No other canonical URI call sites

## Evidence
READ: verified at `2099cbe`

## Risk
Very low — adds a while loop to handle edge case. No behavior change for normal paths.