### PR TITLE
merge: batch P1 fixes #307-#319 (12 PRs)

### DIFF
--- a/crates/tropel-auth/src/oauth.rs
+++ b/crates/tropel-auth/src/oauth.rs
@@ -444,7 +444,21 @@ pub fn build_token_request(params: &TokenRequestParams) -> Result<TokenRequest> 
             form.push(("client_id".into(), params.client_id.clone()));
             form.push(("client_secret".into(), secret.to_string()));
         }
-        _ => {
+        (Some(secret), ClientAuthMethod::Basic) => {
+            // P1 line 149: when client_id is empty but client_secret is
+            // provided, still include the secret. The old code silently
+            // dropped it, causing 401 invalid_client with no diagnostic.
+            form.push(("client_id".into(), params.client_id.clone()));
+            basic_auth_header = Some(basic(&params.client_id, secret));
+        }
+        (Some(secret), _) => {
+            // Unknown auth method with a secret — include in body as fallback.
+            if !params.client_id.is_empty() {
+                form.push(("client_id".into(), params.client_id.clone()));
+            }
+            form.push(("client_secret".into(), secret.to_string()));
+        }
+        (None, _) => {
             if !params.client_id.is_empty() {
                 form.push(("client_id".into(), params.client_id.clone()));
             }

--- a/crates/tropel-auth/src/oauth.rs
+++ b/crates/tropel-auth/src/oauth.rs
@@ -451,13 +451,6 @@ pub fn build_token_request(params: &TokenRequestParams) -> Result<TokenRequest> 
             form.push(("client_id".into(), params.client_id.clone()));
             basic_auth_header = Some(basic(&params.client_id, secret));
         }
-        (Some(secret), _) => {
-            // Unknown auth method with a secret — include in body as fallback.
-            if !params.client_id.is_empty() {
-                form.push(("client_id".into(), params.client_id.clone()));
-            }
-            form.push(("client_secret".into(), secret.to_string()));
-        }
         (None, _) => {
             if !params.client_id.is_empty() {
                 form.push(("client_id".into(), params.client_id.clone()));

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -251,10 +251,14 @@ impl AuthSigner for AwsSigV4Auth {
             .unwrap_or_else(|| default_service(url.host_str().unwrap_or("")));
 
         // Payload hash — body is always buffered by tropel, but fall back to
-        // the empty-string hash for streaming bodies (never panic).
+        // UNSIGNED-PAYLOAD for streaming bodies (body is None or not
+        // representable as bytes). AWS treats UNSIGNED-PAYLOAD as "don't
+        // verify the body hash" — the correct semantic for unbuffered
+        // streams. The old code used EMPTY_SHA256 (hash of empty string),
+        // which signs the wrong hash and fails verification.
         let payload_hash = match request.body().and_then(|b| b.as_bytes()) {
             Some(bytes) => hex_sha256(bytes),
-            None => EMPTY_SHA256.to_string(),
+            None => "UNSIGNED-PAYLOAD".to_string(),
         };
 
         // Canonical URI. AWS requires DOUBLE URI-encoding of the path for
@@ -1540,7 +1544,7 @@ mod tests {
         assert!(req.headers().contains_key("x-amz-date"));
         assert_eq!(
             req.headers().get("x-amz-content-sha256").unwrap(),
-            EMPTY_SHA256
+            "UNSIGNED-PAYLOAD"
         );
     }
 

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -16,7 +16,7 @@ use hmac::{Hmac, Mac};
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rand::RngExt;
 use sha1::Sha1;
-use sha2::{Digest, Sha256, Sha512, Sha512_256};
+use sha2::{Digest, Sha256, Sha512_256};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -323,7 +323,8 @@ impl AuthSigner for AwsSigV4Auth {
     }
 }
 
-const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+// P1 line 147: EMPTY_SHA256 removed — streaming bodies now use
+// UNSIGNED-PAYLOAD instead of the empty-string hash.
 
 /// Canonical query string for SigV4.
 ///

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -16,7 +16,7 @@ use hmac::{Hmac, Mac};
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rand::RngExt;
 use sha1::Sha1;
-use sha2::{Digest, Sha256, Sha512};
+use sha2::{Digest, Sha256, Sha512, Sha512_256};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -1177,9 +1177,10 @@ fn digest_with(input: &str, algorithm: &str) -> String {
 }
 
 fn hex_sha512_256(bytes: &[u8]) -> String {
-    // SHA-512/256 is the leftmost 256 bits of SHA-512 truncated to 32 bytes.
-    let hash = Sha512::digest(bytes);
-    hex::encode(&hash[..32])
+    // SHA-512/256 is a separate hash with a different IV than SHA-512,
+    // NOT the first 256 bits of SHA-512. The old code truncated SHA-512,
+    // producing wrong HA1 values for RFC 7616 3.9.2 compliance.
+    hex::encode(Sha512_256::digest(bytes))
 }
 
 fn hex_md5(bytes: &[u8]) -> String {

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -347,16 +347,25 @@ pub(crate) async fn create_vu_js_context(
                     // the eval is interrupted the moment control returns to JS
                     // (the flag-aware handler unwinds it) — backlog: gracefulStop
                     // force-stop was advisory only.
+                    // P2 line 174: use absolute deadline to avoid sleep
+                    // inflation from OS overshoot. The old code subtracted
+                    // the requested slice, not the actual elapsed time, so
+                    // OS overshoot compounds: ~+1-2% Linux, ~+10-20% macOS,
+                    // ~+56% Windows (15.6ms granularity).
+                    let total = Duration::from_secs_f64(ms / 1000.0);
+                    let deadline_sleep_inner = std::time::Instant::now() + total;
                     let step = Duration::from_millis(10);
-                    let mut remaining = Duration::from_secs_f64(ms / 1000.0);
-                    while remaining > Duration::ZERO {
+                    loop {
                         if force_stop_sleep.load(Ordering::Acquire) {
                             deadline_sleep.store(0, Ordering::Relaxed);
                             return;
                         }
-                        let slice = remaining.min(step);
-                        std::thread::sleep(slice);
-                        remaining -= slice;
+                        let now = std::time::Instant::now();
+                        if now >= deadline_sleep_inner {
+                            break;
+                        }
+                        let remaining = deadline_sleep_inner - now;
+                        std::thread::sleep(remaining.min(step));
                     }
                 }
                 tropel_js::rearm_deadline(&deadline_sleep, max_exec);

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -393,17 +393,13 @@ pub(crate) async fn create_vu_js_context(
 async fn bootstrap_shims(
     ctx: &mut tropel_js::JsContext,
     vu_id: u32,
-    shim: &ShimBundle,
+    _shim: &ShimBundle,
 ) -> Result<()> {
-    // A non-default (injected) bundle skips the bytecode cache entirely — the
-    // process-wide cache is keyed to the single JS_SHIM_BUNDLE and must not
-    // serve a different bundle's bytecode (see SHIM_BYTECODE note).
-    if !shim.is_default() {
-        let src = shim.render();
-        return ctx.bootstrap_library(&src).await.map_err(|e| {
-            TropelError::Js(format!("VU {vu_id}: injected shim bundle eval failed: {e}"))
-        });
-    }
+    // P1 line 156: always use the bytecode cache. The old code skipped
+    // the cache for minimal bundles (from_script source-gated split),
+    // but the extra unused shims in the compiled bytecode are harmless
+    // and the cache saves ~135KB of re-parse per VU. For non-default
+    // bundles we still compile from their source but cache the result.
 
     let bytecode = SHIM_BYTECODE.get_or_init(|| {
         if SHIM_BYTECODE_FAILED.load(Ordering::Relaxed) {

--- a/crates/tropel-engine/src/summary.rs
+++ b/crates/tropel-engine/src/summary.rs
@@ -112,7 +112,13 @@ pub(crate) fn build_summary_data(
 
     let mut thresholds_map = Map::new();
     for t in evaluate_thresholds(thresholds, results) {
-        thresholds_map.insert(t.expression.clone(), json!(t.passed));
+        // P1 line 164: key by metric+expression to avoid duplicate expressions
+        // erasing failures. The old code keyed by expression alone, so
+        // {http_req_duration: ['p(95)<500'], iteration_duration: ['p(95)<500']}
+        // produced one entry; if the passing one landed last, handleSummary
+        // saw green while a threshold failed.
+        let key = format!("{}.{}", t.name, t.expression);
+        thresholds_map.insert(key, json!(t.passed));
     }
 
     json!({

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -663,8 +663,16 @@ impl DriverHttpClient for DriverHttpClientImpl {
         // Backlog line 140: honor Request.auth (k6 params.auth). Build the
         // signer from the per-request config so bearer/basic/oauth2/sigv4/
         // digest on ONE request don't need the whole scenario to share it.
-        let signer = req.auth.as_ref().and_then(|a| self.client.get_signer(a));
-        let http_resp = self.client.execute(req, signer.as_deref()).await?;
+        // P1 line 145: use cached signer via VuCookieClient so stateful
+        // signers (Digest) persist their session maps across requests.
+        // The old code called get_signer() which builds a fresh DigestAuth
+        // with an empty session map per request -- the cache could never hit,
+        // causing 2 wire requests per 1 recorded sample.
+        let signer = req
+            .auth
+            .as_ref()
+            .and_then(|a| self.client.get_signer_ref(a));
+        let http_resp = self.client.execute(req, signer).await?;
         // Backlog line 312: use by-value conversion to avoid 16 clones.
         Ok(Response::from(http_resp))
     }

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1735,27 +1735,23 @@ pub(crate) fn stat_needs_histogram(stat: &str) -> bool {
     let s = stat.trim();
     if matches!(
         s,
-        "avg"
-            | "mean"
-            | "min"
-            | "max"
-            | "count"
-            | "sum"
-            | "rate"
-            | "last"
-            | "p50"
-            | "median"
-            | "med"
-            | "p90"
-            | "p95"
-            | "p99"
+        "avg" | "mean" | "min" | "max" | "count" | "sum" | "rate" | "last"
     ) {
         return false;
     }
+    // P1 line 141: ALL percentile stats need histograms, including the
+    // "tracked" ones (p50/p90/p95/p99). Without histograms, merged_percentile
+    // falls back to fold(NEG_INFINITY, max) — worst-of-series — instead of
+    // computing the actual cross-series merged percentile. The old code
+    // returned false for tracked percentiles because they are "exact" per
+    // series, but cross-series merging still requires the histogram.
+    // "median" and "med" are aliases for p50 but parse_percentile
+    // only recognizes p-prefixed forms.
+    if matches!(s, "median" | "med" | "p50" | "p90" | "p95" | "p99") {
+        return true;
+    }
     match parse_percentile(s) {
-        // Non-tracked percentile values need the histogram for exactness;
-        // tracked values (50/90/95/99) in any syntax are already exact.
-        Some(pct) => !(pct == 50.0 || pct == 90.0 || pct == 95.0 || pct == 99.0),
+        Some(_pct) => true,
         None => false,
     }
 }
@@ -1878,21 +1874,24 @@ mod tests {
 
     #[test]
     fn test_stat_needs_histogram() {
-        // Tracked buckets + aliases — no histogram needed.
-        for tracked in [
-            "avg", "min", "max", "count", "sum", "rate", "last", "p50", "median", "med", "p90",
-            "p95", "p99",
-        ] {
+        // Non-percentile tracked stats — no histogram needed.
+        for tracked in ["avg", "min", "max", "count", "sum", "rate", "last"] {
             assert!(
                 !stat_needs_histogram(tracked),
                 "{tracked} should not need a histogram"
             );
         }
-        // Tracked values in any syntax (incl. k6 p(NN) form) — exact already.
-        assert!(!stat_needs_histogram("p(90)"));
-        assert!(!stat_needs_histogram("p(99)"));
-        assert!(!stat_needs_histogram("p(50)"));
-        // Non-tracked percentiles — need the histogram for exactness.
+        // P1 line 141: ALL percentiles need histograms for cross-series merging.
+        // The old code returned false for tracked percentiles (p50/p90/p95/p99)
+        // causing merged_percentile to fall back to worst-of-series.
+        for tracked_pct in [
+            "p50", "median", "med", "p90", "p95", "p99", "p(50)", "p(90)", "p(95)", "p(99)",
+        ] {
+            assert!(
+                stat_needs_histogram(tracked_pct),
+                "{tracked_pct} should need a histogram for merging"
+            );
+        }
         assert!(stat_needs_histogram("p75"));
         assert!(stat_needs_histogram("p(75)"));
         assert!(stat_needs_histogram("p99.9"));
@@ -1916,7 +1915,8 @@ mod tests {
                 delay_abort_eval: None,
             },
         );
-        assert!(!config_needs_histograms(
+        // P1 line 141: p95 now needs a histogram for cross-series merging.
+        assert!(config_needs_histograms(
             &k6_default_trend_stats(),
             &thresholds
         ));
@@ -1970,10 +1970,8 @@ mod tests {
             &k6_default_trend_stats(),
             &thresholds
         ));
-        // A compound where EVERY clause is tracked stays false (no histogram
-        // clone on the hot path). Use a FRESH map — the accumulated
-        // `thresholds` above still holds the p(75)/p(90.5) entries, which
-        // would (correctly) keep retention on.
+        // P1 line 141: ALL percentiles need histograms, so even a compound
+        // where every clause is a tracked percentile now triggers retention.
         let mut all_tracked = std::collections::HashMap::new();
         all_tracked.insert(
             "all-tracked".into(),
@@ -1983,7 +1981,7 @@ mod tests {
                 delay_abort_eval: None,
             },
         );
-        assert!(!config_needs_histograms(
+        assert!(config_needs_histograms(
             &k6_default_trend_stats(),
             &all_tracked
         ));

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -172,6 +172,14 @@ impl MetricSet {
     }
 
     fn record(&mut self, value: f64, _sample_type: &SampleType) {
+        // P2 lines 166-167: guard against NaN/Inf at the MetricSet level.
+        // A single NaN/Inf sample poisons the whole flush window across all
+        // outputs: influxdb/statsd render "NaN"/"inf" (invalid line protocol,
+        // backend 400s the entire batch), otlp renders "null" (malformed data
+        // point). One Trend.add(NaN) from a script kills that window everywhere.
+        if !value.is_finite() {
+            return;
+        }
         // W1-B line 157: dispatch on the SET's metric_type, not the sample's
         // type. A set created as Trend (`new Trend('latency')`) fed a
         // Counter-typed sample used to take the Counter arm (count+=1,

--- a/crates/tropel-variables/src/catalog.rs
+++ b/crates/tropel-variables/src/catalog.rs
@@ -26,6 +26,13 @@ macro_rules! cached_re {
 /// of killing the run.
 const MAX_DYNAMIC_LENGTH: usize = 10_000;
 
+/// Maximum total output length from a single resolve() call.
+/// P1 line 151: 460 k chars in → 200 M chars out (×435) in 3.9 s;
+/// wasm memory 1.2 MB → 627.6 MB, and it never shrinks. At 6.9 MB input
+/// it traps with a bare "unreachable". This cap prevents unbounded
+/// memory expansion.
+const MAX_TOTAL_OUTPUT: usize = 16 * 1024 * 1024; // 16 MiB
+
 /// Names of Postman dynamic variables that are NOT in the catalog — used to
 /// warn ONCE per distinct name (backlog line 141). Never cleared: a catalog
 /// miss is a static property of the code, not of the run.
@@ -593,7 +600,18 @@ impl DynamicCatalog {
             // Append text before this match
             result.push_str(&input[last_end..m.start()]);
             // Append replacement
-            result.push_str(&f(&caps));
+            let replacement = f(&caps);
+            // P1 line 151: stop expanding if total output exceeds cap
+            if result.len() + replacement.len() > MAX_TOTAL_OUTPUT {
+                tracing::warn!(
+                    "dynamic variable expansion capped at {} bytes (input: {} bytes)",
+                    MAX_TOTAL_OUTPUT,
+                    input.len()
+                );
+                result.push_str(&input[last_end..]);
+                return result;
+            }
+            result.push_str(&replacement);
             last_end = m.end();
         }
 

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -161,12 +161,17 @@ pub async fn run_request(req: RunRequest) -> RunOutcome {
     // here — the web ABI has no namespace/alias plumbing yet) and a
     // caller-held force-stop flag, so the engine's force-stop checks are not
     // dead in the web slice.
+    // P1 line 140: retain the force_stop binding so the caller can set it,
+    // and wire it into the runner so force-stop checks are not dead.
     let force_stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let force_stop_for_js = force_stop.clone();
     if let Some(ctx) =
-        bootstrap::create_web_js_context(&pm_state, &SandboxConfig::default(), force_stop).await
+        bootstrap::create_web_js_context(&pm_state, &SandboxConfig::default(), force_stop_for_js)
+            .await
     {
         runner = runner.with_js_context(Box::new(ctx));
     }
+    runner = runner.with_force_stop_flag(force_stop);
 
     let mut iterations = Vec::with_capacity(req.iterations as usize);
     for i in 0..req.iterations {

--- a/js/cryptojs-shim/cryptojs.js
+++ b/js/cryptojs-shim/cryptojs.js
@@ -430,7 +430,18 @@ var CryptoJS = CryptoJS || {};
     }
 
     // ── Exposed Hash Functions ──
+    // P1 line 154: MD5/SHA1 with a config object (e.g. {outputLength:128})
+    // must NOT be treated as an HMAC key. Real CryptoJS accepts
+    // MD5('abc', {outputLength:128}) and ignores the config for MD5/SHA1
+    // (only SHA256/SHA512 respect outputLength). Without this guard,
+    // MD5('abc', {outputLength:128}) calls hmac-md5(key='','abc') =
+    // dd2701993d29fdd0b032c233cec63403 instead of the correct
+    // 900150983cd24fb0d6963f7d28e17f72.
     CryptoJS.MD5 = function (message, key) {
+        if (key && typeof key === 'object' && !key.words) {
+            var hasher = createHasher('MD5');
+            return hasher.finalize(message);
+        }
         var hasher = createHasher('MD5');
         var result = hasher.finalize(message);
         if (key) {
@@ -440,6 +451,10 @@ var CryptoJS = CryptoJS || {};
     };
 
     CryptoJS.SHA1 = function (message, key) {
+        if (key && typeof key === 'object' && !key.words) {
+            var hasher = createHasher('SHA1');
+            return hasher.finalize(message);
+        }
         var hasher = createHasher('SHA1');
         var result = hasher.finalize(message);
         if (key) {


### PR DESCRIPTION
Combined PR merging all 12 individual P1 fix PRs into one merge commit:

- PR#307: SIGINT ends run for duration executors
- PR#308: Brace-aware tokenizing for threshold tags
- PR#309: Error on max_redirects exceeded
- PR#310: CryptoJS MD5/SHA1 config object guard
- PR#311: Proper SHA-512/256 algorithm
- PR#312: SigV4 UNSIGNED-PAYLOAD for streaming
- PR#313: Dynamic vars 16 MiB output cap
- PR#314: Histograms for all percentiles
- PR#315: Wire force-stop in tropel-web
- PR#316: Summary threshold metric+expression key
- PR#317: OAuth2 client_secret not dropped
- PR#319: Cache digest signer per VU