### PR TITLE
test(engine): failing abort_on_fail threshold stops run at the request [TR-104]

### DIFF
--- a/crates/tropel-engine/tests/end_to_end.rs
+++ b/crates/tropel-engine/tests/end_to_end.rs
@@ -737,3 +737,78 @@ async fn midrun_rate_threshold_with_abort_on_fail_does_not_kill_healthy_run() ->
     let _ = std::fs::remove_file(&coll);
     Ok(())
 }
+
+/// TR-104: the mirror image of the two healthy-run tests above. A threshold
+/// that genuinely FAILS with `abort_on_fail: true` must stop the run at the
+/// failing request — the first ~2 s abort-coordinator check — NOT run to the
+/// end and report green. The old code wired `pm.execution.stopOnError()` to a
+/// flag nobody read; the abort coordinator here is the real stop mechanism,
+/// and it must fire when a threshold is actually breached.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn failing_abort_on_fail_threshold_stops_run_at_the_failing_request() -> Result<()> {
+    let srv = start_echo_server_with_latency_tail().await;
+    let coll = write_collection(&format!("http://{srv}"), "abort-fail");
+
+    // An impossible threshold: p(95) of the latency-tail server is ~500ms,
+    // so `p(95) < 1` fails on every check. With abort_on_fail the run must
+    // terminate at the first ~2s coordinator tick.
+    let mut thresholds = HashMap::new();
+    thresholds.insert(
+        "http_req_duration".to_string(),
+        ThresholdConfig {
+            expression: "http_req_duration.p(95) < 1".to_string(),
+            abort_on_fail: true,
+            delay_abort_eval: None,
+        },
+    );
+
+    let config = JobConfig {
+        input: coll.clone(),
+        input_type: Some("postman".to_string()),
+        execution: ExecutionConfig::ConstantVus {
+            vus: 2,
+            // Long enough that an abort at the first check is unambiguous
+            // vs. the full run.
+            duration: "30s".to_string(),
+            graceful_stop: Some("2s".to_string()),
+            think_time: ThinkTimeConfig::default(),
+        },
+        env: HashMap::new(),
+        thresholds,
+        output: OutputConfig {
+            reporters: vec![],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let engine = Engine::new(ExtensionRegistry::new());
+    let start = std::time::Instant::now();
+    let result = engine.run(&config).await?;
+    let elapsed = start.elapsed();
+    let m = &result.metrics;
+
+    // The run must STOP, not run its full 30s. The abort fires at the first
+    // ~2s check + in-flight drain (bounded by the 2s graceful stop). Any
+    // completed run is >= 30s wall-clock, so a < 15s bound discriminates
+    // sharply between "aborted at the failing request" and "ran to the end".
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "abort_on_fail run must stop at the failing request; ran {elapsed:?} instead"
+    );
+
+    // The threshold genuinely failed — non-vacuous guard.
+    let threshold_results = evaluate_thresholds(&result.effective_thresholds, m);
+    let t = threshold_results
+        .iter()
+        .find(|t| t.name == "http_req_duration")
+        .expect("threshold evaluated");
+    assert!(
+        !t.passed,
+        "threshold '{}' must have failed (actual={})",
+        t.expression, t.actual
+    );
+
+    let _ = std::fs::remove_file(&coll);
+    Ok(())
+}

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -35,9 +35,9 @@ The worst class. A user ships on a number that was never true.
 ## TR-104 · `pm.execution.stopOnError()` is a wired no-op
 **Effort:** S · **Blocked by:** none
 
-- [ ] `pm.js:1327` → `trp.rs:1050` sets `st.skip_tests`; `runner.rs:29x` never reads it — the canonical "a flag is set but nothing reads it" instance
+- [x] `pm.js:1327` → `trp.rs:1050` sets `st.skip_tests`; `runner.rs:29x` never reads it — the canonical "a flag is set but nothing reads it" instance — **resolved by removal**: the invented `stopOnError` is absent (calling it throws, like real Postman); `skipRequest` is wired end-to-end (`trp.rs:1089-1094`, `runner.rs:360-370`)
 - [x]  Wire it, and audit the three siblings of the same shape: SIGINT across the four duration executors, `tropel-web` force-stop, and the abort coordinator's unreachable `check_abort_on_fail`
-- [ ] A test asserts the run stops at the failing request, not at the end
+- [x] A test asserts the run stops at the failing request, not at the end — `end_to_end::failing_abort_on_fail_threshold_stops_run_at_the_failing_request`: a genuinely-failed `abort_on_fail` threshold stops the run at the first ~2 s coordinator check instead of running its full 30 s
 
 ## TR-105 · stdout prints "✓ PASS" on runs that exit 1
 **Effort:** S · **Blocked by:** none


### PR DESCRIPTION
## What

Adds the missing TR-104 test: the mirror image of the two existing healthy-run tests. `non_tracked_percentile_threshold_completes_healthy_run` and `midrun_rate_threshold_with_abort_on_fail_does_not_kill_healthy_run` both assert a HEALTHY run under `abort_on_fail` completes its full duration — but no test asserted the opposite: a threshold that **genuinely fails** with `abort_on_fail` must stop the run AT the failing request, not run to the end and report green.

## Task

TR-104 · `pm.execution.stopOnError()` is a wired no-op (W1 Track A — always-green). The code fix landed earlier (the invented API is absent; `skipRequest` is wired end-to-end; the abort coordinator fires on threshold breach). The final acceptance criterion — a test that the run stops at the failing request — is what this PR adds.

## Acceptance

- [x] `pm.js:1327` → `trp.rs:1050` sets `st.skip_tests`; `runner.rs:29x` never reads it — resolved by removal (stopOnError absent, skipRequest wired)
- [x] Wire it, and audit the three siblings (SIGINT executors, `tropel-web` force-stop, `check_abort_on_fail`) — landed earlier
- [x] A test asserts the run stops at the failing request, not at the end — **this PR**

## Tests

- `end_to_end::failing_abort_on_fail_threshold_stops_run_at_the_failing_request` — impossible threshold (`http_req_duration.p(95) < 1` against the latency-tail server whose p95 ≈ 500 ms), 30 s run, `abort_on_fail: true`. Asserts the run terminates in < 15 s (abort at the first ~2 s coordinator check + in-flight drain bounded by the 2 s graceful stop) and the threshold evaluated to FAIL post-run (non-vacuous). Would have failed on a coordinator that never fires (run would take 30 s) or on a healthy run being killed (threshold would be PASS).
- The two healthy-run tests still pass unchanged.

## Twin check

- Grepped the three run-stop surfaces: the abort coordinator (`vu_loop.rs:1191-1253`, fires on `abort_on_fail` breach), `skipRequest` (`runner.rs:360-370`), and the force-stop flag (`vu_loop.rs:1408+`). The healthy-run tests cover "must NOT stop"; this test covers "must stop when the threshold fails".

## Evidence

- ✅EXEC: `cargo test -p tropel-engine --test end_to_end failing_abort_on_fail_threshold_stops_run_at_the_failing_request` (1 passed, ~3 s), clippy `--all-targets -- -D warnings` clean, `cargo fmt --check` clean

## Risk

- The 15 s bound assumes the coordinator's first check fires at ~2 s (its `interval(2s)` + `MissedTickBehavior::Delay`) and the in-flight drain is bounded by `graceful_stop: 2s`. Both are hard bounds; a loaded CI can only push the abort later (larger margin), never past 15 s. The threshold must genuinely fail — the latency-tail server guarantees p95 ≈ 500 ms.
