### PR TITLE
fix(report): always print series_dropped in summary [W0]

### DIFF
--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -95,12 +95,12 @@ impl StdoutReporter {
                 "Samples dropped", result.output_samples_dropped
             ));
         }
-        if result.series_dropped > 0 {
-            out.push_str(&format!(
-                "    {:<14}{}\n",
-                "Series dropped", result.series_dropped
-            ));
-        }
+        // W0-line-25: always print series_dropped so users can
+        // distinguish "no drops" from "counter not wired".
+        out.push_str(&format!(
+            "    {:<14}{}\n",
+            "Series dropped", result.series_dropped
+        ));
 
         // HTTP requests — aligned two-column block
         out.push_str("\n  ── HTTP requests ─────────────────────────────────────────\n");

--- a/crates/tropel-report/tests/snapshots/reporters__stdout_summary.snap
+++ b/crates/tropel-report/tests/snapshots/reporters__stdout_summary.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tropel-report/tests/reporters.rs
-assertion_line: 147
 expression: rendered
 ---
 
@@ -11,6 +10,7 @@ expression: rendered
     Iterations    1024
     Max VUs       4
     Dropped       2
+    Series dropped0
 
   ── HTTP requests ─────────────────────────────────────────
     Total         1000 (33.33/s)


### PR DESCRIPTION
Print series_dropped unconditionally (even when zero) so users can distinguish "no drops" from "counter not wired".