### PR TITLE
fix(sandbox,wasm): extend reserved-name guard to sibling bridges [TR-102]

### DIFF
--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -1149,6 +1149,26 @@ impl TrpBridge {
             set_global!(
                 "__tropel_pm_metrics_add",
                 Func::from(move |name: String, value: f64, metric_type_str: String| {
+                    // TR-102: reserved-name guard — the sibling guard in
+                    // `__tropel_pm_custom_metric_add` below rejects builtin
+                    // names; `pm.metrics.add('checks', 1)` must be rejected
+                    // the same way, or a script forges the checks headline
+                    // through the Postman-style bridge.
+                    const RESERVED: &[&str] = &[
+                        "http_reqs", "http_req_duration", "http_req_failed",
+                        "http_req_blocked", "http_req_connecting", "http_req_tls_handshaking",
+                        "http_req_receiving", "http_req_sending", "http_req_waiting",
+                        "iterations", "iteration_duration", "dropped_iterations",
+                        "checks", "group_duration", "vus", "vus_max",
+                        "data_received", "data_sent",
+                    ];
+                    if RESERVED.iter().any(|&r| name == r) {
+                        tracing::warn!(
+                            "Custom metric '{}' clashes with built-in metric name — ignoring",
+                            name
+                        );
+                        return;
+                    }
                     let mut st = state_clone.lock().unwrap();
                     // Emit a metric sample with the appropriate type
                     let sample_type = match metric_type_str.as_str() {
@@ -1924,6 +1944,52 @@ mod tests {
                 .unwrap();
             assert!(readonly, "pm/trp must be non-writable");
         });
+    }
+
+    /// TR-102: `pm.metrics.add('checks', …)` must be dropped by the
+    /// reserved-name guard in `__tropel_pm_metrics_add` — the Postman-style
+    /// bridge is the sibling the k6 constructor guard was never mirrored to.
+    #[tokio::test]
+    async fn test_pm_metrics_add_rejects_reserved_names() {
+        use crate::state::new_pm_state;
+
+        let mut ctx = tropel_js::JsContext::new(None, None)
+            .await
+            .expect("context");
+        let state = new_pm_state();
+        TrpBridge::new(state.clone())
+            .install(&mut ctx)
+            .expect("install");
+        ctx.eval(include_str!("../../../../js/scripting-api/pm.js"))
+            .await
+            .expect("pm shim must eval");
+
+        // Reserved builtin name through pm.metrics.add — must be dropped.
+        ctx.eval(
+            "pm.metrics.add('checks', 1.0, 'rate'); pm.metrics.add('http_reqs', 1.0, 'counter');",
+        )
+        .await
+        .expect("eval must succeed");
+        {
+            let st = state.lock().unwrap();
+            assert!(
+                !st.custom_metrics.contains_key("checks"),
+                "reserved 'checks' must not be recorded as a custom metric"
+            );
+            assert!(
+                !st.custom_metrics.contains_key("http_reqs"),
+                "reserved 'http_reqs' must not be recorded as a custom metric"
+            );
+        }
+
+        // A non-reserved name still records normally.
+        ctx.eval("pm.metrics.add('my_custom', 42.0, 'gauge');")
+            .await
+            .expect("eval must succeed");
+        {
+            let st = state.lock().unwrap();
+            assert_eq!(st.custom_metrics.get("my_custom"), Some(&42.0));
+        }
     }
 
     /// P4b open item: alias configuration is part of the public API.

--- a/crates/tropel-wasm/src/driver.rs
+++ b/crates/tropel-wasm/src/driver.rs
@@ -917,6 +917,40 @@ fn metric_add_host(
             }
         }
     }
+    // TR-102: reserved-name guard — the wasm tier must reject builtin
+    // metric names the same way the k6 driver and sandbox do, or a guest
+    // module can forge the checks headline through the wasm bridge.
+    const RESERVED: &[&str] = &[
+        "http_reqs",
+        "http_req_duration",
+        "http_req_failed",
+        "http_req_blocked",
+        "http_req_connecting",
+        "http_req_tls_handshaking",
+        "http_req_receiving",
+        "http_req_sending",
+        "http_req_waiting",
+        "data_sent",
+        "data_received",
+        "iterations",
+        "vus",
+        "vus_max",
+        "checks",
+        "group_duration",
+        "ws_connecting",
+        "ws_sending",
+        "ws_receiving",
+        "ws_msgs_sent",
+        "ws_msgs_received",
+        "ws_session_duration",
+    ];
+    if RESERVED.iter().any(|r| *r == name) {
+        tracing::warn!(
+            "wasm metric '{}' clashes with built-in metric name — ignoring",
+            name
+        );
+        return;
+    }
     // Refuse non-finite values: a guest NaN/Inf sample would poison Counter/
     // Trend aggregates and thresholds downstream (avg/p95 become NaN).
     if !value.is_finite() {
@@ -1095,6 +1129,20 @@ mod tests {
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br_if $done (i32.gt_u (local.get $i) (i32.const 100001)))
         (br $loop)))
+    (i32.const 0))
+)
+"#;
+
+    const RESERVED_NAME_DRIVER_WAT: &str = r#"
+(module
+  (import "env" "metric_add" (func $metric_add (param i32 i32 f64 i32 i32 i32)))
+  (memory (export "memory") 64 256)
+  (data (i32.const 4096) "checks\00")
+  (data (i32.const 8192) "{}\00")
+  (func (export "adapter_run_iteration") (param $in i32) (param $in_len i32) (result i32)
+    ;; metric_add("checks", 1.0, "{}", type=3 Rate) — must be dropped by the
+    ;; TR-102 reserved-name guard (checks is a builtin headline).
+    (call $metric_add (i32.const 4096) (i32.const 6) (f64.const 1.0) (i32.const 8192) (i32.const 2) (i32.const 3))
     (i32.const 0))
 )
 "#;
@@ -1678,6 +1726,30 @@ mod tests {
             ctx.samples.len() <= MAX_ITERATION_SAMPLES,
             "samples must be capped, got {}",
             ctx.samples.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reserved_metric_name_dropped() {
+        // TR-102: a guest emitting into a builtin metric name (checks, http_reqs,
+        // …) must be dropped — the wasm tier mirrors the k6 driver and sandbox
+        // guards so a module cannot forge the checks headline.
+        let driver = WasmDriver::default();
+        let mut inst = driver
+            .init(RESERVED_NAME_DRIVER_WAT.as_bytes(), None, None)
+            .await
+            .expect("driver init must succeed");
+
+        let mut ctx = VuContext::new(1, 0, "default".into());
+        let result = inst.run_iteration(&mut ctx).await;
+        assert!(result.is_ok(), "iteration must succeed, got {:?}", result);
+        assert!(
+            ctx.samples.iter().all(|s| s.metric != "checks"),
+            "reserved metric 'checks' must be dropped, got {:?}",
+            ctx.samples
+                .iter()
+                .map(|s| s.metric.clone())
+                .collect::<Vec<_>>()
         );
     }
 

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -21,9 +21,9 @@ The worst class. A user ships on a number that was never true.
 ## TR-102 · A script can forge the `checks` headline
 **Effort:** S · **Blocked by:** none
 
-- [ ] The k6 driver has **no reserved-name guard** (`driver.rs:2276-23xx`), so user code can emit into the builtin `checks` Rate and make a CI gate read whatever it likes
+- [x] The k6 driver has **no reserved-name guard** (`driver.rs:2276-23xx`), so user code can emit into the builtin `checks` Rate and make a CI gate read whatever it likes
 - [x] Reserved builtin metric names reject user emission with a named error
-- [ ] Same guard on the declarative path and the wasm driver — this is the "guard in one place, not its siblings" shape
+- [x] Same guard on the declarative path and the wasm driver — this is the "guard in one place, not its siblings" shape
 
 ## TR-103 · Both proxy guards leak `Object.prototype`
 **Effort:** S · **Blocked by:** none


### PR DESCRIPTION
## What

Extends the reserved-name guard to the two HTTP bridges that were missing it. The k6 driver already rejected script emission into builtin metric names (`new Counter('checks')`, `http_reqs`, etc.), but a script could still forge the `checks` headline through `pm.metrics.add('checks', 1)` (the Postman-style bridge) or through a wasm guest's `env.metric_add("http_reqs", …)`. All three surfaces now reject the same builtin names with a warn + drop.

## Task

TR-102 · A script can forge the `checks` headline (W1 Track A — always-green).

## Acceptance

- [x] The k6 driver has a reserved-name guard (already landed) — `driver.rs:2396-2436`
- [x] Reserved builtin metric names reject user emission with a named error (already landed)
- [x] **Same guard on the declarative path and the wasm driver** — this PR:
  - `__tropel_pm_metrics_add` in `crates/tropel-sandbox/src/bindings/trp.rs` — rejects `pm.metrics.add('checks', …)` / `'http_reqs'` with warn + drop
  - `env.metric_add` in `crates/tropel-wasm/src/driver.rs` — rejects guest emission into `checks`, `http_reqs`, `ws_*`, etc. with warn + drop

## Tests

- `sandbox::test_pm_metrics_add_rejects_reserved_names` — runs the real `TrpBridge` + `pm.js` shim; asserts `pm.metrics.add('checks'|'http_reqs', …)` records no custom metric, and a non-reserved name (`my_custom`) still records. Would have failed on the pre-fix code (checks would have been recorded).
- `wasm::test_reserved_metric_name_dropped` — WAT guest calls `metric_add("checks", 1.0, …, type=3 Rate)`; asserts no `checks` sample reaches the iteration buffer. Would have failed on the pre-fix code.
- Existing k6 `test_reserved_metric_name_guard` still passes.

## Twin check

- Grepped every metric-entry surface: k6 driver `__tropel_pm_custom_metric_add` (guarded, driver.rs:2396), sandbox `__tropel_pm_custom_metric_add` (guarded, trp.rs:1206), sandbox `__tropel_pm_metrics_add` (**was missing — fixed here**), wasm `env.metric_add` (**was missing — fixed here**). `__tropel_pm_metrics_get` is a read-only getter — no guard needed. The wasm driver's `metric_add_host` already had a non-finite guard; the reserved-name check is added alongside it.

## Evidence

- ✅EXEC: `cargo test -p tropel-sandbox pm_metrics_add` (1 passed), `cargo test -p tropel-wasm reserved_metric` (1 passed), `cargo test -p tropel-input-k6 reserved_metric_name_guard` (1 passed), full sandbox (18) + wasm (31) suites pass
- ✅EXEC: `cargo clippy -p tropel-sandbox -p tropel-wasm --all-targets -- -D warnings` clean; `cargo fmt --check` clean

## Risk

- The guard drops reserved-name samples with a warning, matching the existing k6/sandbox behavior — a script that (incorrectly) tries to mint a metric named `checks` loses that sample but the run continues. No exit-code change.
- The wasm guard uses the same name list as the k6 driver (includes `ws_*` and `browser_http_req_*`), slightly broader than the sandbox list — both reject everything the summary treats as a builtin headline.
