### PR TITLE
fix(report): stdout PASS/FAIL verdict includes checks_failed [TR-105]

### DIFF
--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -288,11 +288,13 @@ impl StdoutReporter {
 
         // ── Status footer: green PASS / red FAIL ──
         // ANSI colors only when stdout is a TTY so piped output stays clean.
-        // FAIL is driven by THRESHOLDS ONLY — matching k6 semantics and the
-        // CLI exit code (cli.rs returns Err on threshold failure, not on
-        // ordinary request failures like a single 404 in thousands).
+        // TR-105: FAIL is driven by thresholds AND checks — matching the
+        // CLI exit code (cli.rs returns Err on threshold failure or
+        // script_failures). A run with failed checks but no threshold
+        // must not print PASS while exiting non-zero.
         let thresholds_failed = threshold_results.iter().any(|t| !t.passed);
-        let (status, color) = if thresholds_failed {
+        let checks_failed = result.checks_failed > 0;
+        let (status, color) = if thresholds_failed || checks_failed {
             ("✗ FAIL — one or more thresholds crossed", "\x1b[31m") // red
         } else {
             ("✓ PASS — test completed successfully", "\x1b[32m") // green
@@ -469,6 +471,13 @@ mod tests {
         assert!(out.contains("── Thresholds ──"), "{out}");
         assert!(out.contains("✗"), "failed threshold mark");
         assert!(out.contains("FAIL"), "{out}");
+
+        // TR-105: checks_failed must also show FAIL.
+        let mut checks_fail = result_with();
+        checks_fail.checks_failed = 1;
+        checks_fail.checks_total = 5;
+        let out = StdoutReporter.render(&checks_fail);
+        assert!(out.contains("FAIL"), "checks failure must show FAIL: {out}");
     }
 
     #[test]


### PR DESCRIPTION
## What
Fix the stdout PASS/FAIL verdict to include `checks_failed`. The verdict was based on thresholds only, but the CLI exit code also considers `script_failures`. A run with failed checks but no threshold failures would print PASS while exiting non-zero.

## Task
TR-105 — stdout prints "✓ PASS" on runs that exit 1.

## Acceptance
- [x] Verdict includes `checks_failed > 0` in the FAIL decision
- [x] Test added for checks_failed → FAIL
- [x] All report tests pass
- [x] Snapshot test passes

## Tests
- Added `render_thresholds_pass_fail_and_status_footer` test case for checks_failed

## Twin check
- cli.rs exit code logic — now consistent with stdout verdict
- summary.rs — JSON summary already includes checksFailed

## Evidence
READ: verified at `2099cbe`

## Risk
Very low — adds one field to the verdict decision. No behavior change for runs without check failures.