### PR TITLE
fix(http): close timing and HTTP2 correctness gaps [TR-012] [TR-014]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
 name = "tropel-http"
 version = "0.1.0"
 dependencies = [
+ "h2",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ rquickjs = { version = "0.12.2", features = ["full-async"] }
 
 # HTTP client
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "cookies", "gzip", "brotli", "http2", "json", "stream", "query", "form"] }
+h2 = "0.4.16"
 tower = { version = "0.5.3", default-features = false }
 
 # Serialization

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1010,7 +1010,7 @@ fn k6_error_envelope<'js>(
     // contract — error_code mapped via k6_error_code (was hardcoded 1000),
     // and a binary response keeps an empty ArrayBuffer body so
     // res.body.byteLength doesn't see a type change (was String "").
-    let _ = e.set("error_code", k6_error_code(msg));
+    let _ = e.set("error_code", k6_error_code_message(msg));
     let _ = e.set("headers", rquickjs::Object::new(ctx.clone()).ok()?);
     if binary {
         match rquickjs::ArrayBuffer::new(ctx.clone(), Vec::<u8>::new()) {
@@ -1260,10 +1260,16 @@ fn compress_k6_body(kind: &str, data: &[u8]) -> Option<Vec<u8>> {
 /// k6-style error codes for `res.error_code`. k6 defines a 1xxx series:
 /// 1000 generic, 1010 non-TCP network error, 1020 malformed HTTP, 1050
 /// timeout, 1100 DNS, 1200 TCP connect, 1300 TLS, 1600 HTTP/2, 1990
-/// unknown. reqwest surfaces most failures as strings, so we map by
-/// substring (best-effort, k6 parity for the common `if (res.error)` idiom
-/// plus `res.error_code` for programmatic branching).
-fn k6_error_code(msg: &str) -> i32 {
+/// unknown. Typed HTTP/2 failures are classified directly; other errors use
+/// the existing message-based mapping for common transport categories.
+fn k6_error_code(error: &tropel_sdk::TropelError) -> i32 {
+    if matches!(error, tropel_sdk::TropelError::Http2(_)) {
+        return 1600;
+    }
+    k6_error_code_message(&error.to_string())
+}
+
+fn k6_error_code_message(msg: &str) -> i32 {
     let m = msg.to_ascii_lowercase();
     if m.contains("dns") || m.contains("nodename") || m.contains("resolve") {
         1100
@@ -1323,9 +1329,10 @@ fn push_http_failure(
     elapsed: Duration,
     sent: usize,
     error_msg: &str,
+    protocol: &str,
 ) {
     let now = tropel_js::clock::monotonic_wall_now();
-    let mut tags = http_tags(req, "0", scenario, extra_tags, group, "");
+    let mut tags = http_tags(req, "0", scenario, extra_tags, group, protocol);
     // TR-204: error tag is populated on transport failures (k6 semantics).
     // The error tag is empty on success; error_code is 0 on success.
     if !error_msg.is_empty() {
@@ -1643,12 +1650,16 @@ fn build_k6_response_object<'js>(
         let timings_obj = rquickjs::Object::new(ctx.clone())?;
         let _ = timings_obj.set("blocked", t.blocked.as_secs_f64() * 1000.0);
         let _ = timings_obj.set("dns", t.dns.as_secs_f64() * 1000.0);
+        // k6 declares looking_up but never assigns it; retain the key for
+        // byte-compatible response objects and keep it aligned with metrics.
+        let _ = timings_obj.set("looking_up", 0.0);
         let _ = timings_obj.set("connecting", t.connecting.as_secs_f64() * 1000.0);
         let _ = timings_obj.set("tls_handshaking", t.tls_handshaking.as_secs_f64() * 1000.0);
         let _ = timings_obj.set("sending", t.sending.as_secs_f64() * 1000.0);
         let _ = timings_obj.set("waiting", t.waiting.as_secs_f64() * 1000.0);
         let _ = timings_obj.set("receiving", t.receiving.as_secs_f64() * 1000.0);
-        let _ = timings_obj.set("duration", response_time_ms);
+        let duration_ms = (t.sending + t.waiting + t.receiving).as_secs_f64() * 1000.0;
+        let _ = timings_obj.set("duration", duration_ms);
         let _ = obj.set("timings", timings_obj);
     }
     // `responseType: "binary"` → native ArrayBuffer body (raw bytes survive);
@@ -1946,7 +1957,7 @@ fn register_http_bridges<'js>(
                         1000,
                         &response_type,
                         &[],
-                        "HTTP/1.1",
+                        "",
                     );
                 }
                 let extra_tags = params.tags;
@@ -2044,6 +2055,11 @@ fn register_http_bridges<'js>(
                             start.elapsed(),
                             sent,
                             &err,
+                            if matches!(e, tropel_sdk::TropelError::Http2(_)) {
+                                "HTTP/2"
+                            } else {
+                                ""
+                            },
                         );
                         build_k6_response_object(
                             &ctx,
@@ -2054,10 +2070,14 @@ fn register_http_bridges<'js>(
                             0.0,
                             None,
                             &err,
-                            k6_error_code(&err),
+                            k6_error_code(&e),
                             &response_type,
                             &[],
-                            "HTTP/1.1",
+                            if matches!(e, tropel_sdk::TropelError::Http2(_)) {
+                                "HTTP/2"
+                            } else {
+                                ""
+                            },
                         )
                     }
                 }
@@ -2251,6 +2271,11 @@ fn register_http_bridges<'js>(
                                     start.elapsed(),
                                     sent,
                                     &err,
+                                    if matches!(e, tropel_sdk::TropelError::Http2(_)) {
+                                        "HTTP/2"
+                                    } else {
+                                        ""
+                                    },
                                 );
                                 build_k6_response_object(
                                     &ctx,
@@ -2261,10 +2286,14 @@ fn register_http_bridges<'js>(
                                     0.0,
                                     None,
                                     &err,
-                                    k6_error_code(&err),
+                                    k6_error_code(&e),
                                     &response_type,
                                     &[],
-                                    "HTTP/1.1",
+                                    if matches!(e, tropel_sdk::TropelError::Http2(_)) {
+                                        "HTTP/2"
+                                    } else {
+                                        ""
+                                    },
                                 )?
                             }
                         };
@@ -4624,7 +4653,7 @@ mod tests {
                 out,
                 concat!(
                     "[\"abc123\",true,\"GET\",\"https://example.com/\",",
-                    "\"req-7\",\"HTTP/1.1\",\"string\",\"Hello\",\"World\"]"
+                    "\"req-7\",\"\",\"string\",\"Hello\",\"World\"]"
                 ),
                 "res.cookies/request/proto/remote_ip/html() mismatch: {out}"
             );
@@ -7825,6 +7854,8 @@ mod tests {
                 globalThis.__t_waiting = res1.timings.waiting;
                 globalThis.__t_blocked = res1.timings.blocked;
                 globalThis.__t_receiving = res1.timings.receiving;
+                globalThis.__t_looking_up = res1.timings.looking_up;
+                globalThis.__t_duration = res1.timings.duration;
                 globalThis.__err = res1.error;
                 globalThis.__ecode = res1.error_code;
 
@@ -7893,6 +7924,16 @@ mod tests {
                 ctx.eval::<f64, _>("__t_receiving").unwrap(),
                 50.0,
                 "res.timings.receiving must carry the real body-receive value"
+            );
+            assert_eq!(
+                ctx.eval::<f64, _>("__t_looking_up").unwrap(),
+                0.0,
+                "res.timings.looking_up must exist as k6's declared zero field"
+            );
+            assert_eq!(
+                ctx.eval::<f64, _>("__t_duration").unwrap(),
+                150.0,
+                "res.timings.duration must agree with sending + waiting + receiving"
             );
             assert_eq!(
                 ctx.eval::<String, _>("__err").unwrap(),
@@ -7993,9 +8034,8 @@ mod tests {
             "http_req_blocked",
             "http_req_dns",
             "http_req_connecting",
-            // http_req_tls_handshaking and http_req_sending are always 0
-            // (folded into connecting/waiting by reqwest) and omitted to
-            // save 2 MetricKey builds per request (backlog line 459).
+            "http_req_tls_handshaking",
+            "http_req_sending",
             "http_req_waiting",
             "http_req_receiving",
         ] {
@@ -8013,6 +8053,42 @@ mod tests {
             .find(|s| s.metric == "http_req_blocked")
             .unwrap();
         assert_eq!(blocked.value, 0.1, "blocked must carry the pool-wait in ms");
+        let emitted_duration = samples
+            .iter()
+            .find(|s| s.metric == "http_req_duration")
+            .expect("duration sample");
+        assert_eq!(emitted_duration.value, 4.5);
+
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let response = build_k6_response_object(
+                &ctx,
+                200,
+                "OK".to_string(),
+                Vec::new(),
+                &HashMap::new(),
+                5.1,
+                Some(&timings),
+                "",
+                0,
+                "text",
+                &[],
+                "HTTP/1.1",
+            )
+            .expect("response object");
+            let response_timings: rquickjs::Object = response.get("timings").unwrap();
+            let script_duration: f64 = response_timings.get("duration").unwrap();
+            assert_eq!(
+                script_duration, emitted_duration.value,
+                "res.timings.duration and http_req_duration must use the same phase sum"
+            );
+            assert_eq!(
+                response_timings.get::<_, f64>("looking_up").unwrap(),
+                0.0,
+                "looking_up must exist as k6's declared zero field"
+            );
+        });
         // 5 base + 7 sub-timing samples (all 8 sub-timings emitted)
         assert_eq!(samples.len(), 12, "5 base + 7 sub-timing samples");
     }
@@ -8048,6 +8124,7 @@ mod tests {
             Duration::from_millis(1500),
             7,
             "connection refused",
+            "",
         );
         let samples = sink.lock().unwrap();
         let duration = samples
@@ -10302,7 +10379,7 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
             let err_code: i32 = obj.get("error_code").unwrap();
             assert_eq!(
                 err_code,
-                k6_error_code("binary response body allocation failed"),
+                k6_error_code_message("binary response body allocation failed"),
                 "error_code must mirror k6_error_code(msg), not a hardcoded 1000"
             );
             // The body stays an ArrayBuffer (empty) so scripts probing
@@ -10342,7 +10419,7 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
             let err_code: i32 = resp.get("error_code").unwrap();
             assert_eq!(
                 err_code,
-                k6_error_code("response body exceeds the per-VU JS heap cap"),
+                k6_error_code_message("response body exceeds the per-VU JS heap cap"),
                 "degraded envelope carries the mapped k6 error code"
             );
             let body: rquickjs::Value = resp.get("body").unwrap();
@@ -10394,11 +10471,15 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
         // 1100 DNS, 1200 TCP connect, 1300 TLS, 1600 HTTP/2.
 
         // Transport error codes (unchanged)
-        assert_eq!(k6_error_code("dns resolution failed"), 1100);
-        assert_eq!(k6_error_code("connection timed out"), 1050);
-        assert_eq!(k6_error_code("tls handshake error"), 1300);
-        assert_eq!(k6_error_code("connect refused"), 1200);
-        assert_eq!(k6_error_code("unknown error"), 1000);
+        assert_eq!(k6_error_code_message("dns resolution failed"), 1100);
+        assert_eq!(k6_error_code_message("connection timed out"), 1050);
+        assert_eq!(k6_error_code_message("tls handshake error"), 1300);
+        assert_eq!(k6_error_code_message("connect refused"), 1200);
+        assert_eq!(k6_error_code_message("unknown error"), 1000);
+        assert_eq!(
+            k6_error_code(&tropel_sdk::TropelError::Http2("stream reset".into())),
+            1600
+        );
 
         // HTTP status codes are NOT k6_error_code's responsibility —
         // they are computed at the call site as 1000 + status.

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -114,6 +114,9 @@ async fn run_vu_loop(
                 _ = &mut stop_ready => {
                     stop_ready.set(stop.notified());
                 }
+                // Notify is edge-triggered; re-check the level even if a
+                // control update lands before the future is registered.
+                _ = tokio::time::sleep(Duration::from_millis(100)) => {}
             }
         }
         if sched.is_stop_requested() || sched.is_force_stop_requested() {
@@ -163,6 +166,9 @@ async fn run_vu_loop(
                     _ = &mut stop_ready => {
                         stop_ready.set(stop.notified());
                     }
+                    // The token count is the source of truth. This backstop
+                    // closes the notify_waiters registration race.
+                    _ = tokio::time::sleep(Duration::from_millis(100)) => {}
                 }
             }
             if !got_token {

--- a/crates/tropel-http/Cargo.toml
+++ b/crates/tropel-http/Cargo.toml
@@ -16,6 +16,7 @@ tropel-sdk.workspace = true
 tropel-auth = { workspace = true, features = ["reqwest"] }
 serde.workspace = true
 reqwest.workspace = true
+h2.workspace = true
 tower.workspace = true
 serde_json.workspace = true
 simd-json.workspace = true

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -44,7 +44,7 @@ fn is_credential_header(key: &str) -> bool {
 /// clean 403 "target address is blocked") detect the root cause from the
 /// message string instead of every blocked target degrading to a generic
 /// "upstream request failed".
-fn http_request_error(e: &dyn std::error::Error) -> TropelError {
+fn http_request_error<E: std::error::Error + 'static>(e: &E) -> TropelError {
     let mut msg = format!("Request failed: {e}");
     let mut src = std::error::Error::source(e);
     for _ in 0..8 {
@@ -52,6 +52,13 @@ fn http_request_error(e: &dyn std::error::Error) -> TropelError {
         msg.push_str(" -> ");
         msg.push_str(&s.to_string());
         src = std::error::Error::source(s);
+    }
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = source {
+        if err.downcast_ref::<h2::Error>().is_some() {
+            return TropelError::Http2(msg);
+        }
+        source = std::error::Error::source(err);
     }
     TropelError::Http(msg)
 }
@@ -538,7 +545,9 @@ impl HttpClient {
     ///   is included here)    /// - **waiting** (TTFB): from the request being sent to response headers
     ///   received, EXCLUDING the connection phases (blocked + dns + connecting)
     ///   — subtracted from the raw elapsed so the breakdown sums to `total`,
-    ///   matching k6's `http_req_waiting` semantics.
+    ///   matching k6's `http_req_waiting` semantics. HTTP/2 stream admission
+    ///   queueing is included here because reqwest does not expose it as a
+    ///   separate phase; it is a documented transport limitation.
     /// - **receiving**: from response headers to full body bytes received
     /// - **total**: entire `execute()` duration
     ///

--- a/crates/tropel-scheduler/src/scheduler.rs
+++ b/crates/tropel-scheduler/src/scheduler.rs
@@ -2516,6 +2516,9 @@ mod tests {
                             _ = &mut stop_ready => {
                                 stop_ready.set(stop.notified());
                             }
+                            // The atomics are level-triggered; periodically
+                            // re-check them if an edge-triggered wake is lost.
+                            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
                         }
                     }
                 }
@@ -2526,6 +2529,49 @@ mod tests {
                 tokio::time::sleep(latency).await;
             }
         })
+    }
+
+    /// Regression for the arrival-token lost-wakeup window: deliver a
+    /// notify_waiters wake before making the token visible, then rely on the
+    /// level-triggered timeout recheck to release the waiter. Without the
+    /// timeout arm this task parks indefinitely because Notify stores no
+    /// permit for a notification sent before registration.
+    #[tokio::test(start_paused = true)]
+    async fn arrival_waiter_makes_progress_after_early_wakeup() {
+        let sched = Arc::new(VUScheduler::new(&ExecutionConfig::ConstantArrivalRate {
+            rate: 1.0,
+            time_unit: "1s".to_string(),
+            duration: "1s".to_string(),
+            pre_alloc_vus: 1,
+            max_vus: 1,
+            graceful_stop: None,
+            think_time: Default::default(),
+        }));
+        let handle = arrival_test_vu(sched.clone(), Duration::ZERO);
+
+        while sched.idle_vu_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        // This wake carries no token and is intentionally sent before the
+        // subsequent token update. The waiter must not depend on this edge.
+        sched.arrival_notify().notify_waiters();
+        sched.arrival_tokens.fetch_add(1, Ordering::Release);
+        tokio::time::advance(Duration::from_millis(100)).await;
+        for _ in 0..10 {
+            if sched.idle_vu_count() == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            sched.idle_vu_count(),
+            0,
+            "arrival waiter must acquire a token after an early wake"
+        );
+
+        sched.request_stop();
+        handle.await.expect("arrival test VU must stop cleanly");
     }
 
     /// W0 P0#1: a non-identity `timeUnit` must divide the rate —
@@ -2576,6 +2622,7 @@ mod tests {
                                 _ = &mut stop_ready => {
                                     stop_ready.set(stop.notified());
                                 }
+                                _ = tokio::time::sleep(Duration::from_millis(100)) => {}
                             }
                         }
                     }
@@ -2646,6 +2693,7 @@ mod tests {
                                 _ = &mut stop_ready => {
                                     stop_ready.set(stop.notified());
                                 }
+                                _ = tokio::time::sleep(Duration::from_millis(100)) => {}
                             }
                         }
                     }

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -127,6 +127,8 @@ function k6HTTPRequest(method, url, body, params) {
     // when a legacy/PM bridge returns no timings object.
     var timings = result.timings || {
         blocked: 0,
+        dns: 0,
+        looking_up: 0,
         connecting: 0,
         tls_handshaking: 0,
         sending: 0,
@@ -137,13 +139,15 @@ function k6HTTPRequest(method, url, body, params) {
     // Ensure every k6 key exists (native timings include Tropel's extra dns).
     if (typeof timings === 'object') {
         timings = {
-            blocked: timings.blocked || 0,
-            connecting: timings.connecting || 0,
-            tls_handshaking: timings.tls_handshaking || 0,
-            sending: timings.sending || 0,
-            waiting: timings.waiting || respTime,
-            receiving: timings.receiving || 0,
-            duration: timings.duration || respTime
+            blocked: timings.blocked !== undefined ? timings.blocked : 0,
+            dns: timings.dns !== undefined ? timings.dns : 0,
+            looking_up: 0,
+            connecting: timings.connecting !== undefined ? timings.connecting : 0,
+            tls_handshaking: timings.tls_handshaking !== undefined ? timings.tls_handshaking : 0,
+            sending: timings.sending !== undefined ? timings.sending : 0,
+            waiting: timings.waiting !== undefined ? timings.waiting : respTime,
+            receiving: timings.receiving !== undefined ? timings.receiving : 0,
+            duration: timings.duration !== undefined ? timings.duration : respTime
         };
     }
 
@@ -159,7 +163,7 @@ function k6HTTPRequest(method, url, body, params) {
             headers: canonical.headers,
             body: canonical.body,
             cookies: result.cookies || {}
-        }
+        }, result.proto
     );
     // Backlog line 150: k6 Response.error ("" on success) / error_code (0 on
     // success, 1xxx on transport failure) — `if (res.error)` now detects
@@ -499,20 +503,19 @@ function escapeMultipartFieldName(name) {
 // Backlog line 102: res.cookies / res.request / proto / remote_ip / html()
 // were absent — res.cookies['sid'] threw TypeError. Cookies are real data
 // from the native bridge (name -> [cookie objects], k6 shape); request is
-// the k6 Response.request {method, url, headers, body, cookies}; proto /
-// remote_ip are best-effort defaults (reqwest doesn't expose the wire
-// version or peer IP through the SDK Response), present so scripts never
-// throw on them.
-function K6Response(status, body, headers, timings, url, cookies, requestInfo) {
+// the k6 Response.request {method, url, headers, body, cookies}; proto comes
+// from the native response's negotiated wire version, while remote_ip remains
+// a best-effort default because reqwest does not expose the peer IP here.
+function K6Response(status, body, headers, timings, url, cookies, requestInfo, proto) {
     this.status = status;
     this.body = body;
     this.headers = headers || {};
-    this.timings = timings || { blocked: 0, connecting: 0, tls_handshaking: 0, sending: 0, waiting: 0, receiving: 0, duration: 0 };
+    this.timings = timings || { blocked: 0, dns: 0, looking_up: 0, connecting: 0, tls_handshaking: 0, sending: 0, waiting: 0, receiving: 0, duration: 0 };
     this.url = url || '';
     this.status_text = String(status) + ' ' + getStatusText(status);
     this.cookies = cookies || {};
     this.request = requestInfo || { method: 'GET', url: url || '', headers: this.headers, body: body, cookies: this.cookies };
-    this.proto = 'HTTP/1.1';
+    this.proto = proto || '';
     this.remote_ip = '';
 }
 
@@ -803,6 +806,8 @@ http.batch = function (requests) {
             }
             var timings = raw.timings || {
                 blocked: 0,
+                dns: 0,
+                looking_up: 0,
                 connecting: 0,
                 tls_handshaking: 0,
                 sending: 0,
@@ -812,13 +817,15 @@ http.batch = function (requests) {
             };
             if (typeof timings === 'object') {
                 timings = {
-                    blocked: timings.blocked || 0,
-                    connecting: timings.connecting || 0,
-                    tls_handshaking: timings.tls_handshaking || 0,
-                    sending: timings.sending || 0,
-                    waiting: timings.waiting || rtime,
-                    receiving: timings.receiving || 0,
-                    duration: timings.duration || rtime
+                    blocked: timings.blocked !== undefined ? timings.blocked : 0,
+                    dns: timings.dns !== undefined ? timings.dns : 0,
+                    looking_up: 0,
+                    connecting: timings.connecting !== undefined ? timings.connecting : 0,
+                    tls_handshaking: timings.tls_handshaking !== undefined ? timings.tls_handshaking : 0,
+                    sending: timings.sending !== undefined ? timings.sending : 0,
+                    waiting: timings.waiting !== undefined ? timings.waiting : rtime,
+                    receiving: timings.receiving !== undefined ? timings.receiving : 0,
+                    duration: timings.duration !== undefined ? timings.duration : rtime
                 };
             }
             var resp = new K6Response(
@@ -832,7 +839,7 @@ http.batch = function (requests) {
                     headers: normalized[ei] ? JSON.parse(normalized[ei].headers_json) : {},
                     body: entry.body !== undefined ? entry.body : '',
                     cookies: raw.cookies || {}
-                }
+                }, raw.proto
             );
             resp.error = raw.error || '';
             resp.error_code = raw.error_code || 0;


### PR DESCRIPTION
## What
Closes lost-wakeup races in pause and arrival-token waits, restores k6-compatible zero timing fields, propagates negotiated protocol data, and classifies HTTP/2 transport failures with a typed SDK error. HTTP/2 stream admission queueing is documented as part of waiting because reqwest exposes no separate phase.

## Task
TR-012 and TR-014

## Acceptance
- [x] Pause and arrival-token waits have a level-check backstop
- [x] Arrival waiter regression covers an early wakeup
- [x] tls_handshaking and sending zero samples are emitted
- [x] res.timings includes looking_up and duration agrees with emitted phase metrics
- [x] Protocol is propagated for successful and typed HTTP/2 failure responses
- [x] k6 shim no longer hardcodes HTTP/1.1
- [x] Typed HTTP/2 classification replaces the direct message check
- [x] Existing HTTP/2 keepalive interval/timeout/idle settings were checked

## Dependency
Requires transithq/tropel-sdk#16 for the additive TropelError::Http2 variant.

## Tests
- CARGO_TARGET_DIR=C:\\tropel-native-target cargo check -p tropel-engine -p tropel-runtime -p tropel-http -p tropel-input-k6 --locked: passed
- CARGO_TARGET_DIR=C:\\tropel-native-target cargo test -p tropel-input-k6 --lib --locked: 157 passed
- CARGO_TARGET_DIR=C:\\tropel-native-target cargo test -p tropel-scheduler arrival_waiter_makes_progress_after_early_wakeup --locked -- --nocapture: passed
- cargo fmt --all -- --check: passed

## Twin check
Checked pause and arrival-token sibling wait legs, single and batch k6 response construction, success and transport-failure protocol paths, and both HTTP client error classification call sites.

## Evidence
EXEC: focused Rust checks and tests on Windows using C:\\tropel-native-target.

## Risk
The SDK enum change is additive but this PR must merge after SDK#16. HTTP/2 stream queueing remains included in waiting and is explicitly documented because reqwest does not expose a separate queue timing.