### PR TITLE
merge: batch P1/P2 fixes #324-#330 + #340 (7 PRs)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1983,6 +1983,14 @@ fn register_http_bridges<'js>(
                             Some(&extra_tags),
                             group.as_deref(),
                         );
+                        // W2 parity: k6 sets error_code = 1000 + status for HTTP >= 400,
+                        // while keeping error empty. Only transport errors populate the
+                        // error tag.
+                        let http_error_code = if resp.status_code >= 400 {
+                            1000 + resp.status_code as i32
+                        } else {
+                            0
+                        };
                         build_k6_response_object(
                             &ctx,
                             resp.status_code,
@@ -1992,7 +2000,7 @@ fn register_http_bridges<'js>(
                             resp.response_time.as_secs_f64() * 1000.0,
                             resp.timings.as_ref(),
                             "",
-                            0,
+                            http_error_code,
                             &response_type,
                             &resp.cookies,
                             &resp.protocol,
@@ -2183,6 +2191,11 @@ fn register_http_bridges<'js>(
                                 // ArrayBuffers (no base64/body_b64 detour) and
                                 // timings/cookies/error_code serialize
                                 // identically.
+                                let batch_error_code = if resp.status_code >= 400 {
+                                    1000 + resp.status_code as i32
+                                } else {
+                                    0
+                                };
                                 build_k6_response_object(
                                     &ctx,
                                     resp.status_code,
@@ -2192,7 +2205,7 @@ fn register_http_bridges<'js>(
                                     resp.response_time.as_secs_f64() * 1000.0,
                                     resp.timings.as_ref(),
                                     "",
-                                    0,
+                                    batch_error_code,
                                     &response_type,
                                     &resp.cookies,
                                     &resp.protocol,
@@ -10343,5 +10356,27 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
                 "base64ToBytes must be k6-shim's Uint8Array variant in the production bundle order"
             );
         });
+    }
+
+    #[test]
+    fn k6_error_code_http_4xx_5xx() {
+        // W2 parity: k6 sets error_code = 1000 + status for HTTP >= 400,
+        // while keeping error empty. Only transport errors populate error.
+        // 1000 generic, 1010 non-TCP, 1020 invalid URL, 1050 timeout,
+        // 1100 DNS, 1200 TCP connect, 1300 TLS, 1600 HTTP/2.
+
+        // Transport error codes (unchanged)
+        assert_eq!(k6_error_code("dns resolution failed"), 1100);
+        assert_eq!(k6_error_code("connection timed out"), 1050);
+        assert_eq!(k6_error_code("tls handshake error"), 1300);
+        assert_eq!(k6_error_code("connect refused"), 1200);
+        assert_eq!(k6_error_code("unknown error"), 1000);
+
+        // HTTP status codes are NOT k6_error_code's responsibility —
+        // they are computed at the call site as 1000 + status.
+        assert_eq!(1000 + 404, 1404);
+        assert_eq!(1000 + 500, 1500);
+        assert_eq!(1000 + 403, 1403);
+        assert_eq!(1000 + 503, 1503);
     }
 }

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -968,9 +968,11 @@ impl AuthSigner for DigestAuth {
             algorithm: challenge.get("algorithm").cloned(),
             opaque: challenge.get("opaque").cloned(),
         });
-        // Server rotated the nonce (or first challenge for this host) → reset
-        // the per-nonce counter; otherwise keep counting within this nonce.
-        if sess.nonce != *nonce {
+        // P2 line 180: server rotated the nonce OR changed the realm →
+        // reset session. The old code only checked nonce, so a realm
+        // change with unchanged nonce silently used the old realm's HA1,
+        // causing permanent 401.
+        if sess.nonce != *nonce || sess.realm != *realm {
             sess.nonce = nonce.clone();
             sess.nc = 0;
             sess.realm = realm.clone();
@@ -1160,7 +1162,12 @@ fn build_digest_authorization(
         .iter()
         .map(|(k, v)| match k.as_str() {
             "qop" | "nc" | "algorithm" => format!("{k}={v}"),
-            _ => format!("{k}=\"{}\"", v.replace('"', "")),
+            // P2 line 180: escape quotes with backslash instead of
+            // stripping them. Stripping produced wrong values for usernames
+            // containing quotes (ab"c → abc instead of ab\"c), and a
+            // backslash-terminated username (a\) produced a quoted-pair
+            // breakout enabling directive injection from CSV data files.
+            _ => format!("{k}=\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")),
         })
         .collect::<Vec<_>>()
         .join(", ");

--- a/crates/tropel-engine/src/control_api.rs
+++ b/crates/tropel-engine/src/control_api.rs
@@ -132,11 +132,13 @@ where
 {
     let mut reader = BufReader::new(stream);
     let mut request_line = String::new();
-    if reader.read_line(&mut request_line).await? == 0 {
+    // P2 line 173: use .take() to limit the read BEFORE read_line grows
+    // the String unbounded. The old code checked AFTER read_line, so a
+    // multi-GB line with no newline allocated all of it first.
+    let mut limited = (&mut reader).take(MAX_HEADER_LINE_LEN as u64 + 1);
+    if limited.read_line(&mut request_line).await? == 0 {
         return Ok(());
     }
-    // Backlog line 256: cap header line length to prevent memory exhaustion
-    // from a single multi-GB line (MAX_BODY_SIZE only guards the body).
     if request_line.len() > MAX_HEADER_LINE_LEN {
         return Err(TropelError::Http(format!(
             "control API: request line too long ({} > {})",
@@ -153,10 +155,11 @@ where
     let mut content_length: usize = 0;
     loop {
         let mut line = String::new();
-        if reader.read_line(&mut line).await? == 0 {
+        let mut limited = (&mut reader).take(MAX_HEADER_LINE_LEN as u64 + 1);
+        if limited.read_line(&mut line).await? == 0 {
             break;
         }
-        // Backlog line 256: cap individual header line length.
+        // P2 line 173: cap individual header line length BEFORE read.
         if line.len() > MAX_HEADER_LINE_LEN {
             return Err(TropelError::Http(format!(
                 "control API: header line too long ({} > {})",

--- a/crates/tropel-engine/src/worker.rs
+++ b/crates/tropel-engine/src/worker.rs
@@ -242,6 +242,10 @@ impl VUWorkerPool {
     /// lock is only held for the final insert.
     fn acquire_slot(&self, vu_id: u32) -> Slot {
         if let Some((idx, flag)) = self.find_idle_slot() {
+            // P2 line 170: reset growth_failed when an idle slot is found.
+            // Thread-cap exhaustion is transient (VUs exit, threads free)
+            // but the old code permanently pinned every later VU to Wrapped.
+            self.growth_failed.store(false, Ordering::Release);
             return Slot::Idle(idx, flag);
         }
         loop {

--- a/crates/tropel-http/src/blocking.rs
+++ b/crates/tropel-http/src/blocking.rs
@@ -147,9 +147,20 @@ where
     // spin — otherwise the flag would latch true forever and the "re-arm on
     // fast completion" promise in the doc comment would be unreachable.
     let park_start = Instant::now();
+    // P2 line 169: add a timeout to recv() to prevent parking a VU thread
+    // forever. If the io_rt is saturated the task is never polled, reqwest's
+    // own timeout never starts, and force_stop can't reach a thread blocked
+    // in recv(). VUWorkerPool::drop detaches it after 30s = total deadlock.
     let result = rx
-        .recv()
-        .map_err(|_| TropelError::Http(IO_TASK_DROPPED.into()))?;
+        .recv_timeout(std::time::Duration::from_secs(65))
+        .map_err(|e| match e {
+            std::sync::mpsc::RecvTimeoutError::Timeout => {
+                TropelError::Http("blocking request timed out (65s)".into())
+            }
+            std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                TropelError::Http(IO_TASK_DROPPED.into())
+            }
+        })?;
     if park_start.elapsed() < SPIN_WINDOW {
         SKIP_SPIN.with(|s| s.set(false));
     }

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -920,9 +920,13 @@ fn get_metric_value(metrics: &MetricsResult, name: &str, stat: Option<&str>) -> 
             // `errors < N` the top-level counter IS the merged total, while
             // the helper's default arm would return the worst per-series
             // mean (1.0 for value-1 Counter samples) and pass spuriously.
-            if let Some(v) = stat.and_then(|_| aggregate_series(metrics, "errors", stat)) {
+            // P2 line 181: use aggregate_series for all stat forms of
+            // errors (count, rate, etc.) to keep bare `errors` and
+            // `errors.count` reading the same population.
+            if let Some(v) = aggregate_series(metrics, "errors", stat) {
                 Some(v)
             } else {
+                // Fallback: no tagged sub-series, use the headline total.
                 let secs = metrics.run_duration.as_secs_f64();
                 match stat {
                     Some("rate") | Some("avg") => Some(if secs > 0.0 {

--- a/crates/tropel-report/src/otlp.rs
+++ b/crates/tropel-report/src/otlp.rs
@@ -219,6 +219,8 @@ fn build_export_request(metrics: &HashMap<String, Vec<Sample>>) -> serde_json::V
             // Sum per (sorted tag-set). Keep the LAST timestamp seen for a
             // tag-set so the delta point carries the newest time.
             // P-D.2: Use HashMap for O(1) lookup instead of O(n²) linear scan.
+            // Track the earliest timestamp for startTimeUnixNano.
+            let mut earliest_ts: u64 = u64::MAX;
             let mut per_tags: std::collections::HashMap<Vec<(String, String)>, (f64, u64)> =
                 std::collections::HashMap::new();
             for s in samples {
@@ -233,6 +235,9 @@ fn build_export_request(metrics: &HashMap<String, Vec<Sample>>) -> serde_json::V
                     .duration_since(UNIX_EPOCH)
                     .map(|d| d.as_nanos() as u64)
                     .unwrap_or(0);
+                if ts_nanos < earliest_ts {
+                    earliest_ts = ts_nanos;
+                }
                 match per_tags.get_mut(&tags) {
                     Some((sum, ts)) => {
                         *sum += s.value;
@@ -250,7 +255,11 @@ fn build_export_request(metrics: &HashMap<String, Vec<Sample>>) -> serde_json::V
                         .iter()
                         .map(|(k, v)| json!({ "key": k, "value": { "stringValue": v } }))
                         .collect();
+                    // P2 line 175: include startTimeUnixNano for DELTA
+                    // Sums. Without it, the Collector's deltatocumulative/
+                    // Prometheus exporters drop the point silently.
                     json!({
+                        "startTimeUnixNano": if earliest_ts != u64::MAX { earliest_ts.to_string() } else { ts.to_string() },
                         "timeUnixNano": ts.to_string(),
                         "asDouble": sum,
                         "attributes": attrs,


### PR DESCRIPTION
Merge PR combining 7 individual fix PRs:

- #324: OTLP startTimeUnixNano for delta Sums
- #325: Bound control API header reads
- #326: Reset growth_failed on idle slot
- #327: Add timeout to blocking recv
- #328: Digest correctness bugs (realm + quotes)
- #329: errors/count same population
- #340: error_code = 1000 + status for HTTP >= 400