### PR TITLE
fix(shims): accept reason-phrase form in to.have.status() [TR-114]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -5278,6 +5278,21 @@ mod tests {
                     try { pm.expect(pm.response).to.have.status(200); return true; }
                     catch (e) { return 'threw: ' + e.message; }
                 })());
+                // TR-114: the reason-phrase form `to.have.status('OK')` is
+                // Postman's canonical snippet — must pass against the status
+                // text, and a wrong phrase must throw.
+                globalThis.__status_phrase_ok = String((function () {
+                    try { pm.expect(pm.response).to.have.status('OK'); return true; }
+                    catch (e) { return 'threw: ' + e.message; }
+                })());
+                globalThis.__status_phrase_bad = String((function () {
+                    try { pm.expect(pm.response).to.have.status('Created'); return 'no-throw'; }
+                    catch (e) { return 'threw: ' + e.message; }
+                })());
+                globalThis.__status_chain_phrase_ok = String((function () {
+                    try { pm.response.to.have.status('OK'); return true; }
+                    catch (e) { return 'threw: ' + e.message; }
+                })());
             "#,
             )
             .expect("script should eval");
@@ -5330,6 +5345,22 @@ mod tests {
                 ctx.eval::<String, _>("__status_ok").unwrap(),
                 "true",
                 "pm.expect(pm.response).to.have.status(200) must pass"
+            );
+            assert_eq!(
+                ctx.eval::<String, _>("__status_phrase_ok").unwrap(),
+                "true",
+                "pm.expect(pm.response).to.have.status('OK') must pass (TR-114)"
+            );
+            assert!(
+                ctx.eval::<String, _>("__status_phrase_bad")
+                    .unwrap()
+                    .contains("threw:"),
+                "to.have.status('Created') must throw on a 200 OK (TR-114)"
+            );
+            assert_eq!(
+                ctx.eval::<String, _>("__status_chain_phrase_ok").unwrap(),
+                "true",
+                "pm.response.to.have.status('OK') must pass (TR-114)"
             );
         });
     }
@@ -6036,6 +6067,10 @@ mod tests {
                 // Postman extensions survive delegation.
                 trial('status_ok', function () { pm.expect(pm.response).to.have.status(200); });
                 trial('status_bad', function () { pm.expect(pm.response).to.have.status(404); });
+                // TR-114: the reason-phrase form through the delegated chai
+                // assertion surface.
+                trial('status_phrase_ok', function () { pm.expect(pm.response).to.have.status('OK'); });
+                trial('status_phrase_bad', function () { pm.expect(pm.response).to.have.status('Created'); });
                 trial('header_ok', function () {
                     pm.expect(pm.response).to.have.header('Content-Type', 'application/json');
                 });
@@ -6087,6 +6122,8 @@ mod tests {
             assert_eq!(r("throw_bad"), "threw", "throw must fail closed when nothing throws");
             assert_eq!(r("status_ok"), "true", "pm.expect(pm.response).to.have.status must survive delegation");
             assert_eq!(r("status_bad"), "threw", "status must fail closed");
+            assert_eq!(r("status_phrase_ok"), "true", "status('OK') must pass (TR-114)");
+            assert_eq!(r("status_phrase_bad"), "threw", "status('Created') must fail closed (TR-114)");
             assert_eq!(r("header_ok"), "true", "header must survive delegation");
             assert_eq!(r("header_bad"), "threw", "header must fail closed");
             assert_eq!(r("typo"), "threw", "the guard must still trip on real typos through the delegated chain");

--- a/js/chai/chai-shim.js
+++ b/js/chai/chai-shim.js
@@ -713,6 +713,11 @@ var chai = chai || {};
     // Postman members, not core chai).
     Assertion.prototype.status = function (code) {
         var actual = (typeof pm !== 'undefined' && pm.response) ? pm.response.code : undefined;
+        // TR-114: accept BOTH a numeric code AND a reason-phrase string —
+        // `expect(res).to.have.status('OK')` is the canonical Postman form.
+        if (typeof code === 'string' && typeof pm !== 'undefined' && pm.response) {
+            actual = pm.response.status;
+        }
         var negate = !!(this.__flags && this.__flags.negate);
         var passed = (actual === code) !== negate;
         if (!passed) {

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -436,8 +436,16 @@ pm.response.to = guardChain({
     have: guardChain({
         status: function (code) {
             // Backlog line 143: pm.response.code is a VALUE now.
+            // TR-114: accept BOTH a numeric code AND a reason-phrase string.
+            // Postman's `to.have.status('OK')` is the canonical form; the
+            // numeric form is also valid.
             var actual = pm.response.code;
-            if (actual !== code) {
+            var expected = code;
+            if (typeof code === 'string') {
+                actual = pm.response.status;
+                expected = code;
+            }
+            if (actual !== expected) {
                 throw new Error(
                     'expected response to have status ' + code + ' but got ' + actual
                 );
@@ -777,7 +785,12 @@ AssertChain.prototype.status = function (code) {
     // Must THROW on mismatch (Postman/chai semantics) — a boolean return
     // makes `pm.test` treat the callback's `undefined` statement result as
     // passed. Backlog line 143: pm.response.code is a VALUE now.
+    // TR-114: accept BOTH a numeric code AND a reason-phrase string
+    // (`to.have.status('OK')` is Postman's canonical form).
     var actual = pm.response.code;
+    if (typeof code === 'string') {
+        actual = pm.response.status;
+    }
     var holds = actual === code;
     if (this._negated ? holds : !holds) {
         throw new Error('expected response ' + (this._negated ? 'not ' : '') + 'to have status ' + code + ' but got ' + actual);

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -83,9 +83,9 @@ Less dangerous, equally fatal to adoption — nobody keeps a tool that fails the
 ## TR-114 · `pm.response.to.have.jsonBody("key")` is a false failure
 **Effort:** S · **Blocked by:** none
 
-- [ ] `pm.js:464` deep-equals the argument against the whole body instead of treating a string argument as a path assertion
-- [ ] `to.have.status()` rejects the reason-phrase form in both `pm.js:437-445` and `chai-shim.js:714`
-- [ ] Both fixes land with the six stock-snippet regression tests
+- [x] `pm.js:464` deep-equals the argument against the whole body instead of treating a string argument as a path assertion
+- [x] `to.have.status()` rejects the reason-phrase form in both `pm.js:437-445` and `chai-shim.js:714`
+- [x] Both fixes land with the six stock-snippet regression tests
 
 ---
 


### PR DESCRIPTION
## What

Accepts the reason-phrase form in `to.have.status()`. Postman's canonical snippet `pm.response.to.have.status('OK')` — and the chai form `pm.expect(pm.response).to.have.status('OK')` — always threw, because all three `status()` implementations compared the numeric `pm.response.code` against the argument and a string never matched. All three now compare against `pm.response.status` (the status text) when the argument is a string.

## Task

TR-114 · `pm.response.to.have.jsonBody("key")` is a false failure (W1 Track B — always-red). The `jsonBody` half landed earlier; this closes the `to.have.status()` reason-phrase half.

## Acceptance

- [x] `pm.js:464` deep-equals the argument against the whole body — already fixed (string argument is a key-path assertion)
- [x] `to.have.status()` rejects the reason-phrase form in both `pm.js:437-445` and `chai-shim.js:714` — fixed in all three implementations
- [x] Both fixes land with the six stock-snippet regression tests

## Tests

- `k6::test_pm_response_members_are_value_properties` — `pm.expect(pm.response).to.have.status('OK')` passes, `to.have.status('Created')` throws on a 200/OK, `pm.response.to.have.status('OK')` (the guardChain form) passes
- `k6::test_pm_expect_delegates_to_chai_assertion_surface` — reason-phrase ok/bad trials through the delegated chai `Assertion.prototype.status`
- Full suite: 158 k6 driver tests pass; `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean

## Twin check

- Grepped every `status` comparison against `pm.response.code`:
  - `pm.js` guardChain `have.status` (line 437) — fixed
  - `pm.js` `AssertChain.prototype.status` (line 784) — fixed
  - `chai-shim.js` `Assertion.prototype.status` (line 714) — fixed
  - `pm.js` `AssertChain.prototype.header` / chai `header` — no twin (headers are always strings, the code already compares String-to-String)

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (158 passed), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean

## Risk

- A numeric status argument still compares against `pm.response.code` (unchanged); only string arguments route to the status text. Case is significant (`'OK'` matches `statusText` from the HTTP stack — both the runner and k6 driver emit standard reason phrases), matching Postman.
