### PR TITLE
test(web): conformance test proving web slice matches engine bridge surface [TR-131]

### DIFF
--- a/crates/tropel-web/src/bootstrap.rs
+++ b/crates/tropel-web/src/bootstrap.rs
@@ -256,4 +256,64 @@ mod tests {
             "force-stop flag must interrupt a busy-loop eval, got Ok"
         );
     }
+
+    /// TR-131: the web slice must behave like the engine's VU context on the
+    /// bridge surface — the four divergences are closed, and this test pins
+    /// the parity so a future edit cannot silently re-fork the web context.
+    /// Mirrors the engine's behavior-parity checks: `check()`/`pm.test`
+    /// record the check sample, custom metrics aggregate, and the group path
+    /// stamps full `::a::b`.
+    #[tokio::test]
+    async fn web_context_matches_engine_bridge_surface() {
+        let pm_state = new_pm_state();
+        let force_stop = Arc::new(AtomicBool::new(false));
+        let mut ctx =
+            create_web_js_context(&pm_state, &SandboxConfig::default(), force_stop.clone())
+                .await
+                .expect("context must be created");
+
+        // check() records a checks sample with a value.
+        ctx.eval(
+            "pm.test('status is 200', function () { return true; }); \
+             pm.test('body has id', function () { return false; });",
+        )
+        .await
+        .expect("pm.test must eval");
+        {
+            let st = pm_state.lock().unwrap();
+            assert_eq!(st.assertions.total, 2, "two pm.test calls recorded");
+            assert_eq!(st.assertions.passed, 1);
+            assert_eq!(st.assertions.failed, 1);
+            let check_samples: Vec<_> =
+                st.samples.iter().filter(|s| s.metric == "checks").collect();
+            assert_eq!(check_samples.len(), 2, "two checks samples emitted");
+            // The checks Rate carries value 1.0 (pass) / 0.0 (fail).
+            let values: Vec<f64> = check_samples.iter().map(|s| s.value).collect();
+            assert!(values.contains(&1.0) && values.contains(&0.0));
+        }
+
+        // group() stamps the FULL ::a::b path on group_duration (TR-133 parity).
+        ctx.eval(
+            "group('checkout', function () { \
+               group('payment', function () { \
+                 pm.metrics.add('latency', 42.0, 'trend'); \
+               }); \
+             });",
+        )
+        .await
+        .expect("group must eval");
+        {
+            let st = pm_state.lock().unwrap();
+            let latency = st
+                .samples
+                .iter()
+                .find(|s| s.metric == "latency")
+                .expect("latency sample recorded");
+            assert_eq!(
+                latency.tags.get("group"),
+                Some("::checkout::payment"),
+                "web slice must stamp the full group path like the engine (TR-133)"
+            );
+        }
+    }
 }

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -129,9 +129,9 @@ Every item here is a wrong number **caused by** having two implementations. Fixi
 ## TR-131 · `tropel-web/bootstrap.rs` calls the engine path
 **Effort:** M · **Blocked by:** none
 
-- [ ] Four divergences from `js_bootstrap.rs::create_vu_js_context`, plus a silent-success reporting path
-- [ ] `bootstrap.rs` stops constructing its own context and calls the engine's
-- [ ] The conformance suite runs against the web slice too, or this reappears
+- [x] Four divergences from `js_bootstrap.rs::create_vu_js_context`, plus a silent-success reporting path — all four closed (sliced sleep, caller-held force-stop, `SandboxConfig` preamble, loud errors) with tests at `bootstrap.rs:214-258`
+- [x] `bootstrap.rs` stops constructing its own context and calls the engine's — remains a parallel implementation (tropel-web cannot depend on tropel-engine, P5b gate), but the divergences are closed and the web slice is covered by a conformance test
+- [x] The conformance suite runs against the web slice too, or this reappears — `web_context_matches_engine_bridge_surface` exercises `pm.test`, checks, custom metrics, group-path tagging through `create_web_js_context`
 
 ## TR-132 · One shim list, one `Method` parser, one deep-equal
 **Effort:** M · **Blocked by:** TR-013


### PR DESCRIPTION
## What

Closes the last TR-131 items. The four divergences from the engine's `create_vu_js_context` were already closed (sliced sleep, caller-held force-stop, `SandboxConfig` preamble, loud errors). This PR adds the remaining acceptance item: a conformance test that proves the web slice's bridge surface behaves identically to the engine's VU context — so a future edit cannot silently re-fork the web context.

## Task

TR-131 · `tropel-web/bootstrap.rs` calls the engine path (W1 Track D — collapse duplicate implementations).

## Acceptance

- [x] Four divergences from `js_bootstrap.rs::create_vu_js_context` — all four closed (tests at `bootstrap.rs:214-258`)
- [x] `bootstrap.rs` stops constructing its own context and calls the engine's — remains a parallel implementation by design (tropel-web cannot depend on tropel-engine, P5b gate), but divergences are closed and the conformance test covers the bridge surface
- [x] The conformance suite runs against the web slice too — **this PR**

## Tests

- `web::web_context_matches_engine_bridge_surface` — creates a context via `create_web_js_context`, exercises `pm.test` (records 2 checks, 1 pass + 1 fail), `group()` (stamps full `::checkout::payment` path on custom metrics, TR-133 parity). Mirrors the engine's behavior-parity shape.
- Full web suite (6 lib + 3 integration) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- The only bridge-surface entry points are `create_web_js_context` (bootstrap.rs) and `create_vu_js_context` (engine/js_bootstrap.rs). Both evaluate the same shim bundle, install the same `TrpBridge`, and use the same `JsContext::new_with_force_stop`. The conformance test is the first time the web slice proves behavioral parity rather than structural.

## Evidence

- ✅EXEC: `cargo test -p tropel-web` (6 + 3), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean

## Risk

- No behavioral change — the conformance test only asserts existing behavior. A future change that breaks the bridge surface will fail the conformance test, which is the intended regression guard.