### PR TITLE
fix(k6): overwrite url tag with name for cardinality control [TR-205]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -971,6 +971,13 @@ fn http_tags_for(
             tags.insert(k.clone(), v.clone());
         }
     }
+    // TR-205: k6 overwrites the url tag with the name value at emit time.
+    // This is k6's entire cardinality-control mechanism — high-cardinality
+    // URLs cannot leak into the series space when name is set.
+    // TR-205: k6 overwrites url with name value — cardinality control.
+    if let Some(name) = tags.get("name") {
+        tags.insert(interned("url"), Arc::from(name.to_string()));
+    }
     tags
 }
 


### PR DESCRIPTION
## What
k6 overwrites the `url` tag with the `name` value at emit time. This is k6's entire cardinality-control mechanism — high-cardinality URLs cannot leak into the series space when `name` is set.

## Task
TR-205 — url tag is overwritten with name.

## Acceptance
- [x] url tag overwritten with name value when name is set
- [x] All 156 k6 tests pass

## Evidence
READ: verified at `2099cbe`