### PR TITLE
fix(metrics,engine): NaN guard + sleep pacing fix [P2-line-166,174]

### DIFF
--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -347,16 +347,25 @@ pub(crate) async fn create_vu_js_context(
                     // the eval is interrupted the moment control returns to JS
                     // (the flag-aware handler unwinds it) — backlog: gracefulStop
                     // force-stop was advisory only.
+                    // P2 line 174: use absolute deadline to avoid sleep
+                    // inflation from OS overshoot. The old code subtracted
+                    // the requested slice, not the actual elapsed time, so
+                    // OS overshoot compounds: ~+1-2% Linux, ~+10-20% macOS,
+                    // ~+56% Windows (15.6ms granularity).
+                    let total = Duration::from_secs_f64(ms / 1000.0);
+                    let deadline_sleep_inner = std::time::Instant::now() + total;
                     let step = Duration::from_millis(10);
-                    let mut remaining = Duration::from_secs_f64(ms / 1000.0);
-                    while remaining > Duration::ZERO {
+                    loop {
                         if force_stop_sleep.load(Ordering::Acquire) {
                             deadline_sleep.store(0, Ordering::Relaxed);
                             return;
                         }
-                        let slice = remaining.min(step);
-                        std::thread::sleep(slice);
-                        remaining -= slice;
+                        let now = std::time::Instant::now();
+                        if now >= deadline_sleep_inner {
+                            break;
+                        }
+                        let remaining = deadline_sleep_inner - now;
+                        std::thread::sleep(remaining.min(step));
                     }
                 }
                 tropel_js::rearm_deadline(&deadline_sleep, max_exec);

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -172,6 +172,14 @@ impl MetricSet {
     }
 
     fn record(&mut self, value: f64, _sample_type: &SampleType) {
+        // P2 lines 166-167: guard against NaN/Inf at the MetricSet level.
+        // A single NaN/Inf sample poisons the whole flush window across all
+        // outputs: influxdb/statsd render "NaN"/"inf" (invalid line protocol,
+        // backend 400s the entire batch), otlp renders "null" (malformed data
+        // point). One Trend.add(NaN) from a script kills that window everywhere.
+        if !value.is_finite() {
+            return;
+        }
         // W1-B line 157: dispatch on the SET's metric_type, not the sample's
         // type. A set created as Trend (`new Trend('latency')`) fed a
         // Counter-typed sample used to take the Counter arm (count+=1,


### PR DESCRIPTION
- NaN/Inf guard at MetricSet::record prevents poising flush windows
- Sleep() uses absolute deadline to avoid OS overshoot compounding (+56% on Windows)