### PR TITLE
merge: consolidate remaining W2 PRs (vus cadence, metric contract, path tokens)

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -7388,6 +7388,58 @@ mod tests {
         );
     }
 
+    /// TR-243: k6 rejects async check() predicates and group() callbacks, and
+    /// metric constructors expose a read-only `.name` plus an `.add()` that
+    /// returns a boolean (false for a non-finite value).
+    #[test]
+    fn test_check_group_async_rejected_and_metric_contract() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/scripting-api/pm.js"))
+                .expect("pm shim should eval");
+            // Stub the custom-metric bridge + group bridges.
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_pm_group_start = function (name) {};
+                globalThis.__tropel_pm_group_end = function (name, dur) {};
+                globalThis.__tropel_pm_test = function (name, passed, tags) {};
+                globalThis.__tropel_pm_custom_metric_add = function (name, value, tags, type, isTime) {};
+                var results = {};
+                try {
+                    check({a: 1}, {ok: async function () { return true; }});
+                    results.asyncCheck = 'no-throw';
+                } catch (e) {
+                    results.asyncCheck = 'threw';
+                }
+                try {
+                    group('g', async function () { return 1; });
+                    results.asyncGroup = 'no-throw';
+                } catch (e) {
+                    results.asyncGroup = 'threw';
+                }
+                var c = new Counter('latency_check');
+                results.name = c.name;
+                c.name = 'overridden';
+                results.nameAfterSet = c.name;
+                results.addOk = c.add(1);
+                results.addBad = c.add(parseFloat('not-a-number'));
+                globalThis.__tr243 = JSON.stringify(results);
+            "#,
+            )
+            .expect("TR-243 probe should eval");
+
+            let raw: String = ctx.eval("__tr243").unwrap();
+            let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(v["asyncCheck"], "threw", "async check predicate must be rejected");
+            assert_eq!(v["asyncGroup"], "threw", "async group callback must be rejected");
+            assert_eq!(v["name"], "latency_check");
+            assert_eq!(v["nameAfterSet"], "latency_check", ".name must be read-only");
+            assert_eq!(v["addOk"], true, ".add(1) must return true");
+            assert_eq!(v["addBad"], false, ".add(NaN) must return false");
+        });
+    }
+
     /// W1-B line 159: a non-finite custom-metric value from JS must be
     /// DROPPED at the bridge, not recorded. The wasm driver guards at the
     /// emitter; the k6 bridge used to take `value: f64` straight from JS, so
@@ -7413,11 +7465,10 @@ mod tests {
             .await
             .expect("iteration must complete");
 
-        // The NaN samples DO reach the per-iteration buffer (the bridge guard
-        // is gone — the canonical TR-120 guard is at MetricSet::record and
-        // MetricsCollector::record/record_batch). Assert the buffer carried
-        // both the NaN and the valid sample, then that the COLLECTOR drops
-        // the NaN and the aggregation window survives.
+        // TR-243: the k6 shim's `.add()` now rejects non-finite values (returns
+        // false, drops) BEFORE the bridge — k6 parity. Only the valid sample
+        // reaches the per-iteration buffer. The collector guard (TR-120) still
+        // protects the direct-entry path.
         let latency: Vec<&Sample> = ctx
             .samples
             .iter()
@@ -7425,26 +7476,26 @@ mod tests {
             .collect();
         assert_eq!(
             latency.len(),
-            2,
-            "bridge must forward both samples to the per-iteration buffer"
+            1,
+            "only the valid Trend.add reaches the buffer (shim drops NaN)"
         );
-        assert!(
-            latency.iter().any(|s| !s.value.is_finite()),
-            "NaN Trend.add reaches the buffer (guard is at the collector)"
-        );
-        assert!(latency.iter().any(|s| s.value == 42.0));
+        assert_eq!(latency[0].value, 42.0, "valid Trend.add must survive");
 
         let events: Vec<&Sample> = ctx
             .samples
             .iter()
             .filter(|s| s.metric == "events")
             .collect();
-        assert_eq!(events.len(), 2, "both Counter.add samples reach the buffer");
-        assert!(events.iter().any(|s| !s.value.is_finite()));
+        assert_eq!(
+            events.len(),
+            1,
+            "only the valid Counter.add reaches the buffer"
+        );
+        assert_eq!(events[0].value, 1.0);
 
-        // TR-120: feed the buffer through the real collector and assert the
-        // window survives — the NaN samples are dropped at the primary path,
-        // only the valid ones aggregate.
+        // TR-120: the collector's record/record_batch still guards the
+        // direct-entry path (a NaN fed past the shim must not poison the
+        // window) — the canonical guard at MetricSet::record.
         let collector = tropel_metrics::collector::MetricsCollector::new();
         collector.record_batch(&ctx.samples).await;
         let results = collector.results().await;
@@ -7459,7 +7510,7 @@ mod tests {
         let l = latency_s.expect("latency series must exist");
         assert!(
             l.mean.is_finite(),
-            "NaN Trend must not poison the aggregate (mean={})",
+            "aggregate must stay finite (mean={})",
             l.mean
         );
         assert_eq!(l.count, 1, "only the valid Trend.add should be counted");

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -367,7 +367,7 @@ fn build_url(detail: &RequestDetail) -> String {
         None => return String::new(),
     };
 
-    let mut result = if let Some(raw) = &url.raw {
+    let result = if let Some(raw) = &url.raw {
         if !raw.is_empty() {
             raw.clone()
         } else {
@@ -381,10 +381,14 @@ fn build_url(detail: &RequestDetail) -> String {
     // `url.variable` as `{key, value}` and referenced in the URL as `:key`
     // segments (e.g. `https://api.test/users/:id`). They were parsed and
     // never read — substitute each declared variable into the URL now.
-    // W2 #202: substitute in DESCENDING key-length order so a prefix
-    // variable can't eat a longer one. With an ordered replace,
-    // `/users/:user/posts/:userId` (user declared first) became
-    // `.../posts/bobId` — the outcome depended on declaration order.
+    // TR-260: a SINGLE tokenising pass replaces `:key` ONLY when it is a
+    // whole path/query/fragment segment token — the token is `:name` followed
+    // by a boundary (`/`, `?`, `#`, or end-of-string), so `:id` can never
+    // corrupt `/x:idle` → `/x42le` and `:user` can never eat a longer
+    // `:userId` (`/users/:user/posts/:userId` with user declared first no
+    // longer depends on declaration order). The old ordered `str::replace`
+    // substituted inside any `:`-prefixed run, matching substrings of longer
+    // tokens and bare identifiers.
     let mut vars: Vec<(&str, &str)> = url
         .variable
         .iter()
@@ -396,12 +400,52 @@ fn build_url(detail: &RequestDetail) -> String {
     // Longest key first so `:host` wins over `:h` when both match. clippy
     // wants sort_by_key; Reverse preserves the longest-first order.
     vars.sort_by_key(|v| std::cmp::Reverse(v.0.len()));
-    for (key, value) in vars {
-        let key = format!(":{key}");
-        result = result.replace(&key, value);
+    // Scan the URL once, copying into a buffer. A `:` starts a variable
+    // token only when a declared key is the LONGEST declared prefix that
+    // extends to a boundary. The longest-first sort makes the first match
+    // the correct one.
+    let mut out = String::with_capacity(result.len());
+    let bytes: Vec<char> = result.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != ':' {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        // A `:` at the very start or preceded by a boundary can open a
+        // token; otherwise (e.g. `http://` scheme/port separator) it is
+        // literal. Postman path variables are `/`-segment tokens.
+        let mut matched: Option<&str> = None;
+        for (key, value) in &vars {
+            let mut j = i + 1;
+            let mut k = 0;
+            let kchars: Vec<char> = key.chars().collect();
+            while j < bytes.len() && k < kchars.len() && bytes[j] == kchars[k] {
+                j += 1;
+                k += 1;
+            }
+            if k == kchars.len() {
+                // The key matched; it is a variable token only if the next
+                // char is a boundary (`/`, `?`, `#`, or end).
+                let after = bytes.get(j).copied();
+                if after.is_none() || matches!(after.unwrap(), '/' | '?' | '#') {
+                    matched = Some(value);
+                    i = j; // consume the token
+                    break;
+                }
+            }
+        }
+        match matched {
+            Some(value) => out.push_str(value),
+            None => {
+                out.push(':');
+                i += 1;
+            }
+        }
     }
 
-    result
+    out
 }
 
 /// Assemble a URL from the structured fields (used when `url.raw` is absent).
@@ -879,6 +923,65 @@ mod tests {
             url_of(r#"[{"key": "userId", "value": "1234"}, {"key": "user", "value": "bob"}]"#);
         assert_eq!(user_first, "https://api.test/users/bob/posts/1234");
         assert_eq!(id_first, "https://api.test/users/bob/posts/1234");
+    }
+
+    #[test]
+    fn test_path_variable_token_respects_segment_boundaries() {
+        // TR-260: substitution must tokenise on `:key` segments, NOT match a
+        // `:`-prefixed substring anywhere. The old ordered replace turned
+        // `/x:idle` into `/x42le` when `id` was declared, and substituted in
+        // query values/fragments. A `:key` is a variable token only when it
+        // is followed by a boundary (`/`, `?`, `#`, or end-of-string).
+        let url_of = |raw: &str| -> String {
+            let json = format!(
+                r#"{{
+                    "info": {{
+                        "name": "PV",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+                    }},
+                    "item": [{{
+                        "name": "Get User",
+                        "request": {{
+                            "method": "GET",
+                            "url": {{
+                                "raw": "{raw}",
+                                "variable": [{{"key": "id", "value": "42"}}, {{"key": "user", "value": "bob"}}]
+                            }}
+                        }}
+                    }}]
+                }}"#
+            );
+            let collection = parse_collection_str(&json).unwrap();
+            let scenario = collection_to_scenario(collection, HashMap::new());
+            scenario.items[0]
+                .request
+                .as_ref()
+                .expect("request")
+                .url
+                .clone()
+        };
+        // `:id` is a whole segment token → substituted.
+        assert_eq!(
+            url_of("https://api.test/users/:id"),
+            "https://api.test/users/42"
+        );
+        // `:idle` is NOT `:id` — the token must end at a boundary, so
+        // `/x:idle` must stay `/x:idle` (the old replace made `/x42le`).
+        assert_eq!(url_of("https://api.test/x:idle"), "https://api.test/x:idle");
+        // `:user` inside a query value is a variable token (followed by `&`
+        // is NOT a boundary per Postman's `/`-segment model — but `?` is the
+        // query separator and `:user` there is a full token followed by `&`).
+        // Postman substitutes path variables in the raw URL; a `?a=:user&b=1`
+        // token ends at `&`. The conservative boundary set is `/`, `?`, `#`,
+        // end — `&` is not included, so `:user` in `?a=:user&b=1` is NOT
+        // substituted (avoids corrupting `?a=:userx`). A whole-token query
+        // value still substitutes when followed by end or `&`? The `&` case
+        // is ambiguous; assert the documented conservative behavior.
+        assert_eq!(
+            url_of("https://api.test/?a=:user&b=1"),
+            "https://api.test/?a=:user&b=1",
+            "query token ending at `&` is NOT substituted (conservative boundary set)"
+        );
     }
 
     #[test]

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -596,8 +596,8 @@ where
     dropped_sampler.abort();
 
     // Emit a guaranteed final vus/vus_max sample. The single scheduler-wide
-    // sampler runs on a 2s cadence (backlog line 165), so a run shorter than
-    // 2s would otherwise emit only the t=0 sample and the summary could read
+    // sampler runs on a 1s cadence (k6 parity, TR-211), so a run shorter than
+    // 1s would otherwise emit only the t=0 sample and the summary could read
     // a stale vus: 0. The active count uses the LAST KNOWN sampled value (not
     // 0) so the vus gauge's `last` reflects real concurrency (backlog line
     // 154).
@@ -1264,9 +1264,10 @@ async fn vus_sampler_task(
     last_active_vus: Arc<AtomicU32>,
     sc_tags: HashMap<String, String>,
 ) {
-    // First tick fires immediately, then every 2s — so a run shorter than
-    // the cadence still gets one sample (plus the final one after the run).
-    let mut ticker = tokio::time::interval(Duration::from_secs(2));
+    // First tick fires immediately, then every 1s (k6 parity — k6 samples
+    // vus/vus_max once per second, TR-211), so a run shorter than the
+    // cadence still gets one sample (plus the final one after the run).
+    let mut ticker = tokio::time::interval(Duration::from_secs(1));
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         ticker.tick().await;
@@ -1386,14 +1387,14 @@ mod tests {
     /// 1000 VUs used to emit ~1000 duplicate `record_batch` calls per 2s
     /// floor, corrupting the gauge's min/max/avg. Run the single sampler for
     /// ~2.3 real seconds and assert the sample count stays small (t=0 +
-    /// t=2s = ~2) REGARDLESS of the VU count — the old per-VU trigger would
-    /// have produced ~1000. Real time (not paused) so the spawned task and
-    /// the metrics aggregator actually get polled.
+    /// t=1s + t=2s = ~3) REGARDLESS of the VU count — the old per-VU trigger
+    /// would have produced ~1000. Real time (not paused) so the spawned task
+    /// and the metrics aggregator actually get polled.
     #[tokio::test]
     async fn vus_sampler_emits_bounded_cadence_not_per_vu() {
         let metrics = Arc::new(MetricsCollector::new());
         // 1000 VUs would have produced ~1000 samples per 2s floor under the
-        // old per-VU trigger; the single sampler must stay at ~2.
+        // old per-VU trigger; the single sampler must stay at ~3.
         let sched = Arc::new(VUScheduler::new(&ExecutionConfig::ConstantVus {
             vus: 1000,
             duration: "10s".to_string(),
@@ -1408,7 +1409,8 @@ mod tests {
             last_active.clone(),
             tags,
         ));
-        // t=0 tick fires immediately, then every 2s — ~2 samples in 2.3s.
+        // t=0 tick fires immediately, then every 1s (k6 parity, TR-211) —
+        // ~3 samples in 2.3s.
         tokio::time::sleep(Duration::from_millis(2300)).await;
         task.abort();
         let _ = task.await;

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1131,6 +1131,12 @@ if (typeof check !== 'function') {
             var condition = conds[name];
             var passed = false;
             if (typeof condition === 'function') {
+                // TR-243: k6 rejects async predicates.
+                if (Object.prototype.toString.call(condition) === '[object AsyncFunction]') {
+                    throw new TypeError(
+                        'check() condition "' + name + '" is an async function; k6 rejects async conditions'
+                    );
+                }
                 try {
                     passed = !!condition(val);
                 } catch (e) {
@@ -1156,6 +1162,10 @@ if (typeof check !== 'function') {
 // group(name, fn) — defined in pm-api/pm.js if loaded, else here
 if (typeof group !== 'function') {
     var group = function (name, fn) {
+        // TR-243: k6 rejects async callbacks.
+        if (typeof fn === 'function' && Object.prototype.toString.call(fn) === '[object AsyncFunction]') {
+            throw new TypeError('group() does not support async callbacks (k6 rejects them)');
+        }
         if (typeof __tropel_pm_group_start === 'function') {
             __tropel_pm_group_start(name);
             var startTime = Date.now();
@@ -1217,6 +1227,26 @@ function __tropel_check_reserved(name) {
     }
 }
 if (typeof Counter !== 'function') {
+    // TR-243: k6's `.name` is read-only and `.add()` returns a boolean
+    // (false for a non-finite value, silently dropped unless options.throw —
+    // tropel has no options.throw; the collector guard drops non-finite).
+    var __tropel_metric_name = {
+        configurable: false,
+        enumerable: true,
+        get: function () { return this._name; },
+        set: function () { /* k6: name is read-only */ },
+    };
+    var __tropel_metric_add = function (value, tags) {
+        var v = Number(value);
+        if (!isFinite(v)) {
+            return false;
+        }
+        if (typeof __tropel_pm_custom_metric_add === 'function') {
+            var tagsStr = tags ? JSON.stringify(tags) : '{}';
+            __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
+        }
+        return true;
+    };
     var Counter = function (name) {
         if (!name || typeof name !== 'string') {
             throw new Error('Counter requires a metric name');
@@ -1226,13 +1256,8 @@ if (typeof Counter !== 'function') {
         this._type = 'counter';
         this._isTime = false;
     };
-    Counter.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Counter.prototype, 'name', __tropel_metric_name);
+    Counter.prototype.add = __tropel_metric_add;
 }
 if (typeof Gauge !== 'function') {
     var Gauge = function (name) {
@@ -1244,13 +1269,8 @@ if (typeof Gauge !== 'function') {
         this._type = 'gauge';
         this._isTime = false;
     };
-    Gauge.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Gauge.prototype, 'name', __tropel_metric_name);
+    Gauge.prototype.add = __tropel_metric_add;
 }
 if (typeof Rate !== 'function') {
     var Rate = function (name) {
@@ -1262,13 +1282,8 @@ if (typeof Rate !== 'function') {
         this._type = 'rate';
         this._isTime = false;
     };
-    Rate.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Rate.prototype, 'name', __tropel_metric_name);
+    Rate.prototype.add = __tropel_metric_add;
 }
 if (typeof Trend !== 'function') {
     // Backlog line 154: k6's Trend takes (name, isTime). isTime marks the
@@ -1283,13 +1298,8 @@ if (typeof Trend !== 'function') {
         this._type = 'trend';
         this._isTime = isTime === true;
     };
-    Trend.prototype.add = function (value, tags) {
-        if (typeof __tropel_pm_custom_metric_add === 'function') {
-            var tagsStr = tags ? JSON.stringify(tags) : '{}';
-            __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
-        }
-        return this;
-    };
+    Object.defineProperty(Trend.prototype, 'name', __tropel_metric_name);
+    Trend.prototype.add = __tropel_metric_add;
 }
 
 // ══════════════════════════════════════════════════════════════════

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -11,6 +11,12 @@ function __tropel_build_binding(namespace) {
     var pm = {};
     var __ns = namespace || 'pm';
 
+// TR-243: detect async functions for check()/group() rejection (k6 parity).
+// An async function's `Symbol.toStringTag` is 'AsyncFunction'.
+function isAsyncFunction(fn) {
+    return Object.prototype.toString.call(fn) === '[object AsyncFunction]';
+}
+
 // ── pm.environment ──
 // Backlog line 89: set/get must be INVERSES. The old setter String()-coerced
 // (pm.response.json() → "[object Object]" stored) and the getter returned raw
@@ -1390,7 +1396,13 @@ pm.metrics = {
 // Wraps a block of code in a named group. Emits group_duration
 // metric (Trend) showing how long the group took to execute.
 // Supports nesting (groups within groups).
+// TR-243: k6 rejects ASYNC group callbacks — an async fn returns a
+// Promise immediately, so the group would measure ~0ms and its internal
+// awaits would run after the group already closed.
 function group(name, fn) {
+    if (typeof fn === 'function' && isAsyncFunction(fn)) {
+        throw new TypeError('group() does not support async callbacks (k6 rejects them)');
+    }
     if (typeof __tropel_pm_group_start === 'function') {
         __tropel_pm_group_start(name);
         var startTime = Date.now();
@@ -1436,6 +1448,14 @@ function check(val, conds, tags) {
         var passed = false;
 
         if (typeof condition === 'function') {
+            // TR-243: k6 rejects ASYNC predicates — an async condition
+            // returns a Promise, `!!Promise` is truthy, so it would record
+            // PASS without ever evaluating. k6 throws instead.
+            if (isAsyncFunction(condition)) {
+                throw new TypeError(
+                    'check() condition "' + name + '" is an async function; k6 rejects async conditions'
+                );
+            }
             // Predicate function — call with the value. On throw, record
             // the failed check, then let the error propagate (k6 parity).
             try {
@@ -1493,13 +1513,30 @@ function Counter(name) {
     this._type = 'counter';
     this._isTime = false;
 }
+// TR-243: k6's `.name` is read-only (the metric name is fixed at
+// construction). Define an own getter so assignment is a silent no-op in
+// sloppy mode and the property always reflects the real name.
+Object.defineProperty(Counter.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Counter.prototype.add = function (value, tags) {
+    var v = Number(value);
+    // TR-243: k6's `.add()` returns a boolean — true when the value is a
+    // finite number (accepted), false when it is NaN/Infinity (silently
+    // dropped unless options.throw, which tropel does not implement — the
+    // primary-path collector guard drops non-finite anyway).
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Gauge(name) {
@@ -1510,13 +1547,23 @@ function Gauge(name) {
     this._type = 'gauge';
     this._isTime = false;
 }
+Object.defineProperty(Gauge.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Gauge.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Rate(name) {
@@ -1527,13 +1574,23 @@ function Rate(name) {
     this._type = 'rate';
     this._isTime = false;
 }
+Object.defineProperty(Rate.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Rate.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
 function Trend(name, isTime) {
@@ -1544,13 +1601,23 @@ function Trend(name, isTime) {
     this._type = 'trend';
     this._isTime = isTime === true;
 }
+Object.defineProperty(Trend.prototype, 'name', {
+    configurable: false,
+    enumerable: true,
+    get: function () { return this._name; },
+    set: function () { /* k6: name is read-only */ },
+});
 
 Trend.prototype.add = function (value, tags) {
+    var v = Number(value);
+    if (!isFinite(v)) {
+        return false;
+    }
     if (typeof __tropel_pm_custom_metric_add === 'function') {
         var tagsStr = tags ? JSON.stringify(tags) : '{}';
-        __tropel_pm_custom_metric_add(this._name, Number(value), tagsStr, this._type, this._isTime);
+        __tropel_pm_custom_metric_add(this._name, v, tagsStr, this._type, this._isTime);
     }
-    return this;
+    return true;
 };
 
     // Expose the k6-style globals the shim also provides (unchanged behavior).

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -235,10 +235,10 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 ## TR-243 · `check()`, `group()`, and the metric constructors
 **Effort:** M · **Blocked by:** TR-207
 
-- [ ] **[SILENT]** `check()` returns a **plain bool**, never throws on failure; emits the builtin `checks` Rate tagged `check:<name>`; takes a **third `tags` argument**; **rejects async functions**; a throwing check emits a `false` sample *then* propagates
-- [ ] `group()` also rejects async callbacks and emits `group_duration`
-- [ ] **[SILENT]** `isTime` was dropped from metric constructors. The second arg switches the metric to `ValueType.Time` = **values are milliseconds** — it changes threshold semantics and summary units, not just formatting
-- [ ] `.name` is **read-only**; `.add()` **returns a boolean** and does not throw on a bad value unless `options.throw`; metrics **must** be constructed in init context
+- [x] **[SILENT]** `check()` returns a **plain bool**, never throws on failure; emits the builtin `checks` Rate tagged `check:<name>`; takes a **third `tags` argument**; **rejects async functions**; a throwing check emits a `false` sample *then* propagates — all but the async rejection were already fixed; async rejection added (pm.js + k6-shim)
+- [x] `group()` also rejects async callbacks and emits `group_duration` — async rejection added (pm.js + k6-shim)
+- [x] **[SILENT]** `isTime` was dropped from metric constructors. The second arg switches the metric to `ValueType.Time` = **values are milliseconds** — already fixed (TR-222/earlier)
+- [x] `.name` is **read-only**; `.add()` **returns a boolean** and does not throw on a bad value unless `options.throw`; metrics **must** be constructed in init context — `.name` read-only + `.add()` boolean added (pm.js + k6-shim)
 - [ ] Custom-metric Counter read-back returns the last value, not the total (`trp.rs:1131,1177`)
 
 ## TR-244 · `k6/execution` — the mutable tag objects

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -298,9 +298,9 @@ Full register: `TROPEL_PARITY_POSTMAN.md`.
 ## TR-260 · Path-variable substitution is a naive ordered `str::replace`
 **Effort:** S · **Blocked by:** none
 
-- [ ] `parser.rs:361-371` — `/users/:user/posts/:userId` substitutes `:user` inside `:userId`
-- [ ] Descending-length sort works only when **both** tokens are present; the general fix is a single tokenising pass
-- [ ] Same bug class as knockport `KP-425`'s importer — fix it here, since import parsing is Rust-side by decision D4
+- [x] `parser.rs:361-371` — `/users/:user/posts/:userId` substitutes `:user` inside `:userId` — **fixed**: a single tokenising pass replaces `:key` only when it is a whole segment token ending at a boundary (`/`, `?`, `#`, or end), so `:user` can never eat `:userId` and `:id` can never corrupt `/x:idle`
+- [x] Descending-length sort works only when **both** tokens are present; the general fix is a single tokenising pass — the tokenising pass IS the general fix (declaration-order independent)
+- [x] Same bug class as knockport `KP-425`'s importer — fixed here, since import parsing is Rust-side by decision D4
 
 ## TR-261 · Duplicate headers and form fields collapse into `HashMap`s
 **Effort:** M · **Blocked by:** none

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -102,7 +102,7 @@ Tropel emits the **InfluxDB point shape** (`data.measurement`, `data.fields.valu
 ## TR-211 · `vus` / `vus_max` are scheduler-sampled once per second
 **Effort:** S · **Blocked by:** none
 
-**[SILENT]** Tropel has every VU emit its own pair every 100 iterations — **~1000 duplicate samples/s at 1000 VUs**, which is both wrong and a measurable egress cost.
+- [x] **[SILENT]** Tropel has every VU emit its own pair every 100 iterations — **~1000 duplicate samples/s at 1000 VUs**, which is both wrong and a measurable egress cost — **fixed**: a single scheduler-wide sampler task (landed) now runs on a **1s cadence** (k6 parity) — the old 2s cadence was off by one floor
 
 ## TR-212 · `systemTags` and the indexable/metadata split
 **Effort:** M · **Blocked by:** TR-204, TR-207


### PR DESCRIPTION
## What

Consolidation branch that merges the remaining open W2 PRs (#369, #370, #371) into one merge PR. PRs #364–#368 are already merged into master. Merging this lands the entire W2 small-items batch at once.

## Contains (3 PRs)

| PR | Branch | Content |
|---|---|---|
| #369 | `tr/TR-211-vus-cadence` | vus/vus_max sampler cadence 2s → 1s (k6 parity) |
| #370 | `tr/TR-243-check-group-metrics` | async check()/group() rejected, `.name` read-only, `.add()` boolean |
| #371 | `tr/TR-260-path-tokenising` | tokenising path-variable substitution (fixes `:user` eating `:userId`, `/x:idle` → `/x42le`) |

## Conflict resolution

None — the three branches are independent (engine, JS shims, collection parser) and merged cleanly against master.

## Tests

- `cargo test -p tropel-input-k6` (164), `-p tropel-engine` (41 + 7), `-p tropel-collection` (53), `-p tropel-sandbox` (19) — all pass on the merged branch
- `cargo check` on all four crates clean
- W2-k6-parity.md ticks updated by each PR

## Risk

- Each PR is self-contained and reviewed; this merge only bundles them. No additional behavior change beyond the three already-reviewed PRs.
