### PR TITLE
fix(metrics): guard non-finite values at the primary path, drop bridge guards [TR-120]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -2409,15 +2409,11 @@ impl K6DriverInstance {
                         // (crates/tropel-wasm/src/driver.rs) with the same
                         // rule; the k6 bridge takes `value: f64` straight from
                         // JS, so `myTrend.add(parseFloat(missingHeader))` →
-                        // NaN poisoned `sum` forever (avg=NaN → `avg < 500`
-                        // false forever) while `f64::NAN.max(0.0) == 0.0`
-                        // silently recorded a phantom 0 in the histogram.
-                        // Drop the sample — count and population stay
+                        // NaN is rejected at the primary path
+                        // (MetricsCollector::record, TR-120) which guards
+                        // BEFORE forward_to_sink. count and population stay
                         // consistent and no aggregate/threshold can be
                         // poisoned.
-                        if !value.is_finite() {
-                            return;
-                        }
                         // TR-102: reserved-name guard — user code must not
                         // emit into builtin metrics. A script that writes
                         // `new Rate('http_req_failed').add(0)` makes a CI
@@ -7409,6 +7405,11 @@ mod tests {
             .await
             .expect("iteration must complete");
 
+        // The NaN samples DO reach the per-iteration buffer (the bridge guard
+        // is gone — the canonical TR-120 guard is at MetricSet::record and
+        // MetricsCollector::record/record_batch). Assert the buffer carried
+        // both the NaN and the valid sample, then that the COLLECTOR drops
+        // the NaN and the aggregation window survives.
         let latency: Vec<&Sample> = ctx
             .samples
             .iter()
@@ -7416,24 +7417,53 @@ mod tests {
             .collect();
         assert_eq!(
             latency.len(),
-            1,
-            "NaN Trend.add must be dropped, got: {:?}",
-            latency.iter().map(|s| s.value).collect::<Vec<_>>()
+            2,
+            "bridge must forward both samples to the per-iteration buffer"
         );
-        assert_eq!(latency[0].value, 42.0, "valid Trend.add must survive");
+        assert!(
+            latency.iter().any(|s| !s.value.is_finite()),
+            "NaN Trend.add reaches the buffer (guard is at the collector)"
+        );
+        assert!(latency.iter().any(|s| s.value == 42.0));
 
         let events: Vec<&Sample> = ctx
             .samples
             .iter()
             .filter(|s| s.metric == "events")
             .collect();
-        assert_eq!(
-            events.len(),
-            1,
-            "NaN Counter.add must be dropped, got: {:?}",
-            events.iter().map(|s| s.value).collect::<Vec<_>>()
+        assert_eq!(events.len(), 2, "both Counter.add samples reach the buffer");
+        assert!(events.iter().any(|s| !s.value.is_finite()));
+
+        // TR-120: feed the buffer through the real collector and assert the
+        // window survives — the NaN samples are dropped at the primary path,
+        // only the valid ones aggregate.
+        let collector = tropel_metrics::collector::MetricsCollector::new();
+        collector.record_batch(&ctx.samples).await;
+        let results = collector.results().await;
+        assert!(
+            !results.metrics.is_empty(),
+            "collector must aggregate the samples"
         );
-        assert_eq!(events[0].value, 1.0, "valid Counter.add must survive");
+        let latency_s = results
+            .metrics
+            .iter()
+            .find(|m| m.key.starts_with("latency{"));
+        let l = latency_s.expect("latency series must exist");
+        assert!(
+            l.mean.is_finite(),
+            "NaN Trend must not poison the aggregate (mean={})",
+            l.mean
+        );
+        assert_eq!(l.count, 1, "only the valid Trend.add should be counted");
+        assert_eq!(l.mean, 42.0, "valid Trend.add must survive");
+        let events_s = results
+            .metrics
+            .iter()
+            .find(|m| m.key.starts_with("events{"))
+            .expect("events series must exist");
+        assert!(events_s.mean.is_finite());
+        assert_eq!(events_s.count, 1, "only the valid Counter.add is counted");
+        assert_eq!(events_s.sum, 1.0);
     }
 
     /// Backlog line 62: an abnormal closure (server drops without a close

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -501,9 +501,18 @@ impl MetricsCollector {
     /// If the aggregator has shut down (channel closed), the send silently
     /// drops the samples — acceptable during test teardown.
     pub async fn record_batch(&self, samples: &[Sample]) {
+        // TR-120: guard at the PRIMARY path, same as record().
+        let samples: Vec<Sample> = samples
+            .iter()
+            .filter(|s| s.value.is_finite())
+            .cloned()
+            .collect();
+        if samples.is_empty() {
+            return;
+        }
         self.ensure_aggregator();
         // Forward to streaming output sinks (best-effort, non-blocking)
-        self.forward_to_sink(samples);
+        self.forward_to_sink(&samples);
 
         let batch: Vec<Sample> = samples.to_vec();
         if self.tx.send(MetricsEvent::Samples(batch)).await.is_err() {
@@ -514,6 +523,15 @@ impl MetricsCollector {
     /// Record a single sample — bounded backpressure path.
     /// Also forwards to the streaming output sink if configured.
     pub async fn record(&self, sample: &Sample) {
+        // TR-120: guard at the PRIMARY path — before forward_to_sink (which
+        // bypasses the aggregator guard) AND before the aggregator channel.
+        // A single NaN/Inf sample poisons the flush window across all
+        // streaming outputs AND the aggregator; guard once here, not at the
+        // two bridge-level emitters.
+        if !sample.value.is_finite() {
+            tracing::trace!("MetricsCollector::record dropped non-finite sample");
+            return;
+        }
         self.ensure_aggregator();
         // Forward to streaming output sinks (best-effort, non-blocking)
         self.forward_to_sink(std::slice::from_ref(sample));
@@ -2157,6 +2175,36 @@ mod tests {
         assert_eq!(set.max, 1000.0, "max must reflect the Counter-typed sample");
         let stats = set.trend_stats();
         assert_eq!(stats.count, 2, "both samples must be in the histogram");
+    }
+
+    #[test]
+    fn test_record_drops_non_finite_values() {
+        // TR-120: MetricSet::record must reject NaN/Inf BEFORE any arithmetic
+        // — a single NaN sample poisoned sum forever (avg=NaN → `avg < 500`
+        // false forever) while f64::NAN.max(0.0) == 0.0 silently recorded a
+        // phantom 0 in the histogram. NaN/Inf must not even touch count/sum.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut set = MetricSet::new(MetricType::Trend, None, true);
+            set.record(bad, &SampleType::Trend);
+            set.record(42.0, &SampleType::Trend);
+            assert_eq!(set.count, 1.0, "NaN/Inf must not be counted");
+            assert_eq!(set.sum, 42.0, "NaN/Inf must not touch sum");
+            let mean = set.mean();
+            assert!(mean.is_finite(), "mean must stay finite, got {mean}");
+        }
+
+        // Same for Counter and Rate sets.
+        let mut counter = MetricSet::new(MetricType::Counter, None, true);
+        counter.record(f64::NAN, &SampleType::Counter);
+        counter.record(7.0, &SampleType::Counter);
+        assert_eq!(counter.count, 1.0);
+        assert_eq!(counter.sum, 7.0);
+
+        let mut rate = MetricSet::new(MetricType::Rate, None, true);
+        rate.record(f64::INFINITY, &SampleType::Rate);
+        rate.record(1.0, &SampleType::Rate);
+        assert_eq!(rate.count, 1.0);
+        assert_eq!(rate.sum, 1.0);
     }
 
     #[test]

--- a/crates/tropel-wasm/src/driver.rs
+++ b/crates/tropel-wasm/src/driver.rs
@@ -951,11 +951,6 @@ fn metric_add_host(
         );
         return;
     }
-    // Refuse non-finite values: a guest NaN/Inf sample would poison Counter/
-    // Trend aggregates and thresholds downstream (avg/p95 become NaN).
-    if !value.is_finite() {
-        return;
-    }
     let sample_type = match type_code {
         1 => SampleType::Counter,
         2 => SampleType::Trend,
@@ -1247,6 +1242,50 @@ mod tests {
     (i32.const 0))
 )
 "#;
+
+    const NON_FINITE_DRIVER_WAT: &str = r#"
+(module
+  (import "env" "metric_add" (func $metric_add (param i32 i32 f64 i32 i32 i32)))
+  (memory (export "memory") 64 256)
+  (data (i32.const 4096) "latency\00")
+  (data (i32.const 8192) "{}\00")
+  (func (export "adapter_run_iteration") (param $in i32) (param $in_len i32) (result i32)
+    ;; metric_add("latency", NaN, "{}", type=2 Trend) — must be dropped by the
+    ;; primary-path TR-120 guard, not counted.
+    (call $metric_add (i32.const 4096) (i32.const 7) (f64.const nan) (i32.const 8192) (i32.const 2) (i32.const 2))
+    ;; metric_add("latency", 42.0, "{}", type=2 Trend) — must survive.
+    (call $metric_add (i32.const 4096) (i32.const 7) (f64.const 42.0) (i32.const 8192) (i32.const 2) (i32.const 2))
+    (i32.const 0))
+)
+"#;
+
+    #[tokio::test]
+    async fn test_non_finite_metric_reaches_buffer() {
+        // TR-120: the wasm metric_add bridge's NaN guard was removed (the
+        // canonical guard is at MetricSet::record / MetricsCollector::record).
+        // The NaN sample must now reach the per-iteration buffer instead of
+        // being silently dropped at the bridge — the collector drops it.
+        let driver = WasmDriver::default();
+        let mut inst = driver
+            .init(NON_FINITE_DRIVER_WAT.as_bytes(), None, None)
+            .await
+            .expect("driver init must succeed");
+
+        let mut ctx = VuContext::new(1, 0, "default".into());
+        let result = inst.run_iteration(&mut ctx).await;
+        assert!(result.is_ok(), "iteration must succeed, got {:?}", result);
+        let non_finite: Vec<_> = ctx
+            .samples
+            .iter()
+            .filter(|s| !s.value.is_finite())
+            .collect();
+        assert!(
+            !non_finite.is_empty(),
+            "bridge must forward NaN to the per-iteration buffer (guard is at the collector)"
+        );
+        let valid: Vec<_> = ctx.samples.iter().filter(|s| s.value == 42.0).collect();
+        assert!(!valid.is_empty(), "valid sample must survive");
+    }
 
     #[tokio::test]
     async fn test_init_requires_run_iteration_export() {

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -94,10 +94,10 @@ Less dangerous, equally fatal to adoption — nobody keeps a tool that fails the
 ## TR-120 · No NaN/Inf guard on the primary path
 **Effort:** S · **Blocked by:** none
 
-- [ ] The guard exists in the wasm driver and at two emitters, and **not** in `MetricSet::record` — the canonical sibling-miss
-- [ ] A single NaN/Inf sample poisons a whole flush window across three outputs (`influxdb.rs:232`, `statsd.rs`, Prometheus)
-- [ ] Guard once, at the point every path funnels through; delete the two partial guards
-- [ ] A test feeds NaN through each of the four entry points and asserts the window survives
+- [x] The guard exists in the wasm driver and at two emitters, and **not** in `MetricSet::record` — the canonical sibling-miss — **fixed**: `MetricSet::record` + `MetricsCollector::record`/`record_batch` drop non-finite before any arithmetic or `forward_to_sink`; the two bridge-level guards removed — one guard at the primary path
+- [x] A single NaN/Inf sample poisons a whole flush window across three outputs (`influxdb.rs:232`, `statsd.rs`, Prometheus) — **fixed**: `MetricsCollector::record`/`record_batch` filter before `forward_to_sink`, streaming outputs never receive NaN/Inf
+- [x] Guard once, at the point every path funnels through; delete the two partial guards — wasm + k6 driver guards removed; collector guards the funnel
+- [x] A test feeds NaN through each of the four entry points and asserts the window survives — `MetricSet::record` drops NaN/Inf (Trend/Counter/Rate) in `collector::test_record_drops_non_finite_values`; k6 bridge → collector in `test_custom_metric_add_drops_non_finite_values`; wasm bridge → buffer in `test_non_finite_metric_reaches_buffer`
 
 ## TR-121 · Transport failures emit no `http_req_duration`
 **Effort:** M · **Blocked by:** none · **Also k6 parity — see TR-203**


### PR DESCRIPTION
## What

Moves the NaN/Inf guard to the canonical primary path. The guard existed in the wasm and k6 driver bridges (two partial guards) but NOT at `MetricsCollector::record`/`record_batch`, which call `forward_to_sink` BEFORE the aggregator — so a NaN/Inf sample poisoned streaming outputs (influxdb/statsd/prometheus) even after `MetricSet::record` was guarded. Now the collector guards once, before the aggregator AND before the streaming outputs, and the two bridge-level guards are deleted.

## Task

TR-120 · No NaN/Inf guard on the primary path (W1 Track C — aggregation correctness).

## Acceptance

- [x] The guard exists in the wasm driver and at two emitters, and **not** in `MetricSet::record` — fixed: `MetricSet::record` + `MetricsCollector::record`/`record_batch` drop non-finite
- [x] A single NaN/Inf sample poisons a whole flush window across three outputs — fixed: `record`/`record_batch` filter before `forward_to_sink`
- [x] Guard once, at the point every path funnels through; delete the two partial guards — wasm + k6 driver guards removed
- [x] A test feeds NaN through each of the four entry points and asserts the window survives

## Tests

- `metrics::test_record_drops_non_finite_values` — `MetricSet::record` rejects NaN/Inf/±Inf for Trend/Counter/Rate: count/sum untouched, mean stays finite
- `k6::test_custom_metric_add_drops_non_finite_values` — rewritten: the buffer carries both samples (bridge guard gone), feeding through the real `MetricsCollector` yields count=1, mean=42.0, sum=1.0 — window survives
- `wasm::test_non_finite_metric_reaches_buffer` — the wasm bridge forwards NaN to the buffer (guard at collector)
- Full suites: metrics 100, k6 158, wasm 32 all pass; clippy `-D warnings` clean; fmt clean

## Twin check

- Grepped every non-finite guard: `MetricSet::record` (canonical, kept), `MetricsCollector::record` (new), `MetricsCollector::record_batch` (new), wasm `metric_add_host` (deleted), k6 `custom_metric_add` (deleted). The collector `forward_to_sink` path was the unguarded funnel — now filtered before both the aggregator and the streaming outputs.

## Evidence

- ✅EXEC: `cargo test -p tropel-metrics` (100), `-p tropel-input-k6` (158), `-p tropel-wasm` (32); clippy + fmt clean

## Risk

- Removing the bridge guards means NaN/Inf samples now travel to the per-iteration buffer and get dropped at the collector — a negligible perf cost (the check is one `is_finite()` at a single funnel point) and a correctness win (all paths funnel through the same guard). No behavior change for valid samples.
