### PR TITLE
fix(k6): set res.body to null for 1xx/204/304 status codes [TR-231]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1726,6 +1726,14 @@ fn build_k6_response_object<'js>(
             None => Err(rquickjs::Error::Exception),
         };
     }
+    // TR-231: k6 sets `body` to null for 1xx/204/304 regardless of
+    // `responseType` (a status code with no body by HTTP semantics). The
+    // common `.json()` crash when porting: `res.json()` on a 204/304 must
+    // fail loudly, not return undefined-from-empty-string.
+    if (100..200).contains(&code) || code == 204 || code == 304 {
+        let _ = obj.set("body", rquickjs::Value::new_null(ctx.clone()));
+        return Ok(obj);
+    }
     if response_type.eq_ignore_ascii_case("binary") {
         // In-between sizes (under the cap) try the ArrayBuffer and fall back
         // to the envelope on failure.
@@ -10624,6 +10632,63 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
                 body.as_object().is_some_and(|o| o.is_array_buffer()),
                 "binary degradation must keep an ArrayBuffer body, got: {body:?}"
             );
+        });
+    }
+
+    /// TR-231: k6 sets `res.body` to null for 1xx/204/304 regardless of
+    /// `responseType` (HTTP statuses with no body). The old code always set a
+    /// String/ArrayBuffer body, so `res.json()` on a 204/304 returned
+    /// undefined-from-empty-string instead of failing loudly — the common
+    /// `.json()` crash when porting a k6 script.
+    #[test]
+    fn test_body_is_null_for_no_content_statuses() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            for (code, status_text) in [
+                (100, "Continue"),
+                (204, "No Content"),
+                (304, "Not Modified"),
+            ] {
+                let resp = build_k6_response_object(
+                    &ctx,
+                    code,
+                    status_text.to_string(),
+                    b"should-be-null".to_vec(),
+                    &HashMap::new(),
+                    1.0,
+                    None,
+                    "",
+                    0,
+                    "text",
+                    &[],
+                    "HTTP/1.1",
+                )
+                .expect("response object must build");
+                let body: rquickjs::Value = resp.get("body").unwrap();
+                assert!(
+                    body.is_null(),
+                    "status {code} must have null body, got: {body:?}"
+                );
+            }
+            // A 200 still carries the body.
+            let resp = build_k6_response_object(
+                &ctx,
+                200,
+                "OK".to_string(),
+                b"hello".to_vec(),
+                &HashMap::new(),
+                1.0,
+                None,
+                "",
+                0,
+                "text",
+                &[],
+                "HTTP/1.1",
+            )
+            .expect("response object must build");
+            let body: String = resp.get("body").unwrap();
+            assert_eq!(body, "hello", "200 must keep its body");
         });
     }
 

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -177,13 +177,13 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 
 **[GAP]** Missing: `res.cookies`, `res.request`, `res.error`, `res.error_code`, `res.remote_ip`/`remote_port`, `res.proto`, `res.tls_*`, `res.ocsp`, `res.html()`, `res.submitForm()`, `res.clickLink()`, `timings.looking_up`.
 
-- [ ] `status` is **0 on transport error**
-- [ ] `body` is **`null` for 1xx/204/304 regardless of `responseType`** — the common `.json()` crash when porting
+- [x] `status` is **0 on transport error**
+- [x] `body` is **`null` for 1xx/204/304 regardless of `responseType`** — the common `.json()` crash when porting (test `test_body_is_null_for_no_content_statuses`)
 - [ ] `headers` use Go-canonical MIME keys, multi-values **`", "`-joined into one string**; `request.headers` values are **arrays**, unlike `res.headers`
 - [ ] `cookies` shape `{name: [{name,value,domain,path,http_only,secure,max_age,expires}]}`, `expires` in **Unix ms**
-- [ ] `request` is **pre-flight, first hop only**
+- [x] `request` is **pre-flight, first hop only**
 - [ ] `json(selector?)` uses **gjson** paths, not JSONPath. The no-selector form **throws** with a line/char annotation and caches; the selector form returns **`undefined`** on bad JSON or a missing path
-- [ ] `timings.looking_up` is declared by k6 and **never assigned** — emit 0 for byte-compat
+- [x] `timings.looking_up` is declared by k6 and **never assigned** — emit 0 for byte-compat
 
 ## TR-232 · `http.file()` and multipart
 **Effort:** M · **Blocked by:** TR-230


### PR DESCRIPTION
## What

k6 sets `res.body` to **null** for HTTP statuses with no body (1xx/204/304) regardless of `responseType`. Tropel always set a String or ArrayBuffer body, so `res.json()` on a 204/304 returned `undefined`-from-empty-string instead of failing loudly — the common `.json()` crash when porting a k6 script. This PR adds the null-body guard.

## Task

TR-231 · `Response` — the missing members (W2 Track D). Closes the `body` null-for-no-content sub-item; also ticks the audit-verified `status=0` and `timings.looking_up=0` siblings.

## Acceptance

- [x] `status` is 0 on transport error — already fixed (k6_error_envelope)
- [x] `body` is **null for 1xx/204/304 regardless of `responseType`** — **this PR**
- [x] `request` is pre-flight, first hop only — already fixed
- [x] `timings.looking_up` declared, never assigned — already emits 0

## Tests

- `k6::test_body_is_null_for_no_content_statuses` — `build_k6_response_object` with status 100/204/304 returns a null body; status 200 keeps its body. Would have failed on the pre-fix code (all statuses got a body string).
- Full k6 driver suite (161) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- Grepped every response-body construction: `build_k6_response_object` (k6 driver, fixed), `k6_error_envelope` (status-0 envelope — body already ArrayBuffer-empty per its contract, and status 0 is not in the 1xx/204/304 range so it is unaffected), the declarative runner's `pm.response` (sandbox path — separate, status-0 on error). The k6 success path was the only one returning a body for no-content statuses.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (161), clippy + fmt clean

## Risk

- A script that read `res.body` on a 204/304 previously got `""`; it now gets `null` (k6 parity). Code doing `res.body.length` on a 204 now throws on null — which is the intended parity (k6 does the same); the `.json()` crash becomes a loud, debuggable failure instead of silent `undefined`.
