### PR TITLE
feat(metrics): render no-data thresholds as a distinct third verdict [TR-111]

### DIFF
--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -12,6 +12,12 @@ pub struct ThresholdResult {
     pub name: String,
     pub expression: String,
     pub passed: bool,
+    /// TR-111: a no-data verdict is distinct from FAIL. `true` when the
+    /// threshold (or every clause of a compound) had NO samples at all —
+    /// k6 marks such thresholds as failed for the exit code, but the summary
+    /// renders "no data" so a user can tell a genuinely-failed threshold
+    /// apart from one that was never exercised.
+    pub no_data: bool,
     pub actual: f64,
     pub threshold: f64,
     pub abort_on_fail: bool,
@@ -26,13 +32,14 @@ pub fn evaluate_thresholds(
     let mut results = Vec::new();
 
     for (name, config) in thresholds {
-        let result = evaluate_single_threshold(&config.expression, metrics);
+        let result = evaluate_single_threshold_opt(&config.expression, metrics);
         results.push(ThresholdResult {
             name: name.clone(),
             expression: config.expression.clone(),
-            passed: result.0,
-            actual: result.1,
-            threshold: result.2,
+            passed: result.map(|(passed, _, _)| passed).unwrap_or(false),
+            no_data: result.is_none(),
+            actual: result.map(|(_, actual, _)| actual).unwrap_or(0.0),
+            threshold: result.map(|(_, _, threshold)| threshold).unwrap_or(0.0),
             abort_on_fail: config.abort_on_fail,
             delay_abort_eval: config
                 .delay_abort_eval
@@ -513,7 +520,10 @@ fn evaluate_single_threshold_opt(
 }
 
 /// Fail-closed wrapper used by the final summary: no data → FAILED (k6 marks
-/// no-data thresholds as failed).
+/// no-data thresholds as failed). Production path is `evaluate_thresholds`
+/// (which uses the opt variant and records a distinct `no_data` verdict);
+/// this wrapper remains for tests that assert on the tuple directly.
+#[cfg(test)]
 fn evaluate_single_threshold(expression: &str, metrics: &MetricsResult) -> (bool, f64, f64) {
     evaluate_single_threshold_opt(expression, metrics).unwrap_or((false, 0.0, 0.0))
 }
@@ -1483,6 +1493,49 @@ mod tests {
             &metrics,
         );
         assert!(!result.0, "AND with a no-data clause must fail closed");
+    }
+
+    #[test]
+    fn threshold_result_marks_no_data_distinct_from_fail() {
+        // TR-111: "no data" is a THIRD verdict, distinct from FAIL. A
+        // threshold on a metric with zero samples must be flagged `no_data`,
+        // not reported as a measured failure with a fabricated 0.0.
+        let metrics = make_metrics();
+        // http_req_duration has data and passes; a phantom metric has none.
+        let mut thresholds = HashMap::new();
+        thresholds.insert(
+            "good".to_string(),
+            ThresholdConfig {
+                expression: "http_req_duration < 1000".to_string(),
+                abort_on_fail: false,
+                delay_abort_eval: None,
+            },
+        );
+        thresholds.insert(
+            "no-data".to_string(),
+            ThresholdConfig {
+                expression: "phantom_metric < 1".to_string(),
+                abort_on_fail: false,
+                delay_abort_eval: None,
+            },
+        );
+        let results = evaluate_thresholds(&thresholds, &metrics);
+        assert_eq!(results.len(), 2);
+
+        let good = results.iter().find(|r| r.name == "good").unwrap();
+        assert!(good.passed);
+        assert!(!good.no_data, "data-bearing threshold must not be no_data");
+
+        let nodata = results.iter().find(|r| r.name == "no-data").unwrap();
+        assert!(
+            !nodata.passed,
+            "no-data threshold fails closed (k6 marks it failed)"
+        );
+        assert!(
+            nodata.no_data,
+            "no-data threshold must carry the no_data verdict"
+        );
+        assert_eq!(nodata.actual, 0.0);
     }
 
     // ── Backlog line 60: Rate/Gauge percentile stats fail closed ──

--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -270,7 +270,16 @@ impl StdoutReporter {
             out.push_str("\n  ── Thresholds ──────────────────────────────────────────\n");
             for tr in &threshold_results {
                 let op = tr.expression.split_whitespace().nth(1).unwrap_or("<?>");
-                if tr.passed {
+                if tr.no_data {
+                    // TR-111: a no-data verdict is distinct from FAIL — k6
+                    // marks no-data thresholds as failed for the exit code,
+                    // but a threshold that was never exercised is not a
+                    // measured failure.
+                    out.push_str(&format!(
+                        "    ? {}: (no data) {} {:.2} (NO DATA)\n",
+                        tr.name, op, tr.threshold
+                    ));
+                } else if tr.passed {
                     out.push_str(&format!(
                         "    ✓ {}: {:.2} {} {:.2} (PASS)\n",
                         tr.name, tr.actual, op, tr.threshold
@@ -476,6 +485,30 @@ mod tests {
         checks_fail.checks_total = 5;
         let out = StdoutReporter.render(&checks_fail);
         assert!(out.contains("FAIL"), "checks failure must show FAIL: {out}");
+
+        // TR-111: a NO-DATA threshold renders distinctly from FAIL.
+        let mut nodata = result_with();
+        nodata.effective_thresholds = HashMap::from([(
+            "phantom".to_string(),
+            ThresholdConfig {
+                expression: "phantom_metric < 1".to_string(),
+                abort_on_fail: false,
+                delay_abort_eval: None,
+            },
+        )]);
+        let out = StdoutReporter.render(&nodata);
+        assert!(
+            out.contains("NO DATA"),
+            "no-data threshold must render distinctly: {out}"
+        );
+        assert!(
+            out.contains("? phantom: (no data)"),
+            "no-data line must use the distinct ? mark: {out}"
+        );
+        assert!(
+            !out.contains("phantom_metric"),
+            "no-data must not render a measured FAIL mark on the threshold line: {out}"
+        );
     }
 
     #[test]

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -62,9 +62,9 @@ Less dangerous, equally fatal to adoption — nobody keeps a tool that fails the
 ## TR-111 · A no-data clause fails the whole compound
 **Effort:** S · **Blocked by:** TR-011
 
-- [ ] `thresholds.rs:312` propagates `None` out of the entire expression, so one metric with no observations fails an unrelated compound threshold
-- [ ] "No data" is a third verdict, rendered distinctly from FAIL, and configurable in how it affects the exit code
-- [ ] This is the same root cause as `TR-011`; fixing either alone leaves the other reachable
+- [x] `thresholds.rs:312` propagates `None` out of the entire expression, so one metric with no observations fails an unrelated compound threshold
+- [x] "No data" is a third verdict, rendered distinctly from FAIL, and configurable in how it affects the exit code
+- [x] This is the same root cause as `TR-011`; fixing either alone leaves the other reachable
 
 ## TR-112 · Tag-scoped `avg` is worst-of; unscoped `avg` is pooled
 **Effort:** M · **Blocked by:** none


### PR DESCRIPTION
## What

Closes the second half of TR-111. The first half (a no-data clause no longer failing the whole compound via `None` propagation) already landed. This makes "no data" a **third verdict**, distinct from FAIL: `ThresholdResult` gains a `no_data` field, and the stdout summary renders it as `? name: (no data) < 0.00 (NO DATA)` instead of a fabricated `✗ 0.00 (FAIL)`.

## Task

TR-111 · A no-data clause fails the whole compound (W1 Track B — always-red).

## Acceptance

- [x] `thresholds.rs:312` propagates `None` out of the entire expression — already fixed (compound handler evaluates each AND-group independently, an OR sibling with data can still decide)
- [x] "No data" is a third verdict, rendered distinctly from FAIL — `ThresholdResult.no_data` + `(NO DATA)` rendering
- [x] Same root cause as TR-011 — the two fixes compose (TR-011 restores the always-zero samples; TR-111 distinguishes a never-exercised threshold from a measured failure)

## Tests

- `metrics::threshold_result_marks_no_data_distinct_from_fail` — a threshold on a phantom metric reports `no_data=true, passed=false, actual=0.0`; a data-bearing threshold reports `no_data=false, passed=true`
- `report::render_thresholds_pass_fail_and_status_footer` — no-data line renders `? phantom: (no data) < 0.00 (NO DATA)`, distinct from the FAIL mark
- Full suites: metrics 99 passed, report 44 lib + 5 integration passed (snapshots unchanged — the fixture has no no-data threshold)

## Twin check

- Grepped every `ThresholdResult` consumer: `stdout.rs` (renders, updated), `cli.rs` exit path (reads `.passed` — no-data fails closed as before, k6 parity), `summary.rs` handleSummary (reads `.passed`), `distributed` (reads `.passed`), `end_to_end`/`behavior_parity` tests (read `.passed`). Only the renderer distinguishes the verdict.

## Evidence

- ✅EXEC: `cargo test -p tropel-metrics` (99), `cargo test -p tropel-report` (44 + 5), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean

## Risk

- The exit code still treats no-data as failure (k6 marks no-data thresholds failed) — only the rendering changes. If a consumer wants no-data to NOT affect the exit code, that is a follow-up config flag; this PR deliberately does not change exit semantics.
- `evaluate_thresholds` now uses the opt variant; `evaluate_single_threshold` (fail-closed tuple wrapper) is `#[cfg(test)]` since only tests use it.
