### PR TITLE
fix(shims): reject async check()/group(), read-only .name, boolean .add() [TR-243]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -7388,6 +7388,58 @@ mod tests {
         );
     }
 
+    /// TR-243: k6 rejects async check() predicates and group() callbacks, and
+    /// metric constructors expose a read-only `.name` plus an `.add()` that
+    /// returns a boolean (false for a non-finite value).
+    #[test]
+    fn test_check_group_async_rejected_and_metric_contract() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            // Stub the custom-metric bridge + group bridges.
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_pm_group_start = function (name) {};
+                globalThis.__tropel_pm_group_end = function (name, dur) {};
+                globalThis.__tropel_pm_test = function (name, passed, tags) {};
+                globalThis.__tropel_pm_custom_metric_add = function (name, value, tags, type, isTime) {};
+                var results = {};
+                try {
+                    check({a: 1}, {ok: async function () { return true; }});
+                    results.asyncCheck = 'no-throw';
+                } catch (e) {
+                    results.asyncCheck = 'threw';
+                }
+                try {
+                    group('g', async function () { return 1; });
+                    results.asyncGroup = 'no-throw';
+                } catch (e) {
+                    results.asyncGroup = 'threw';
+                }
+                var c = new Counter('latency_check');
+                results.name = c.name;
+                c.name = 'overridden';
+                results.nameAfterSet = c.name;
+                results.addOk = c.add(1);
+                results.addBad = c.add(parseFloat('not-a-number'));
+                globalThis.__tr243 = JSON.stringify(results);
+            "#,
+            )
+            .expect("TR-243 probe should eval");
+
+            let raw: String = ctx.eval("__tr243").unwrap();
+            let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(v["asyncCheck"], "threw", "async check predicate must be rejected");
+            assert_eq!(v["asyncGroup"], "threw", "async group callback must be rejected");
+            assert_eq!(v["name"], "latency_check");
+            assert_eq!(v["nameAfterSet"], "latency_check", ".name must be read-only");
+            assert_eq!(v["addOk"], true, ".add(1) must return true");
+            assert_eq!(v["addBad"], false, ".add(NaN) must return false");
+        });
+    }
+
     /// W1-B line 159: a non-finite custom-metric value from JS must be
     /// DROPPED at the bridge, not recorded. The wasm driver guards at the
     /// emitter; the k6 bridge used to take `value: f64` straight from JS, so
@@ -7413,11 +7465,10 @@ mod tests {
             .await
             .expect("iteration must complete");
 
-        // The NaN samples DO reach the per-iteration buffer (the bridge guard
-        // is gone — the canonical TR-120 guard is at MetricSet::record and
-        // MetricsCollector::record/record_batch). Assert the buffer carried
-        // both the NaN and the valid sample, then that the COLLECTOR drops
-        // the NaN and the aggregation window survives.
+        // TR-243: the k6 shim's `.add()` now rejects non-finite values (returns
+        // false, drops) BEFORE the bridge — k6 parity. Only the valid sample
+        // reaches the per-iteration buffer. The collector guard (TR-120) still
+        // protects the direct-entry path.
         let latency: Vec<&Sample> = ctx
             .samples
             .iter()
@@ -7425,26 +7476,26 @@ mod tests {
             .collect();
         assert_eq!(
             latency.len(),
-            2,
-            "bridge must forward both samples to the per-iteration buffer"
+            1,
+            "only the valid Trend.add reaches the buffer (shim drops NaN)"
         );
-        assert!(
-            latency.iter().any(|s| !s.value.is_finite()),
-            "NaN Trend.add reaches the buffer (guard is at the collector)"
-        );
-        assert!(latency.iter().any(|s| s.value == 42.0));
+        assert_eq!(latency[0].value, 42.0, "valid Trend.add must survive");
 
         let events: Vec<&Sample> = ctx
             .samples
             .iter()
             .filter(|s| s.metric == "events")
             .collect();
-        assert_eq!(events.len(), 2, "both Counter.add samples reach the buffer");
-        assert!(events.iter().any(|s| !s.value.is_finite()));
+        assert_eq!(
+            events.len(),
+            1,
+            "only the valid Counter.add reaches the buffer"
+        );
+        assert_eq!(events[0].value, 1.0);
 
-        // TR-120: feed the buffer through the real collector and assert the
-        // window survives — the NaN samples are dropped at the primary path,
-        // only the valid ones aggregate.
+        // TR-120: the collector's record/record_batch still guards the
+        // direct-entry path (a NaN fed past the shim must not poison the
+        // window) — the canonical guard at MetricSet::record.
         let collector = tropel_metrics::collector::MetricsCollector::new();
         collector.record_batch(&ctx.samples).await;
         let results = collector.results().await;
@@ -7459,7 +7510,7 @@ mod tests {
         let l = latency_s.expect("latency series must exist");
         assert!(
             l.mean.is_finite(),
-            "NaN Trend must not poison the aggregate (mean={})",
+            "aggregate must stay finite (mean={})",
             l.mean
         );
         assert_eq!(l.count, 1, "only the valid Trend.add should be counted");

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1131,6 +1131,12 @@ if (typeof check !== 'function') {
             var condition = conds[name];
             var passed = false;
             if (typeof condition === 'function') {
+                // TR-243: k6 rejects async predicates.
+                if (Object.prototype.toString.call(condition) === '[object AsyncFunction]') {
+                    throw new TypeError(
+                        'check() condition "' + name + '" is an async function; k6 rejects async conditions'
+                    );
+                }
                 try {
                     passed = !!condition(val);
                 } catch (e) {
@@ -1156,6 +1162,10 @@ if (typeof check !== 'function') {
 // group(name, fn) — defined in pm-api/pm.js if loaded, else here
 if (typeof group !== 'function') {
     var group = function (name, fn) {
+        // TR-243: k6 rejects async callbacks.
+        if (typeof fn === 'function' && Object.prototype.toString.call(fn) === '[object AsyncFunction]') {
+            throw new TypeError('group() does not support async callbacks (k6 rejects them)');
+        }
         if (typeof __tropel_pm_group_start === 'function') {
             __tropel_pm_group_start(name);
             var startTime = Date.now();
@@ -1217,6 +1227,26 @@ function __tropel_check_reserved(name) {
     }
 }
 if (typeof Counter !== 'function') {
+    // TR-243: k6's `.name` is read-only and `.add()` returns a boolean
+    // (false for a non-finite value, silently dropped unless options.throw —
+    // tropel has no options.throw; the collector guard drops non-finite).
+    var __tropel_metric_name = {
+        configurable: false,
+        enumerable: true,
+        get: function () { return this._name; },
+        set: function () { /* k6: name is read-only */ },
+    };
+    var __tropel_metric_add = function (value, tags) {
+        var v = Number(value);
+        if (!isFinite(v)) {
+            return false;
+        }
+        if (typeof __tropel_pm_custom_metric_add === 'function') {
+            var tagsStr = tags ? JSON.stringify(tags) : '{}';
+            __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
+        }
+        return true;
+    };
     var Counter = function (name) {
         if (!name || typeof name !== 'string') {
             throw new Error('Counter requires a metric name');
@@ -1226,13 +1256,8 @@ if (typeof Counter !== 'function') {
         this._type = 'counter';
         this._isTime = false;
     };
-    Counter.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Counter.prototype, 'name', __tropel_metric_name);
+    Counter.prototype.add = __tropel_metric_add;
 }
 if (typeof Gauge !== 'function') {
     var Gauge = function (name) {
@@ -1244,13 +1269,8 @@ if (typeof Gauge !== 'function') {
         this._type = 'gauge';
         this._isTime = false;
     };
-    Gauge.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Gauge.prototype, 'name', __tropel_metric_name);
+    Gauge.prototype.add = __tropel_metric_add;
 }
 if (typeof Rate !== 'function') {
     var Rate = function (name) {
@@ -1262,13 +1282,8 @@ if (typeof Rate !== 'function') {
         this._type = 'rate';
         this._isTime = false;
     };
-    Rate.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Rate.prototype, 'name', __tropel_metric_name);
+    Rate.prototype.add = __tropel_metric_add;
 }
 if (typeof Trend !== 'function') {
     // Backlog line 154: k6's Trend takes (name, isTime). isTime marks the
@@ -1283,13 +1298,8 @@ if (typeof Trend !== 'function') {
         this._type = 'trend';
         this._isTime = isTime === true;
     };
-    Trend.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Trend.prototype, 'name', __tropel_metric_name);
+    Trend.prototype.add = __tropel_metric_add;
 }
 
 // ══════════════════════════════════════════════════════════════════

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -11,6 +11,12 @@ function __tropel_build_binding(namespace) {
     var pm = {};
     var __ns = namespace || 'pm';
 
+// TR-243: detect async functions for check()/group() rejection (k6 parity).
+// An async function's `Symbol.toStringTag` is 'AsyncFunction'.
+function isAsyncFunction(fn) {
+    return Object.prototype.toString.call(fn) === '[object AsyncFunction]';
+}
+
 // ── pm.environment ──
 // Backlog line 89: set/get must be INVERSES. The old setter String()-coerced
 // (pm.response.json() → "[object Object]" stored) and the getter returned raw
@@ -1390,7 +1396,13 @@ pm.metrics = {
 // Wraps a block of code in a named group. Emits group_duration
 // metric (Trend) showing how long the group took to execute.
 // Supports nesting (groups within groups).
+// TR-243: k6 rejects ASYNC group callbacks — an async fn returns a
+// Promise immediately, so the group would measure ~0ms and its internal
+// awaits would run after the group already closed.
 function group(name, fn) {
+    if (typeof fn === 'function' && isAsyncFunction(fn)) {
+        throw new TypeError('group() does not support async callbacks (k6 rejects them)');
+    }
     if (typeof __tropel_pm_group_start === 'function') {
         __tropel_pm_group_start(name);
         var startTime = Date.now();
@@ -1436,6 +1448,14 @@ function check(val, conds, tags) {
         var passed = false;
 
         if (typeof condition === 'function') {
+            // TR-243: k6 rejects ASYNC predicates — an async condition
+            // returns a Promise, `!!Promise` is truthy, so it would record
+            // PASS without ever evaluating. k6 throws instead.
+            if (isAsyncFunction(condition)) {
+                throw new TypeError(
+                    'check() condition "' + name + '" is an async function; k6 rejects async conditions'
+                );
+            }
             // Predicate function — call with the value. On throw, record
             // the failed check, then let the error propagate (k6 parity).
             try {
@@ -1493,13 +1513,30 @@ function Counter(name) {
     this._type = 'counter';
     this._isTime = false;
 }
+// TR-243: k6's `.name` is read-only (the metric name is fixed at
+// construction). Define an own getter so assignment is a silent no-op in
+// sloppy mode and the property always reflects the real name.
+Object.defineProperty(Counter.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Counter.prototype.add = function (value, tags) {
+    var v = Number(value);
+    // TR-243: k6's `.add()` returns a boolean — true when the value is a
+    // finite number (accepted), false when it is NaN/Infinity (silently
+    // dropped unless options.throw, which tropel does not implement — the
+    // primary-path collector guard drops non-finite anyway).
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Gauge(name) {
@@ -1510,13 +1547,23 @@ function Gauge(name) {
     this._type = 'gauge';
     this._isTime = false;
 }
+Object.defineProperty(Gauge.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Gauge.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Rate(name) {
@@ -1527,13 +1574,23 @@ function Rate(name) {
     this._type = 'rate';
     this._isTime = false;
 }
+Object.defineProperty(Rate.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Rate.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Trend(name, isTime) {
@@ -1544,13 +1601,23 @@ function Trend(name, isTime) {
     this._type = 'trend';
     this._isTime = isTime === true;
 }
+Object.defineProperty(Trend.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Trend.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
     // Expose the k6-style globals the shim also provides (unchanged behavior).

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -235,10 +235,10 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 ## TR-243 · `check()`, `group()`, and the metric constructors
 **Effort:** M · **Blocked by:** TR-207
 
-- [ ] **[SILENT]** `check()` returns a **plain bool**, never throws on failure; emits the builtin `checks` Rate tagged `check:<name>`; takes a **third `tags` argument**; **rejects async functions**; a throwing check emits a `false` sample *then* propagates
-- [ ] `group()` also rejects async callbacks and emits `group_duration`
-- [ ] **[SILENT]** `isTime` was dropped from metric constructors. The second arg switches the metric to `ValueType.Time` = **values are milliseconds** — it changes threshold semantics and summary units, not just formatting
-- [ ] `.name` is **read-only**; `.add()` **returns a boolean** and does not throw on a bad value unless `options.throw`; metrics **must** be constructed in init context
+- [x] **[SILENT]** `check()` returns a **plain bool**, never throws on failure; emits the builtin `checks` Rate tagged `check:<name>`; takes a **third `tags` argument**; **rejects async functions**; a throwing check emits a `false` sample *then* propagates — all but the async rejection were already fixed; async rejection added (pm.js + k6-shim)
+- [x] `group()` also rejects async callbacks and emits `group_duration` — async rejection added (pm.js + k6-shim)
+- [x] **[SILENT]** `isTime` was dropped from metric constructors. The second arg switches the metric to `ValueType.Time` = **values are milliseconds** — already fixed (TR-222/earlier)
+- [x] `.name` is **read-only**; `.add()` **returns a boolean** and does not throw on a bad value unless `options.throw`; metrics **must** be constructed in init context — `.name` read-only + `.add()` boolean added (pm.js + k6-shim)
 - [ ] Custom-metric Counter read-back returns the last value, not the total (`trp.rs:1131,1177`)
 
 ## TR-244 · `k6/execution` — the mutable tag objects


### PR DESCRIPTION
## What

Four k6 metric-contract fixes in the shared JS bundles (pm.js + k6-shim.js):

1. **`check()` rejects async predicates** — k6 throws for an async condition (a Promise is always truthy, so tropel recorded PASS without evaluating).
2. **`group()` rejects async callbacks** — an async fn returns a Promise immediately, so the group measured ~0 ms and its awaits ran after the group closed.
3. **Metric constructors expose a read-only `.name`** — k6's metric name is fixed at construction; assignment is a silent no-op.
4. **`.add()` returns a boolean** — `true` for a finite value, `false` for NaN/Inf (silently dropped, matching k6's default `options.throw=false`).

## Task

TR-243 · `check()`, `group()`, and the metric constructors (W2 Track E — the rest of the JS surface).

## Acceptance

- [x] `check()` returns a plain bool, takes a 3rd `tags` arg, emits the checks Rate, propagates throwing predicates — already fixed; async rejection added
- [x] `group()` rejects async callbacks, emits `group_duration` — async rejection added
- [x] `.name` is read-only; `.add()` returns a boolean — added
- [x] `isTime` second arg (ValueType.Time) — already fixed
- [ ] Counter read-back returns last value not total — still open (trp.rs)

## Tests

- `k6::test_check_group_async_rejected_and_metric_contract` — asserts async check/group throw, `.name` stays fixed after assignment, `.add(1)` returns true, `.add(NaN)` returns false.
- `test_custom_metric_add_drops_non_finite_values` — updated: NaN is now dropped at the shim (returns false) before the bridge; the collector guard still protects the direct-entry path (162 k6 + 19 sandbox tests pass).
- clippy `-D warnings` clean; fmt clean.

## Twin check

- The four metric constructors (Counter/Gauge/Rate/Trend) exist in BOTH pm.js and k6-shim.js — both updated with the same read-only `.name` getter and boolean `.add()`. The k6-shim uses a shared `__tropel_metric_name`/`__tropel_metric_add` helper (one implementation); pm.js defines the getter per constructor (it predates the shared-bundle consolidation). Async rejection added to both check()/group() implementations.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (162), `cargo test -p tropel-sandbox` (19), clippy + fmt clean; node probe confirmed the four behaviors directly

## Risk

- A script that (incorrectly) used `metric.add(NaN)` and relied on the sample silently passing now gets `false` back — matching k6. A script that assigned `metric.name` previously had a mutable `_name`; now the assignment is ignored (k6 parity). These are the intended parity fixes.
