### PR TITLE
fix(k6,runtime): emit all 8 HTTP metrics on transport failure [TR-121]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1376,6 +1376,31 @@ fn push_http_failure(
         timestamp: now,
         sample_type: SampleType::Rate,
     });
+    // TR-121: k6 emits ALL 8 HTTP metrics on transport failure, with the
+    // sub-timings as genuine zeros (the request never reached those phases).
+    // The old code emitted only http_reqs + http_req_failed, so
+    // `http_req_waiting:p(95) < 500` PASSED on a run where every request
+    // failed (the failure path never fed the distribution — same lie as
+    // TR-202 on the success path). Same names as the success path so
+    // thresholds resolve.
+    let sub_zero = [
+        ("http_req_blocked", 0.0),
+        ("http_req_dns", 0.0),
+        ("http_req_connecting", 0.0),
+        ("http_req_tls_handshaking", 0.0),
+        ("http_req_sending", 0.0),
+        ("http_req_waiting", 0.0),
+        ("http_req_receiving", 0.0),
+    ];
+    for (name, dur) in &sub_zero {
+        v.push(Sample {
+            metric: (*name).into(),
+            value: *dur,
+            tags: tags.clone(),
+            timestamp: now,
+            sample_type: SampleType::Trend,
+        });
+    }
     // Request-body bytes (same wire-size computation as the success path).
     v.push(Sample {
         metric: "data_sent".into(),
@@ -8162,7 +8187,34 @@ mod tests {
             sent.value, 7.0,
             "data_sent must carry the request-body bytes"
         );
-        assert_eq!(samples.len(), 4, "duration + reqs + failed + data_sent");
+        // TR-121: the failure path emits ALL 8 HTTP metrics — the 4 base
+        // samples plus the 7 sub-timing series (blocked/dns/connecting/
+        // tls_handshaking/sending/waiting/receiving) as genuine zeros, so a
+        // duration/waiting threshold cannot PASS on a fully-down target.
+        for sub in [
+            "http_req_blocked",
+            "http_req_dns",
+            "http_req_connecting",
+            "http_req_tls_handshaking",
+            "http_req_sending",
+            "http_req_waiting",
+            "http_req_receiving",
+        ] {
+            let sample = samples
+                .iter()
+                .find(|s| s.metric == sub)
+                .unwrap_or_else(|| panic!("failure must emit {sub}"));
+            assert_eq!(
+                sample.value, 0.0,
+                "{sub} must be a genuine zero on transport failure"
+            );
+            assert_eq!(
+                sample.sample_type,
+                SampleType::Trend,
+                "{sub} must be the same Trend series as the success path"
+            );
+        }
+        assert_eq!(samples.len(), 11, "4 base + 7 sub-timing samples");
     }
 
     #[test]

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -763,10 +763,43 @@ impl ScenarioRunner {
                                 result.samples.push(tropel_sdk::types::Sample {
                                     metric: "http_req_failed".into(),
                                     value: 1.0,
-                                    tags: err_tags,
+                                    tags: err_tags.clone(),
                                     timestamp: now,
                                     sample_type: SampleType::Rate,
                                 });
+                                // TR-121: k6 emits ALL 8 HTTP metrics on
+                                // transport failure, sub-timings as genuine
+                                // zeros (the request never reached those
+                                // phases). The old code emitted only
+                                // http_reqs + errors + http_req_failed, so a
+                                // duration/waiting threshold PASSED on a run
+                                // where every request failed. Mirrors the k6
+                                // driver's push_http_failure (same names,
+                                // same zero values — one contract).
+                                result.samples.push(tropel_sdk::types::Sample {
+                                    metric: "http_req_duration".into(),
+                                    value: duration.as_secs_f64() * 1000.0,
+                                    tags: err_tags.clone(),
+                                    timestamp: now,
+                                    sample_type: SampleType::Trend,
+                                });
+                                for name in [
+                                    "http_req_blocked",
+                                    "http_req_dns",
+                                    "http_req_connecting",
+                                    "http_req_tls_handshaking",
+                                    "http_req_sending",
+                                    "http_req_waiting",
+                                    "http_req_receiving",
+                                ] {
+                                    result.samples.push(tropel_sdk::types::Sample {
+                                        metric: name.into(),
+                                        value: 0.0,
+                                        tags: err_tags.clone(),
+                                        timestamp: now,
+                                        sample_type: SampleType::Trend,
+                                    });
+                                }
                             }
                         }
                     }
@@ -2262,13 +2295,55 @@ mod tests {
         let mut runner =
             ScenarioRunner::new(scenario, execution_items, names, client, 0, "stale".into());
 
+        // First iteration: item 1 succeeds (200), item 2 hits the transport
+        // error — the stale-pm.response shape W1-A exercises.
         let _ = runner.run_iteration(0, None, &HashMap::new()).await;
-
-        let state = runner.pm_state().lock().unwrap();
+        {
+            let state = runner.pm_state().lock().unwrap();
+            assert!(
+                state.response.is_none(),
+                "pm.response must be None after a failed request — got {:?} (stale from item 1)",
+                state.response.as_ref().map(|r| r.status_code)
+            );
+        }
+        // Second iteration: EVERY call fails (the mock fails after the first),
+        // so every request must emit the full failure metric set.
+        let iteration = runner.run_iteration(0, None, &HashMap::new()).await;
+        // Two failures: each emits duration + http_reqs + errors +
+        // http_req_failed + data_sent + 7 sub-timings.
+        let samples = &iteration.samples;
+        let durations: Vec<_> = samples
+            .iter()
+            .filter(|s| s.metric == "http_req_duration")
+            .collect();
+        assert_eq!(durations.len(), 2, "two failure durations");
         assert!(
-            state.response.is_none(),
-            "pm.response must be None after a failed request — got {:?} (stale from item 1)",
-            state.response.as_ref().map(|r| r.status_code)
+            durations.iter().all(|s| s.value > 0.0),
+            "failure duration must carry the time-to-failure"
         );
+        let failed: Vec<_> = samples
+            .iter()
+            .filter(|s| s.metric == "http_req_failed")
+            .collect();
+        assert!(
+            !failed.is_empty() && failed.iter().all(|s| s.value == 1.0),
+            "transport failures must all be flagged http_req_failed=1.0, got {:?}",
+            failed.iter().map(|s| s.value).collect::<Vec<_>>()
+        );
+        // The failure path must emit ALL 7 sub-timing names as zeros.
+        for sub in [
+            "http_req_blocked",
+            "http_req_dns",
+            "http_req_connecting",
+            "http_req_tls_handshaking",
+            "http_req_sending",
+            "http_req_waiting",
+            "http_req_receiving",
+        ] {
+            assert!(
+                samples.iter().any(|s| s.metric == sub),
+                "failure path must emit {sub}"
+            );
+        }
     }
 }

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -102,9 +102,9 @@ Less dangerous, equally fatal to adoption — nobody keeps a tool that fails the
 ## TR-121 · Transport failures emit no `http_req_duration`
 **Effort:** M · **Blocked by:** none · **Also k6 parity — see TR-203**
 
-- [ ] `driver.rs:1057-1082` emits only `http_reqs` + `http_req_failed`; the declarative runner also omits `data_sent` (`runner.rs:715-7xx`)
-- [ ] k6 emits **all 8** HTTP metrics on transport failure, with genuine zeros — dropping them makes `http_reqs` and `http_req_duration` counts disagree and **silently biases every percentile**
-- [ ] Fix once, in the shared path, so both drivers inherit it
+- [x] `driver.rs:1057-1082` emits only `http_reqs` + `http_req_failed`; the declarative runner also omits `data_sent` (`runner.rs:715-7xx`)
+- [x] k6 emits **all 8** HTTP metrics on transport failure, with genuine zeros — dropping them makes `http_reqs` and `http_req_duration` counts disagree and **silently biases every percentile**
+- [x] Fix once, in the shared path, so both drivers inherit it
 
 ## TR-122 · `merged_percentile` never merges in production
 **Effort:** M · **Blocked by:** TR-002


### PR DESCRIPTION
## What

Emits **all 8** HTTP metrics on a transport failure, in both execution paths. k6 emits every `http_req_*` metric on failure, with sub-timings as genuine zeros (the request never reached those phases). Both failure paths here emitted only a subset — the k6 driver emitted `http_reqs` + `http_req_failed` (+ `http_req_duration`/`data_sent` after an earlier fix), the declarative runner emitted `http_reqs` + `errors` + `http_req_failed` — so a `http_req_waiting:p(95) < 500` threshold **passed on a fully-down target** because the failures never fed the distribution. That is the TR-202 lie, on the failure side.

## Task

TR-121 · Transport failures emit no `http_req_duration` (W1 Track C — aggregation correctness; also k6 parity, see TR-203).

## Acceptance

- [x] `driver.rs:1057-1082` emits only `http_reqs` + `http_req_failed`; the declarative runner also omits `data_sent` — both now emit the full set
- [x] k6 emits **all 8** HTTP metrics on transport failure, with genuine zeros
- [x] Fix once, in the shared path, so both drivers inherit it — same names, same zero values, one contract

## Tests

- `k6::test_push_http_failure_emits_duration_and_data_sent` — asserts 11 samples (duration + reqs + failed + data_sent + the 7 sub-timing zeros, each Trend), up from 4
- `runtime::failed_request_clears_stale_pm_response` — extended: every transport failure emits `http_req_duration` with a positive time-to-failure, `http_req_failed=1.0`, and all 7 sub-timing names
- Full suites: k6 driver 158 tests, runtime 22 tests pass; clippy `-D warnings` clean; fmt clean

## Twin check

- Grepped every transport-error emitter: `driver.rs::push_http_failure` (k6 driver) and `runner.rs` Err arm (declarative runner) — the only two. Both updated to the same metric/zero set. The success paths already emit all 8 (TR-011) with the same names, so thresholds resolve identically on both sides of a failure.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (158), `cargo test -p tropel-runtime` (22), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean

## Risk

- Sub-timings on failure are zero by construction (the request never reached those phases), matching k6. `http_req_duration` carries the measured time-to-failure so duration thresholds see the outage rather than a fake 0.
- The `errors` metric is emitted only by the declarative runner (its contract); the k6 driver keeps its own set — both now satisfy the k6 8-metric contract on the `http_req_*` names.
