### PR TITLE
feat(summary): build root_group tree from per-group data [TR-113]

### DIFF
--- a/crates/tropel-engine/src/summary.rs
+++ b/crates/tropel-engine/src/summary.rs
@@ -5,7 +5,7 @@
 //! and run state). Moved out of the former `engine.rs` god-file.
 
 use serde_json::{json, Map};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::Instant;
 use tropel_core::config::ThresholdConfig;
 use tropel_metrics::collector::MetricSummary;
@@ -123,7 +123,7 @@ pub(crate) fn build_summary_data(
 
     json!({
         "metrics": metrics,
-        "root_group": { "name": "", "path": "", "id": "", "groups": [], "checks": [] },
+        "root_group": build_root_group(results),
         "options": {},
         "thresholds": thresholds_map,
         "state": {
@@ -142,10 +142,142 @@ pub(crate) fn build_summary_data(
     })
 }
 
+/// Build the k6-style `root_group` tree from the per-group metric summaries.
+/// k6's handleSummary v2.1.0 shape nests groups with their checks — the
+/// hardcoded empty stub (TR-113) was the only thing keeping handleSummary
+/// from rendering group-level data.
+fn build_root_group(results: &MetricsResult) -> serde_json::Value {
+    // Distinct group paths from the per-group summaries (root "" included).
+    let mut paths: Vec<String> = vec![String::new()];
+    for m in &results.per_group {
+        if let Some(group) = m
+            .tags
+            .iter()
+            .find(|(k, _)| k == "group")
+            .map(|(_, v)| v.clone())
+        {
+            if !paths.contains(&group) {
+                paths.push(group);
+            }
+        }
+    }
+    // Sort so shallower paths come first (root, ::a, ::a::b).
+    paths.sort_by_key(|p| (p.matches("::").count(), p.clone()));
+
+    // Build one node per path keyed by the full path so children can be
+    // attached. Root "" is the outer object.
+    let mut nodes: std::collections::BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for path in &paths {
+        if path.is_empty() {
+            continue;
+        }
+        let leaf = path.rsplit("::").next().unwrap_or(path);
+        let (passes, fails) = group_checks(results, path);
+        let mut checks = Vec::new();
+        if passes > 0 || fails > 0 {
+            checks.push(json!({ "name": "all", "passes": passes, "fails": fails }));
+        }
+        nodes.insert(
+            path.clone(),
+            json!({
+                "name": leaf,
+                "path": path,
+                "id": leaf,
+                "groups": [],
+                "checks": checks,
+            }),
+        );
+    }
+
+    // Attach each node to its parent's `groups` (parent path = strip the
+    // final `::leaf`). Iterate sorted so a parent is processed before its
+    // children.
+    let parent_of = |path: &str| -> String {
+        match path.rfind("::") {
+            Some(i) => path[..i].to_string(),
+            None => String::new(),
+        }
+    };
+    // Root checks: per-group `checks` Rate for root (group="" and the
+    // default runner tag "http").
+    let (rpasses, rfails) = group_checks(results, "");
+    let (hpasses, hfails) = group_checks(results, "http");
+    let mut root_checks = Vec::new();
+    let rp = rpasses + hpasses;
+    let rf = rfails + hfails;
+    if rp > 0 || rf > 0 {
+        root_checks.push(json!({ "name": "all", "passes": rp, "fails": rf }));
+    }
+
+    // Build the tree: repeatedly move each node into its parent's `groups`
+    // (parent = strip the final ::leaf). Because `nodes` is keyed by path
+    // and paths are sorted shallow-first, every parent already has its
+    // `groups` array populated before a child needs to attach to it.
+    let mut tree: BTreeMap<String, serde_json::Value> = nodes;
+    for _ in 0..tree.len() {
+        // A single pass moves every top-level leftover; nested attachments
+        // need repeats since each iteration can only move a node whose
+        // parent is still a plain map (not yet wrapped). Iterate until the
+        // map holds only the root's direct children.
+        let keys: Vec<String> = tree.keys().cloned().collect();
+        let mut changed = false;
+        for path in &keys {
+            if path.is_empty() {
+                continue;
+            }
+            let parent = parent_of(path);
+            if let Some(node) = tree.remove(path) {
+                if let Some(parent_node) = tree.get_mut(&parent) {
+                    if let Some(groups) = parent_node["groups"].as_array_mut() {
+                        groups.push(node);
+                    }
+                    changed = true;
+                } else {
+                    tree.insert(path.clone(), node);
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    // Any path whose parent was never a node in the tree (e.g. the parent
+    // didn't exist in per_group) attaches to the root.
+    let mut root_groups: Vec<serde_json::Value> = Vec::new();
+    for (_, node) in tree {
+        root_groups.push(node);
+    }
+    root_groups.sort_by(|a, b| a["path"].as_str().cmp(&b["path"].as_str()));
+
+    json!({
+        "name": "",
+        "path": "",
+        "id": "",
+        "groups": root_groups,
+        "checks": root_checks,
+    })
+}
+
+/// Pass/fail counts for one group path from the per-group `checks` Rate
+/// summaries. `count` is the number of checks recorded in that group; `rate`
+/// is the pass fraction (k6 Rate semantics).
+fn group_checks(results: &MetricsResult, group: &str) -> (u64, u64) {
+    let mut count: f64 = 0.0;
+    let mut rate: f64 = 0.0;
+    for m in &results.per_group {
+        if m.key.starts_with("checks") && m.tags.iter().any(|(k, v)| k == "group" && v == group) {
+            count += m.count as f64;
+            rate += m.rate * m.count as f64;
+        }
+    }
+    let passes = rate.round() as u64;
+    let fails = (count - rate).round() as u64;
+    (passes, fails)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use tropel_metrics::collector::MetricSummary;
     use tropel_metrics::collector::MetricType;
 
@@ -238,5 +370,74 @@ mod tests {
             metrics["http_req_duration"]["values"]["p(95)"],
             json!(300.0)
         );
+    }
+
+    /// TR-113: `root_group` must be a real group tree built from the
+    /// per-group summaries, not the hardcoded empty stub. handleSummary
+    /// scripts reading `data.root_group.groups` get the nested groups and
+    /// per-group checks.
+    #[test]
+    fn root_group_builds_tree_from_per_group_data() {
+        let mk = |key: &str, group: &str, count: u64, rate: f64| MetricSummary {
+            key: key.into(),
+            tags: vec![("group".to_string(), group.to_string())],
+            metric_type: MetricType::Rate,
+            count,
+            sum: count as f64,
+            mean: rate,
+            min: 0.0,
+            max: 1.0,
+            p50: 0.0,
+            p90: 0.0,
+            p95: 0.0,
+            p99: 0.0,
+            last: 0.0,
+            rate,
+            histogram: None,
+        };
+        let results = MetricsResult {
+            per_group: vec![
+                // checks at root (k6 runner default group tag "http").
+                mk("checks{group=http}", "http", 10, 0.9),
+                // nested groups with their own checks.
+                mk("checks{group=::checkout}", "::checkout", 5, 1.0),
+                mk(
+                    "checks{group=::checkout::payment}",
+                    "::checkout::payment",
+                    4,
+                    0.5,
+                ),
+            ],
+            ..Default::default()
+        };
+        let data = build_summary_data(&results, &HashMap::new(), std::time::Instant::now());
+        let root = &data["root_group"];
+        assert_eq!(root["name"], json!(""));
+        assert_eq!(root["path"], json!(""));
+
+        // Root checks: 10 @ 0.9 → 9 passes, 1 fail.
+        assert_eq!(root["checks"][0]["passes"], json!(9));
+        assert_eq!(root["checks"][0]["fails"], json!(1));
+
+        // Top-level group "checkout" with path ::checkout.
+        let checkout = root["groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|g| g["name"] == "checkout")
+            .expect("checkout group must be in the tree");
+        assert_eq!(checkout["path"], json!("::checkout"));
+        assert_eq!(checkout["checks"][0]["passes"], json!(5));
+
+        // Nested "payment" inside checkout.
+        let payment = checkout["groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|g| g["name"] == "payment")
+            .expect("payment group must nest under checkout");
+        assert_eq!(payment["path"], json!("::checkout::payment"));
+        assert_eq!(payment["checks"][0]["passes"], json!(2));
+        assert_eq!(payment["checks"][0]["fails"], json!(2));
     }
 }

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -76,9 +76,9 @@ Less dangerous, equally fatal to adoption — nobody keeps a tool that fails the
 ## TR-113 · `handleSummary` has no unscoped `http_req_duration`
 **Effort:** S · **Blocked by:** TR-112
 
-- [ ] `summary.rs:23-84` iterates `results.metrics`; the merged unscoped series never appears, so the most common `handleSummary` script in existence reads `undefined`
-- [ ] k6's v2.1.0 default `data` shape is still the legacy `{root_group, options, state, metrics, setup_data}` — match it
-- [ ] `root_group` is currently a hardcoded empty stub while `per_group` is fully populated
+- [x] `summary.rs:23-84` iterates `results.metrics`; the merged unscoped series never appears, so the most common `handleSummary` script in existence reads `undefined` — **fixed**: `summary.rs` re-injects the merged `http_req_duration`/`iteration_duration` headlines under their unscoped keys (test `headline_http_req_duration_reinjected_into_handle_summary`)
+- [x] k6's v2.1.0 default `data` shape is still the legacy `{root_group, options, state, metrics, setup_data}` — match it — `metrics` carries the headline series and `root_group` is now a real tree
+- [x] `root_group` is currently a hardcoded empty stub while `per_group` is fully populated — **fixed**: `build_root_group` builds a nested group tree (name/path/id/groups/checks) from the per-group summaries; test `root_group_builds_tree_from_per_group_data` asserts nested `checkout::payment` with per-group passes/fails
 
 ## TR-114 · `pm.response.to.have.jsonBody("key")` is a false failure
 **Effort:** S · **Blocked by:** none


### PR DESCRIPTION
## What

Replaces the hardcoded `root_group: { name: "", path: "", id: "", groups: [], checks: [] }` stub in `handleSummary` data with a real group tree built from the per-group metric summaries. k6's v2.1.0 handleSummary data shape nests groups with their checks — `data.root_group.groups[0].groups[0].checks[0].passes` — and the stub made the most common group-level introspection return nothing.

## Task

TR-113 · `handleSummary` has no unscoped `http_req_duration` (W1 Track B — always-red). The headline re-injection landed earlier; `root_group` was the remaining gap.

## Acceptance

- [x] `summary.rs` iterates `results.metrics`; the merged unscoped series never appears — fixed by earlier PR (headline re-injection)
- [x] k6's v2.1.0 default `data` shape — `metrics` now carries headline series, `root_group` is a real tree
- [x] `root_group` is currently a hardcoded empty stub while `per_group` is fully populated — **this PR**

## Tests

- `summary::root_group_builds_tree_from_per_group_data` — per-group `checks` Rate at root (`http`, 10@0.9), `::checkout` (5@1.0), `::checkout::payment` (4@0.5). Asserts: root checks 9 passes / 1 fail, `checkout` group has 5 passes, `payment` nests under `checkout` with 2 passes / 2 fails.
- Full engine lib suite (41 tests) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- The only two callers of `root_group` data are `build_summary_data` (handleSummary) and the old std-out which never used it. The per-group breakdown lives in `stdout.rs`'s `Per-group breakdown` section, which iterates `results.per_group` directly and is unaffected.

## Evidence

- ✅EXEC: `cargo test -p tropel-engine --lib` (41), `cargo test root_group_builds_tree` (1), clippy + fmt clean

## Risk

- The tree builder iterates `per_group` entries and builds a BTreeMap keyed by group path. With 1000+ groups the O(n log n) sort is fine (handleSummary runs once post-run). The checks pass/fail computation uses `rate * count` rounded — a Rate with 0.5 pass rate and 3 total checks gives 2 passes/2 fails (rounding). This is a heuristic; k6 fixes the per-check-name breakdown from the raw check samples, which tropel doesn't retain per-check per-group.