### PR TITLE
fix(engine): vus/vus_max sampler cadence 2s to 1s (k6 parity) [TR-211]

### DIFF
--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -596,8 +596,8 @@ where
     dropped_sampler.abort();
 
     // Emit a guaranteed final vus/vus_max sample. The single scheduler-wide
-    // sampler runs on a 2s cadence (backlog line 165), so a run shorter than
-    // 2s would otherwise emit only the t=0 sample and the summary could read
+    // sampler runs on a 1s cadence (k6 parity, TR-211), so a run shorter than
+    // 1s would otherwise emit only the t=0 sample and the summary could read
     // a stale vus: 0. The active count uses the LAST KNOWN sampled value (not
     // 0) so the vus gauge's `last` reflects real concurrency (backlog line
     // 154).
@@ -1264,9 +1264,10 @@ async fn vus_sampler_task(
     last_active_vus: Arc<AtomicU32>,
     sc_tags: HashMap<String, String>,
 ) {
-    // First tick fires immediately, then every 2s — so a run shorter than
-    // the cadence still gets one sample (plus the final one after the run).
-    let mut ticker = tokio::time::interval(Duration::from_secs(2));
+    // First tick fires immediately, then every 1s (k6 parity — k6 samples
+    // vus/vus_max once per second, TR-211), so a run shorter than the
+    // cadence still gets one sample (plus the final one after the run).
+    let mut ticker = tokio::time::interval(Duration::from_secs(1));
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         ticker.tick().await;
@@ -1386,14 +1387,14 @@ mod tests {
     /// 1000 VUs used to emit ~1000 duplicate `record_batch` calls per 2s
     /// floor, corrupting the gauge's min/max/avg. Run the single sampler for
     /// ~2.3 real seconds and assert the sample count stays small (t=0 +
-    /// t=2s = ~2) REGARDLESS of the VU count — the old per-VU trigger would
-    /// have produced ~1000. Real time (not paused) so the spawned task and
-    /// the metrics aggregator actually get polled.
+    /// t=1s + t=2s = ~3) REGARDLESS of the VU count — the old per-VU trigger
+    /// would have produced ~1000. Real time (not paused) so the spawned task
+    /// and the metrics aggregator actually get polled.
     #[tokio::test]
     async fn vus_sampler_emits_bounded_cadence_not_per_vu() {
         let metrics = Arc::new(MetricsCollector::new());
         // 1000 VUs would have produced ~1000 samples per 2s floor under the
-        // old per-VU trigger; the single sampler must stay at ~2.
+        // old per-VU trigger; the single sampler must stay at ~3.
         let sched = Arc::new(VUScheduler::new(&ExecutionConfig::ConstantVus {
             vus: 1000,
             duration: "10s".to_string(),
@@ -1408,7 +1409,8 @@ mod tests {
             last_active.clone(),
             tags,
         ));
-        // t=0 tick fires immediately, then every 2s — ~2 samples in 2.3s.
+        // t=0 tick fires immediately, then every 1s (k6 parity, TR-211) —
+        // ~3 samples in 2.3s.
         tokio::time::sleep(Duration::from_millis(2300)).await;
         task.abort();
         let _ = task.await;

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -102,7 +102,7 @@ Tropel emits the **InfluxDB point shape** (`data.measurement`, `data.fields.valu
 ## TR-211 · `vus` / `vus_max` are scheduler-sampled once per second
 **Effort:** S · **Blocked by:** none
 
-**[SILENT]** Tropel has every VU emit its own pair every 100 iterations — **~1000 duplicate samples/s at 1000 VUs**, which is both wrong and a measurable egress cost.
+- [x] **[SILENT]** Tropel has every VU emit its own pair every 100 iterations — **~1000 duplicate samples/s at 1000 VUs**, which is both wrong and a measurable egress cost — **fixed**: a single scheduler-wide sampler task (landed) now runs on a **1s cadence** (k6 parity) — the old 2s cadence was off by one floor
 
 ## TR-212 · `systemTags` and the indexable/metadata split
 **Effort:** M · **Blocked by:** TR-204, TR-207


### PR DESCRIPTION
## What

k6 samples the `vus`/`vus_max` gauges once per second. The scheduler-wide sampler task that replaced the per-VU sample storm still ran on a **2 s** cadence — one floor off k6's. This PR changes it to **1 s**.

## Task

TR-211 · `vus`/`vus_max` are scheduler-sampled once per second (W2 Track B — the metric and tag contract).

## Acceptance

- [x] No per-VU vus/vus_max emission — already fixed (single scheduler-wide sampler)
- [x] Cadence is **once per second** — **this PR** (2s → 1s)

## Tests

- `engine::vus_sampler_emits_bounded_cadence_not_per_vu` — still passes: ~3 samples in 2.3s (t=0,1,2), under the `<= 4` bound; the 1000-VU storm case would still produce ~1000.
- clippy `-D warnings` clean; fmt clean.

## Twin check

- Grepped every sampler cadence: `vus_sampler_task` (changed to 1s), `dropped_sampler_task` (2s — k6 emits dropped_iterations on its own cadence, not tied to vus; unchanged). The final-sample comment referenced the 2s cadence; updated to 1s.

## Evidence

- ✅EXEC: `cargo test -p tropel-engine vus_sampler_emits_bounded_cadence_not_per_vu` (1 passed), clippy + fmt clean

## Risk

- Doubles the vus/vus_max sample rate (2 samples/s → 1/s per metric pair for the whole run) — an egress increase of ~2 extra tiny records per second, negligible against the pre-fix per-VU storm this task already eliminated.
