### PR TITLE
fix(cryptojs): MD5/SHA1 with config returns hash not HMAC [P1-line-154]

### DIFF
--- a/js/cryptojs-shim/cryptojs.js
+++ b/js/cryptojs-shim/cryptojs.js
@@ -430,7 +430,18 @@ var CryptoJS = CryptoJS || {};
     }
 
     // ── Exposed Hash Functions ──
+    // P1 line 154: MD5/SHA1 with a config object (e.g. {outputLength:128})
+    // must NOT be treated as an HMAC key. Real CryptoJS accepts
+    // MD5('abc', {outputLength:128}) and ignores the config for MD5/SHA1
+    // (only SHA256/SHA512 respect outputLength). Without this guard,
+    // MD5('abc', {outputLength:128}) calls hmac-md5(key='','abc') =
+    // dd2701993d29fdd0b032c233cec63403 instead of the correct
+    // 900150983cd24fb0d6963f7d28e17f72.
     CryptoJS.MD5 = function (message, key) {
+        if (key && typeof key === 'object' && !key.words) {
+            var hasher = createHasher('MD5');
+            return hasher.finalize(message);
+        }
         var hasher = createHasher('MD5');
         var result = hasher.finalize(message);
         if (key) {
@@ -440,6 +451,10 @@ var CryptoJS = CryptoJS || {};
     };
 
     CryptoJS.SHA1 = function (message, key) {
+        if (key && typeof key === 'object' && !key.words) {
+            var hasher = createHasher('SHA1');
+            return hasher.finalize(message);
+        }
         var hasher = createHasher('SHA1');
         var result = hasher.finalize(message);
         if (key) {


### PR DESCRIPTION
MD5('abc', {outputLength:128}) treated the config object as an HMAC key.

Added the same config-object guard that SHA256 already had: if the 2nd arg is a plain object (no .words property), treat it as a config and just hash normally.

Closes TROPEL_MASTER_TODO.md line 154