### PR TITLE
fix(js): console exactly 5 methods, add TextEncoder/TextDecoder globals [TR-242]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -10839,6 +10839,41 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
         });
     }
 
+    /// TR-242: k6 exposes the WHATWG TextEncoder/TextDecoder globals. They
+    /// must exist in the shim bundle, round-trip UTF-8, and not throw.
+    #[test]
+    fn test_k6_shim_bundle_has_text_encoder_decoder() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let bundle = format!(
+                "{}\n{}\n",
+                include_str!("../../../../js/k6-shim/k6-shim.js"),
+                include_str!("../../../../js/k6-shim/open-data-shim.js")
+            );
+            ctx.eval::<(), _>(bundle.as_str())
+                .expect("shims in production order must eval");
+            let roundtrip: String = ctx
+                .eval(
+                    "var enc = new TextEncoder(); \
+                     var bytes = enc.encode('héllo'); \
+                     var dec = new TextDecoder(); \
+                     dec.decode(bytes)",
+                )
+                .expect("TextEncoder/TextDecoder must eval");
+            assert_eq!(roundtrip, "héllo", "UTF-8 round-trip must survive");
+            // ArrayBuffer input to decode is accepted.
+            let len: i32 = ctx
+                .eval(
+                    "var dec2 = new TextDecoder(); \
+                     var buf = new Uint8Array([104, 105]).buffer; \
+                     dec2.decode(buf).length",
+                )
+                .expect("TextDecoder must accept an ArrayBuffer");
+            assert_eq!(len, 2);
+        });
+    }
+
     #[test]
     fn test_reserved_metric_name_guard() {
         // W1 line 24-26: user code cannot create custom metrics with builtin

--- a/crates/tropel-js/src/context.rs
+++ b/crates/tropel-js/src/context.rs
@@ -345,12 +345,13 @@ impl JsContext {
                         );
                     }),
                 );
-                // Backlog line 98: console.info/debug/trace/dir were missing —
-                // a script calling console.info('x') threw TypeError and
-                // ABORTED the iteration (k6/Node both define all of these).
-                // info ≈ log at info level; debug/trace map to their tracing
-                // levels; dir prints the inspected first arg like Node's
-                // console.dir (reuses the shared stringifier).
+                // Backlog line 98: console.info/debug were missing — a script
+                // calling console.info('x') threw TypeError and ABORTED the
+                // iteration (k6/Node both define these). TR-242: k6's console
+                // has EXACTLY five methods (log/debug/info/warn/error) — the
+                // old trace/dir extras are removed so a script that relies on
+                // a non-k6 method fails loudly instead of silently working.
+                // info ≈ log at info level; debug maps to its tracing level.
                 let _ = console.set(
                     "info",
                     Func::from(|ctx, args| {
@@ -367,26 +368,6 @@ impl JsContext {
                         let ConsoleArgs(ctx, args) = ConsoleArgs(ctx, args);
                         tracing::debug!(
                             "[JS console.debug] {}",
-                            console_args_to_string(&ctx, &args.0)
-                        );
-                    }),
-                );
-                let _ = console.set(
-                    "trace",
-                    Func::from(|ctx, args| {
-                        let ConsoleArgs(ctx, args) = ConsoleArgs(ctx, args);
-                        tracing::trace!(
-                            "[JS console.trace] {}",
-                            console_args_to_string(&ctx, &args.0)
-                        );
-                    }),
-                );
-                let _ = console.set(
-                    "dir",
-                    Func::from(|ctx, args| {
-                        let ConsoleArgs(ctx, args) = ConsoleArgs(ctx, args);
-                        tracing::info!(
-                            "[JS console.dir] {}",
                             console_args_to_string(&ctx, &args.0)
                         );
                     }),
@@ -1311,19 +1292,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn console_info_debug_trace_dir_do_not_throw() {
-        // Backlog line 98: console.info/debug/trace/dir were missing — a
-        // script calling console.info('x') threw TypeError and ABORTED the
-        // iteration (k6/Node define all of them). They must exist, accept
-        // arbitrary args (incl. objects), and never throw.
+    async fn console_info_debug_do_not_throw() {
+        // Backlog line 98: console.info/debug were missing — a script
+        // calling console.info('x') threw TypeError and ABORTED the
+        // iteration (k6/Node define them). They must exist, accept
+        // arbitrary args (incl. objects), and never throw. TR-242: k6's
+        // console has EXACTLY five methods (log/debug/info/warn/error) —
+        // trace/dir are NOT defined (a script relying on them fails loudly).
         let mut ctx = new_ctx().await;
         let r = ctx
-            .eval_async(
-                "console.info('a', 1); console.debug({d: 2}); console.trace('t'); console.dir({o: 3}); 'done'",
-            )
+            .eval_async("console.info('a', 1); console.debug({d: 2}); 'done'")
             .await
             .unwrap();
         assert_eq!(r, "done");
+        // trace/dir must be undefined (k6 parity — exactly five methods).
+        let trace = ctx.eval_async("typeof console.trace").await.unwrap();
+        assert_eq!(trace, "undefined", "console.trace must be absent (TR-242)");
+        let dir = ctx.eval_async("typeof console.dir").await.unwrap();
+        assert_eq!(dir, "undefined", "console.dir must be absent (TR-242)");
     }
 
     #[tokio::test]

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1357,6 +1357,41 @@ function k6Utf8Decode(bytes) {
     return out;
 }
 
+// TR-242: TextEncoder/TextDecoder globals (k6 exposes the WHATWG
+// encoders; a script calling `new TextEncoder()` threw ReferenceError).
+// Reuse the k6Utf8Encode/Decode helpers (one implementation per behaviour).
+if (typeof TextEncoder === 'undefined') {
+    var TextEncoder = function () {};
+    TextEncoder.prototype.encode = function (str) {
+        if (str === undefined) str = '';
+        var bytes = k6Utf8Encode(String(str));
+        return new Uint8Array(bytes);
+    };
+    TextEncoder.prototype.encodeInto = function (str, dest) {
+        var bytes = k6Utf8Encode(String(str));
+        var n = Math.min(bytes.length, dest.length);
+        for (var i = 0; i < n; i++) dest[i] = bytes[i];
+        return { read: n, written: n };
+    };
+}
+if (typeof TextDecoder === 'undefined') {
+    var TextDecoder = function (label) {
+        this._label = label || 'utf-8';
+    };
+    TextDecoder.prototype.decode = function (input) {
+        if (input === undefined) return '';
+        var bytes;
+        if (input instanceof ArrayBuffer) {
+            bytes = new Uint8Array(input);
+        } else if (typeof Uint8Array !== 'undefined' && input instanceof Uint8Array) {
+            bytes = input;
+        } else {
+            throw new TypeError('TextDecoder.decode: expected a BufferSource');
+        }
+        return k6Utf8Decode(Array.prototype.slice.call(bytes));
+    };
+}
+
 // k6's common.ToBytes: string → UTF-8 bytes, ArrayBuffer → bytes.
 function k6ToBytes(input) {
     if (typeof input === 'string') {

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -226,10 +226,10 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 **Effort:** S · **Blocked by:** none
 
 - [ ] **[GAP]** `k6/timers` — but these are **globals**; the module is a pure re-export, so implementing the globals is sufficient. It also unblocks the lodash `debounce`/`throttle` shims
-- [ ] **[GAP]** `randomSeed()` — one line, and the only way to get a reproducible run. **Per-VU, not global**
+- [x] **[GAP]** `randomSeed()` — one line, and the only way to get a reproducible run. **Per-VU, not global** — mulberry32 per-context (`k6-shim.js:1646-1659`)
 - [ ] `__tropel_timers` grows without bound — it reaps only *expired* one-shots, so `setInterval` handles accumulate for the whole run
-- [ ] **[SILENT]** `console` has exactly 5 methods — `log`, `debug`, `info`, `warn`, `error`, with **`log` aliasing `info`**. No `trace`/`table`/`group`/`dir`/`time`/`assert`
-- [ ] **[GAP]** `TextEncoder`/`TextDecoder` globals
+- [x] **[SILENT]** `console` has exactly 5 methods — `log`, `debug`, `info`, `warn`, `error`, with **`log` aliasing `info`**. No `trace`/`table`/`group`/`dir`/`time`/`assert` — `trace`/`dir` removed (`context.rs`); log/info alias at info level
+- [x] **[GAP]** `TextEncoder`/`TextDecoder` globals — added to the k6-shim bundle (reuse `k6Utf8Encode`/`k6Utf8Decode`), test `test_k6_shim_bundle_has_text_encoder_decoder`
 - [ ] 34 generic globals currently leak from `k6-shim.js` — `parse`, `crypto`, `open`, `test`, `hmac`, `randomBytes` — and `globalThis.crypto` is the wrong object. Namespacing them is part of this task, not a follow-up
 
 ## TR-243 · `check()`, `group()`, and the metric constructors


### PR DESCRIPTION
## What

Two k6 surface fixes:

1. **console has exactly 5 methods** (`log`/`debug`/`info`/`warn`/`error`). The old `trace`/`dir` extras are removed — k6 does not define them, so a script relying on a non-k6 method now fails loudly instead of silently working. `log` and `info` both emit at info level (functional alias, matching k6's `log`-as-`info` behavior).
2. **TextEncoder/TextDecoder WHATWG globals** added to the k6-shim bundle, reusing the existing `k6Utf8Encode`/`k6Utf8Decode` helpers (one implementation per behaviour). A script calling `new TextEncoder().encode(str)` previously threw `ReferenceError`.

## Task

TR-242 · Timers, `randomSeed`, and the globals (W2 Track E — the rest of the JS surface).

## Acceptance

- [x] `randomSeed()` per-VU — already fixed (mulberry32 per context)
- [x] console exactly 5 methods — **this PR** (trace/dir removed)
- [x] TextEncoder/TextDecoder globals — **this PR**
- [ ] `__tropel_timers` unbounded growth — still open (separate item)
- [ ] 34 generic globals leak + wrong `globalThis.crypto` — still open (separate item)

## Tests

- `js::console_info_debug_do_not_throw` — console.info/debug accept args without throwing; `typeof console.trace` and `typeof console.dir` are `"undefined"` (k6 parity).
- `k6::test_k6_shim_bundle_has_text_encoder_decoder` — `TextEncoder().encode('héllo')` → `TextDecoder().decode()` round-trips; decode accepts an ArrayBuffer.
- Full suites: k6 165, js 24 pass; clippy `-D warnings` clean; fmt clean.

## Twin check

- TextEncoder/TextDecoder reuse the existing `k6Utf8Encode`/`k6Utf8Decode` helpers — no third UTF-8 implementation. The console object is built once in `tropel-js/src/context.rs` (used by k6, sandbox, web); removing trace/dir there applies to all three surfaces consistently.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (165), `cargo test -p tropel-js` (24), clippy + fmt clean; node probe confirmed the encoder round-trip

## Risk

- A script that used the non-k6 `console.trace`/`console.dir` now gets `TypeError` (k6 parity). `TextEncoder`/`TextDecoder` use the shim's byte helpers — behavior identical to the k6 (Go) UTF-8 encoder for the BMP + surrogate pairs the helper already handled.
