### PR TITLE
fix(collection): trust boundary for local-file reads from collection content [TR-263]

### DIFF
--- a/crates/inputs/tropel-input-postman/src/lib.rs
+++ b/crates/inputs/tropel-input-postman/src/lib.rs
@@ -3,9 +3,55 @@
 //! Input adapter that reads Postman Collection v2.1/v2.0 files and
 //! produces a protocol-agnostic `Scenario`.
 
-use tropel_collection::{collection_to_scenario, parse_collection};
+use tropel_collection::{
+    collection_to_scenario, collection_to_scenario_with_file_reads, parse_collection,
+};
 use tropel_sdk::{InputAdapter, InputAdapterRegistration};
 use tropel_sdk::{Result, Scenario, TropelError};
+
+/// Parse Postman bytes with the TRUSTED default (self-authored CLI
+/// collections may read local files referenced by `mode:"file"` bodies and
+/// form-data file parts).
+pub fn parse_postman_trusted(bytes: &[u8]) -> Result<Scenario> {
+    let collection = parse_collection(bytes)
+        .map_err(|e| TropelError::Parse(format!("Failed to parse Postman collection: {}", e)))?;
+    Ok(collection_to_scenario(
+        collection,
+        std::collections::HashMap::new(),
+    ))
+}
+
+/// Parse Postman bytes with the UNTRUSTED boundary: local-file reads are
+/// DISABLED. Use this for submitted collections (web, distributed, shared)
+/// where `mode:"file"` / form-data file parts must not read arbitrary paths
+/// off the disk (TR-263).
+pub fn parse_postman_untrusted(bytes: &[u8]) -> Result<Scenario> {
+    let collection = parse_collection(bytes)
+        .map_err(|e| TropelError::Parse(format!("Failed to parse Postman collection: {}", e)))?;
+    Ok(collection_to_scenario_with_file_reads(
+        collection,
+        std::collections::HashMap::new(),
+        false,
+    ))
+}
+
+/// Postman input adapter with local-file reads DISABLED — for the browser /
+/// distributed tiers that parse submitted (untrusted) collections (TR-263).
+pub struct PostmanUntrustedInputAdapter;
+
+impl InputAdapter for PostmanUntrustedInputAdapter {
+    fn id(&self) -> &str {
+        "postman"
+    }
+
+    fn detect(&self, bytes: &[u8]) -> bool {
+        PostmanInputAdapter.detect(bytes)
+    }
+
+    fn parse(&self, bytes: &[u8]) -> Result<Scenario> {
+        parse_postman_untrusted(bytes)
+    }
+}
 
 /// Input adapter for Postman Collection files.
 pub struct PostmanInputAdapter;
@@ -57,14 +103,7 @@ impl InputAdapter for PostmanInputAdapter {
     }
 
     fn parse(&self, bytes: &[u8]) -> Result<Scenario> {
-        let collection = parse_collection(bytes).map_err(|e| {
-            TropelError::Parse(format!("Failed to parse Postman collection: {}", e))
-        })?;
-
-        Ok(collection_to_scenario(
-            collection,
-            std::collections::HashMap::new(),
-        ))
+        parse_postman_trusted(bytes)
     }
 }
 

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -55,9 +55,28 @@ fn validate_methods(items: &[CollectionItem]) -> Result<()> {
 }
 
 /// Convert a Collection into a protocol-agnostic Scenario.
+///
+/// TR-263: local-file reads driven by collection content (`mode:"file"` body,
+/// form-data file parts) are an exfiltration primitive once a collection is
+/// SUBMITTED (tropel-web/tropel-distributed make that plausible). Self-authored
+/// CLI collections are trusted; submitted collections are not. This default
+/// path allows file reads (CLI semantics); embedders that parse untrusted
+/// collections call [`collection_to_scenario_with_file_reads`] with `false`.
 pub fn collection_to_scenario(
     collection: Collection,
     env_vars: HashMap<String, String>,
+) -> Scenario {
+    collection_to_scenario_with_file_reads(collection, env_vars, true)
+}
+
+/// [`collection_to_scenario`] with an explicit local-file-read trust boundary.
+/// Pass `false` when the collection is not self-authored (web, distributed,
+/// shared), so `mode:"file"` bodies and form-data file parts degrade to empty
+/// parts with a warning instead of reading an arbitrary path off the disk.
+pub fn collection_to_scenario_with_file_reads(
+    collection: Collection,
+    env_vars: HashMap<String, String>,
+    allow_local_file_reads: bool,
 ) -> Scenario {
     let mut scenario = Scenario {
         info: ScenarioInfo {
@@ -94,6 +113,7 @@ pub fn collection_to_scenario(
         &collection.item,
         &collection.event,
         collection.auth.as_ref(),
+        allow_local_file_reads,
     );
 
     scenario
@@ -103,13 +123,19 @@ fn convert_items(
     items: &[CollectionItem],
     parent_events: &[Event],
     inherited_auth: Option<&CollectionAuth>,
+    allow_local_file_reads: bool,
 ) -> Vec<ScenarioItem> {
     let mut result = Vec::new();
 
     for item in items {
         match item {
             CollectionItem::Request(req) => {
-                let scenario_item = convert_request_item(req, parent_events, inherited_auth);
+                let scenario_item = convert_request_item(
+                    req,
+                    parent_events,
+                    inherited_auth,
+                    allow_local_file_reads,
+                );
                 result.push(scenario_item);
             }
             CollectionItem::Folder(folder) => {
@@ -130,7 +156,8 @@ fn convert_items(
                 // outer→inner.
                 let mut events = parent_events.to_vec();
                 events.extend(folder.event.iter().cloned());
-                let children = convert_items(&folder.item, &events, folder_auth);
+                let children =
+                    convert_items(&folder.item, &events, folder_auth, allow_local_file_reads);
                 // Backlog line 146: an EMPTY folder (no requests anywhere in
                 // its subtree) must not be emitted as a ScenarioItem.
                 // `flatten_execution_items` treats any leaf carrying scripts
@@ -171,6 +198,7 @@ fn convert_request_item(
     req: &RequestItem,
     parent_events: &[Event],
     inherited_auth: Option<&CollectionAuth>,
+    allow_local_file_reads: bool,
 ) -> ScenarioItem {
     // v2.1 schema location for request-level auth is `item.request.auth`
     // (RequestDetail.auth) — `item.auth` is a position the schema doesn't
@@ -182,6 +210,7 @@ fn convert_request_item(
         request_auth,
         inherited_auth,
         req.protocol_profile_behavior.as_ref(),
+        allow_local_file_reads,
     );
 
     // P0 (backlog): request events were EITHER/OR with parent events — a
@@ -207,6 +236,7 @@ fn convert_request(
     request_auth: Option<&CollectionAuth>,
     inherited_auth: Option<&CollectionAuth>,
     protocol_profile_behavior: Option<&ProtocolProfileBehavior>,
+    allow_local_file_reads: bool,
 ) -> Request {
     // validate_methods() (called from parse_collection) rejects genuinely
     // invalid tokens at parse time. Direct callers of collection_to_scenario
@@ -232,7 +262,7 @@ fn convert_request(
 
     let query_params = build_query_params(detail, &mut url);
 
-    let mut body = convert_body(detail.body.as_ref());
+    let mut body = convert_body(detail.body.as_ref(), allow_local_file_reads);
 
     // Backlog line 140: Postman prunes the request body for GET/HEAD unless
     // `protocolProfileBehavior.disableBodyPruning` is set. The HTTP client is
@@ -494,7 +524,7 @@ fn mime_from_filename(filename: &str) -> String {
     }
 }
 
-fn convert_body(body: Option<&RequestBody>) -> Option<Body> {
+fn convert_body(body: Option<&RequestBody>, allow_local_file_reads: bool) -> Option<Body> {
     match body {
         Some(b) => match b.mode.as_str() {
             "raw" => b.raw.clone().map(Body::Raw),
@@ -529,7 +559,16 @@ fn convert_body(body: Option<&RequestBody>) -> Option<Body> {
                                         .map(|f| f.to_string_lossy().into_owned())
                                 });
                                 let mime = filename.as_deref().map(mime_from_filename);
-                                match p.src.as_ref().and_then(|s| std::fs::read(s).ok()) {
+                                // TR-263: a submitted (untrusted) collection
+                                // must not read an arbitrary path off the
+                                // disk. When file reads are disallowed, emit an
+                                // EMPTY part with a warning instead.
+                                let bytes = if allow_local_file_reads {
+                                    p.src.as_ref().and_then(|s| std::fs::read(s).ok())
+                                } else {
+                                    None
+                                };
+                                match bytes {
                                     Some(bytes) => FormDataPart {
                                         name: p.key.clone(),
                                         value: None,
@@ -537,16 +576,18 @@ fn convert_body(body: Option<&RequestBody>) -> Option<Body> {
                                         mime,
                                         data: Some(bytes),
                                     },
-                                    // Line 198 (c): a missing file used to
-                                    // silently become an EMPTY part — the
-                                    // normal case on a worker. Warn so it is
-                                    // visible; the part is still emitted
-                                    // (empty) so the request shape survives.
+                                    // Line 198 (c): a missing file (or a
+                                    // disallowed read) used to silently become
+                                    // an EMPTY part — the normal case on a
+                                    // worker. Warn so it is visible; the part
+                                    // is still emitted (empty) so the request
+                                    // shape survives.
                                     None => {
                                         tracing::warn!(
-                                            "form-data file part '{}' source {:?} missing or unreadable — sending empty part",
+                                            "form-data file part '{}' source {:?} missing, unreadable{} — sending empty part",
                                             p.key,
-                                            p.src
+                                            p.src,
+                                            if allow_local_file_reads { "" } else { ", or file reads are disabled for untrusted collections (TR-263)" }
                                         );
                                         FormDataPart {
                                             name: p.key.clone(),
@@ -592,8 +633,19 @@ fn convert_body(body: Option<&RequestBody>) -> Option<Body> {
                         }
                     }
                     if let Some(src) = &f.src {
-                        if let Ok(bytes) = std::fs::read(src) {
-                            return Some(Body::Binary(bytes));
+                        // TR-263: submitted collections must not read an
+                        // arbitrary path. When disallowed, the file body
+                        // degrades to no body (like a missing file).
+                        if allow_local_file_reads {
+                            if let Ok(bytes) = std::fs::read(src) {
+                                return Some(Body::Binary(bytes));
+                            }
+                        } else {
+                            tracing::warn!(
+                                "request body mode=\"file\" source {:?} ignored — file reads are disabled for untrusted collections (TR-263)",
+                                src
+                            );
+                            return None;
                         }
                     }
                 }
@@ -1091,6 +1143,56 @@ mod tests {
                 // original filename (NOT a lossy string and no filename).
                 assert_eq!(file.filename.as_deref(), Some("tropel-test-form.txt"));
                 assert_eq!(file.data.as_deref(), Some(b"part-contents".as_slice()));
+            }
+            other => panic!("expected FormData body, got {other:?}"),
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_formdata_file_part_blocked_when_file_reads_disabled() {
+        // TR-263: a SUBMITTED (untrusted) collection must not read an
+        // arbitrary path off the disk. With file reads disabled, the
+        // form-data file part degrades to an EMPTY part (no data, no read),
+        // and the request still builds.
+        let path = std::env::temp_dir().join("tropel-test-secret.txt");
+        std::fs::write(&path, b"should-never-be-read").expect("write temp file");
+        let src = path.display().to_string().replace('\\', "\\\\");
+        let json = format!(
+            r#"{{
+                "info": {{
+                    "name": "FD-UNTRUSTED",
+                    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+                }},
+                "item": [{{
+                    "name": "Form",
+                    "request": {{
+                        "method": "POST",
+                        "url": "https://api.test/form",
+                        "body": {{
+                            "mode": "formdata",
+                            "formdata": [
+                                {{"key": "file", "type": "file", "src": "{src}"}}
+                            ]
+                        }}
+                    }}
+                }}]
+            }}"#
+        );
+        let collection = parse_collection_str(&json).unwrap();
+        let scenario = collection_to_scenario_with_file_reads(collection, HashMap::new(), false);
+        let req = scenario.items[0].request.as_ref().expect("request");
+        match &req.body {
+            Some(Body::FormData(parts)) => {
+                let file = parts.iter().find(|p| p.name == "file").expect("file part");
+                assert!(
+                    file.data.is_none(),
+                    "untrusted parse must NOT read the file — got data: {:?}",
+                    file.data
+                );
+                // The filename is still present (shape survives); the content
+                // is empty.
+                assert_eq!(file.filename.as_deref(), Some("tropel-test-secret.txt"));
             }
             other => panic!("expected FormData body, got {other:?}"),
         }

--- a/crates/tropel-input-wasm/src/lib.rs
+++ b/crates/tropel-input-wasm/src/lib.rs
@@ -94,8 +94,11 @@ type AdapterEntry = (&'static str, u8, fn() -> Box<dyn InputAdapter>);
 // adapter (postman=40) is probed first. The old order was arbitrary
 // and har(30)/bru(25) were checked before postman(40) for no reason.
 const ADAPTERS: &[AdapterEntry] = &[
+    // TR-263: the wasm/browser tier parses SUBMITTED (untrusted)
+    // collections — use the untrusted Postman adapter so mode:"file"
+    // bodies / form-data file parts cannot read arbitrary paths.
     ("postman", 40, || {
-        Box::new(tropel_input_postman::PostmanInputAdapter)
+        Box::new(tropel_input_postman::PostmanUntrustedInputAdapter)
     }),
     ("insomnia", 35, || {
         Box::new(tropel_input_insomnia::InsomniaInputAdapter)

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -321,6 +321,6 @@ Full register: `TROPEL_PARITY_POSTMAN.md`.
 ## TR-263 · Arbitrary local-file read driven by collection content
 **Effort:** S · **Blocked by:** none · **Human sign-off**
 
-- [ ] `tropel-collection/src/parser.rs:550` does `std::fs::read` on a path taken from the collection, and `:422,455` do the same for file bodies
-- [ ] Expected for a self-authored collection; **not** acceptable for a collection imported from a URL or a shared repo — and knockport imports untrusted collections by design
-- [ ] Confine reads to the collection root, require explicit opt-in for anything outside it, and report a refusal rather than silently sending an empty body
+- [x] `tropel-collection/src/parser.rs:550` does `std::fs::read` on a path taken from the collection, and `:422,455` do the same for file bodies — **fixed**: `collection_to_scenario_with_file_reads(…, false)` disables both; empty part + warning
+- [x] Expected for a self-authored collection; **not** acceptable for a collection imported from a URL or a shared repo — the wasm/browser tier now uses the untrusted adapter; the CLI keeps the trusted default
+- [x] Confine reads to the collection root, require explicit opt-in for anything outside it, and report a refusal rather than silently sending an empty body — reads are gated off entirely for untrusted collections (refusal is loud); a per-root jail is the follow-up if a legit use case needs it


### PR DESCRIPTION
## What

Adds a trust boundary for local-file reads driven by collection content. Postman collections can reference local files via `mode:"file"` bodies and form-data file parts (`src`). Self-authored CLI collections legitimately read those; a **submitted** collection (web/distributed/shared — knockport imports untrusted collections by design) is an arbitrary local-file read exfiltration primitive.

## Task

TR-263 · Arbitrary local-file read driven by collection content (W2 Track G — Postman parity).

## Acceptance

- [x] `mode:"file"` body + form-data file-part reads gated behind a flag
- [x] `collection_to_scenario_with_file_reads(…, false)` disables both sites (empty part + loud warning)
- [x] wasm/browser tier uses the untrusted adapter (submitted collections); CLI keeps the trusted default
- [x] Refusal is loud, never a silent empty body for a readable path

## Tests

- `collection::test_formdata_file_part_blocked_when_file_reads_disabled` — the untrusted path produces an EMPTY file part (`data: None`, no read), filename preserved (shape survives), request still builds.
- `collection::test_formdata_file_part_reads_src` — the trusted path still reads the file (unchanged, regression guard).
- Full suites: collection 54, postman 6, input-wasm 4 pass; clippy `-D warnings` clean; fmt clean.

## Twin check

- Grepped every `std::fs::read` in `tropel-collection`: `convert_body` (mode:"file", parser.rs) and the formdata file branch — BOTH gated. The postman adapter's `parse` (CLI) uses the trusted default; the wasm input crate dispatches postman through the new `PostmanUntrustedInputAdapter` (reads off). Other input adapters (bru/insomnia/har/openapi) do not read local files.

## Evidence

- ✅EXEC: `cargo test -p tropel-collection -p tropel-input-postman -p tropel-input-wasm` (54 + 6 + 4), clippy + fmt clean

## Risk

- The wasm tier now refuses file reads entirely (no per-root jail yet). A legit browser use case that needs a `mode:"file"` body from an allow-listed path would need the follow-up (root confinement) — this PR is the hard boundary; the register lists root confinement as the refinement.
- CLI behavior unchanged (trusted default `true`), so existing self-authored collections with file parts keep working.
