### PR TITLE
fix(auth): OAuth2 client_secret no longer dropped [P1-line-149]

### DIFF
--- a/crates/tropel-auth/src/oauth.rs
+++ b/crates/tropel-auth/src/oauth.rs
@@ -444,7 +444,21 @@ pub fn build_token_request(params: &TokenRequestParams) -> Result<TokenRequest> 
             form.push(("client_id".into(), params.client_id.clone()));
             form.push(("client_secret".into(), secret.to_string()));
         }
-        _ => {
+        (Some(secret), ClientAuthMethod::Basic) => {
+            // P1 line 149: when client_id is empty but client_secret is
+            // provided, still include the secret. The old code silently
+            // dropped it, causing 401 invalid_client with no diagnostic.
+            form.push(("client_id".into(), params.client_id.clone()));
+            basic_auth_header = Some(basic(&params.client_id, secret));
+        }
+        (Some(secret), _) => {
+            // Unknown auth method with a secret — include in body as fallback.
+            if !params.client_id.is_empty() {
+                form.push(("client_id".into(), params.client_id.clone()));
+            }
+            form.push(("client_secret".into(), secret.to_string()));
+        }
+        (None, _) => {
             if !params.client_id.is_empty() {
                 form.push(("client_id".into(), params.client_id.clone()));
             }


### PR DESCRIPTION
With default Basic auth and empty client_id, the secret was silently dropped, causing 401 with no diagnostic.

Added explicit match arms for (secret, Basic) and (secret, unknown) so the secret is always included.

Closes TROPEL_MASTER_TODO.md line 149