### PR TITLE
fix(thresholds): support k6's === strict-equality operator [TR-222]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/options.rs
+++ b/crates/inputs/tropel-input-k6/src/options.rs
@@ -559,7 +559,7 @@ fn translate_k6_clause(metric: &str, expr: &str) -> String {
     // silently passed (fail-open gate). `value` is k6's Gauge stat (backlog
     // line 121) and maps onto the evaluator's `.value`.
     let re = Regex::new(
-        r"^\s*(p\(\d+(?:\.\d+)?\)|avg|med|min|max|count|sum|rate|value)\s*(<=|>=|==|!=|<|>)\s*(-?\d+(?:\.\d+)?)\s*$",
+        r"^\s*(p\(\d+(?:\.\d+)?\)|avg|med|min|max|count|sum|rate|value)\s*(<=|>=|===|==|!=|<|>)\s*(-?\d+(?:\.\d+)?)\s*$",
     )
     .expect("threshold translation regex is valid");
     if let Some(caps) = re.captures(expr) {
@@ -882,6 +882,15 @@ mod tests {
         // Durations are ms end-to-end (backlog §0): 1.5 ms stays 1.5.
         let expr = translate_k6_expression("http_req_duration", "avg<1.5");
         assert_eq!(expr, "http_req_duration.avg < 1.5");
+    }
+
+    #[test]
+    fn test_threshold_strict_equals_translated() {
+        // TR-222: k6's `===` operator must translate like `==` — the old
+        // regex only accepted `==`, so a valid k6 threshold `value === 1`
+        // aborted the run at startup.
+        let expr = translate_k6_expression("my_gauge", "value === 1");
+        assert_eq!(expr, "my_gauge.value === 1");
     }
 
     #[test]

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -82,7 +82,7 @@ pub fn validate_thresholds(thresholds: &HashMap<String, ThresholdConfig>) -> Res
                     parts.len()
                 ));
             }
-            if !matches!(parts[1], "<" | "<=" | ">" | ">=" | "==" | "!=") {
+            if !matches!(parts[1], "<" | "<=" | ">" | ">=" | "==" | "!=" | "===") {
                 return Err(format!(
                     "threshold '{}': unknown operator '{}' in clause '{}' of '{}'",
                     name, parts[1], clause, expr
@@ -504,7 +504,7 @@ fn evaluate_single_threshold_opt(
         "<=" => actual <= threshold,
         ">" => actual > threshold,
         ">=" => actual >= threshold,
-        "==" => (actual - threshold).abs() < f64::EPSILON,
+        "==" | "===" => (actual - threshold).abs() < f64::EPSILON,
         "!=" => (actual - threshold).abs() > f64::EPSILON,
         _ => {
             tracing::error!(
@@ -1697,6 +1697,46 @@ mod tests {
             abort_config("http_req_duration.value < 500", false, None),
         );
         assert!(validate_thresholds(&ok).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_strict_equals_operator() {
+        // TR-222: k6 supports `===` (strict equality) as a threshold operator.
+        // The old validator whitelist rejected it, so `value === 1` aborted at
+        // startup.
+        let mut thresholds = HashMap::new();
+        thresholds.insert(
+            "a".to_string(),
+            abort_config("my_gauge.value === 1", false, None),
+        );
+        assert!(
+            validate_thresholds(&thresholds).is_ok(),
+            "=== must be a valid operator"
+        );
+        // Evaluation: `===` uses the same epsilon comparison as `==`.
+        let mut metrics = make_metrics();
+        // Inject a gauge series with last=1.0.
+        metrics.metrics.push(MetricSummary {
+            key: "my_gauge".into(),
+            tags: vec![],
+            metric_type: MetricType::Gauge,
+            count: 1,
+            sum: 1.0,
+            mean: 1.0,
+            min: 1.0,
+            max: 1.0,
+            p50: 0.0,
+            p90: 0.0,
+            p95: 0.0,
+            p99: 0.0,
+            last: 1.0,
+            rate: 0.0,
+            histogram: None,
+        });
+        let result = evaluate_single_threshold("my_gauge.value === 1", &metrics);
+        assert!(result.0, "1.0 === 1.0 must pass");
+        let result = evaluate_single_threshold("my_gauge.value === 2", &metrics);
+        assert!(!result.0, "1.0 === 2.0 must fail");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds k6's `===` (strict equality) threshold operator. k6's grammar includes it; tropel's validator whitelist and k6 translator regex only accepted `==`, so a valid k6 threshold like `my_gauge.value === 1` aborted the run at startup — a [SILENT] gap.

## Task

TR-222 · Thresholds — grammar, semantics, and the units model (W2 Track C). This closes the `===` sub-item.

## Acceptance

- [x] `value` (Gauge-only) — already fixed
- [x] `===` — **this PR** (translator regex, validator whitelist, evaluator)
- [x] Compound `&&`/`||` translate — already fixed
- [x] Counter `rate` per-second — already fixed
- [x] Unknown stat = startup error — already fixed
- [x] Tag-scoped thresholds match — already fixed

## Tests

- `options::test_threshold_strict_equals_translated` — `value === 1` → `my_gauge.value === 1`
- `metrics::validate_accepts_strict_equals_operator` — validation passes; evaluation: `1.0 === 1.0` passes, `1.0 === 2.0` fails
- Full suites: metrics 101, k6 159 pass; clippy `-D warnings` clean; fmt clean

## Twin check

- Grepped every operator list: `validate_thresholds` whitelist (thresholds.rs:85), the evaluator's `match operator` (thresholds.rs:502), and the k6 translator regex (options.rs:561). All three now accept `===` — the validator, the translator, and the evaluator were the three places a new operator must land.

## Evidence

- ✅EXEC: `cargo test -p tropel-metrics validate_accepts_strict_equals_operator` (1), `cargo test -p tropel-input-k6 test_threshold_strict_equals` (1), full suites green, clippy + fmt clean

## Risk

- `===` evaluates identically to `==` (epsilon float comparison). k6's `===` on floats is likewise an exact-value comparison after the metric aggregates; no semantic distinction is lost for the metrics model.
