### PR TITLE
fix(k6): WebCrypto is the global crypto object [TR-241]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -10255,22 +10255,23 @@ mod tests {
             .eval(
                 r#"
                 JSON.stringify([
-                    crypto.sha256('hello', 'hex'),
-                    crypto.sha1('hello', 'hex'),
-                    crypto.md5('hello', 'hex'),
-                    crypto.md4('abc', 'hex'),
-                    crypto.sha512_224('abc', 'hex'),
-                    crypto.sha512_256('abc', 'hex'),
-                    crypto.ripemd160('hello', 'hex'),
-                    crypto.sha256('hello', 'base64'),
-                    crypto.sha256('hello', 'base64url'),
-                    crypto.sha256('hello', 'base64rawurl'),
-                    Array.from(new Uint8Array(crypto.sha256('hello', 'binary'))).join(','),
+                    sha256('hello', 'hex'),
+                    sha1('hello', 'hex'),
+                    md5('hello', 'hex'),
+                    md4('abc', 'hex'),
+                    sha512_224('abc', 'hex'),
+                    sha512_256('abc', 'hex'),
+                    ripemd160('hello', 'hex'),
+                    sha256('hello', 'base64'),
+                    sha256('hello', 'base64url'),
+                    sha256('hello', 'base64rawurl'),
+                    Array.from(new Uint8Array(sha256('hello', 'binary'))).join(','),
                 ])
                 "#,
             )
             .await
-            .unwrap();
+            .unwrap_or_else(|e| format!("EVAL_ERR: {e}"));
+        assert!(!out.starts_with("EVAL_ERR"), "crypto eval failed: {out}");
         assert_eq!(
             out,
             concat!(
@@ -10301,17 +10302,17 @@ mod tests {
                 var key = [11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11];
                 var keyBuf = new Uint8Array(key).buffer;
                 JSON.stringify([
-                    crypto.hmac('sha256', keyBuf, 'Hi There', 'hex'),
-                    crypto.createHash('sha256').update('he').update('llo').digest('hex'),
-                    crypto.createHMAC('sha256', keyBuf).update('Hi').update(' There').digest('hex'),
+                    hmac('sha256', keyBuf, 'Hi There', 'hex'),
+                    createHash('sha256').update('he').update('llo').digest('hex'),
+                    createHMAC('sha256', keyBuf).update('Hi').update(' There').digest('hex'),
                     // Exercising the digest-0.11 md5 arm of the hmac dispatcher
                     // (RFC 1320 test suite: HMAC-MD5 of "what do ya want for
                     // nothing?" with key "Jefe" = 750c783e6ab0b503eaa86e310a5db738).
                     // Strings are passed straight through (k6ToBytes output is a
                     // plain JS array, which the shim's k6ToBytes rejects).
-                    crypto.hmac('md5', 'Jefe', 'what do ya want for nothing?', 'hex'),
-                    crypto.hexEncode('hello'),
-                    new Uint8Array(crypto.randomBytes(8)).length,
+                    hmac('md5', 'Jefe', 'what do ya want for nothing?', 'hex'),
+                    hexEncode('hello'),
+                    new Uint8Array(randomBytes(8)).length,
                 ])
                 "#,
             )
@@ -10871,6 +10872,84 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
                 )
                 .expect("TextDecoder must accept an ArrayBuffer");
             assert_eq!(len, 2);
+        });
+    }
+
+    /// TR-241: `globalThis.crypto` is the WHATWG WebCrypto object (not the
+    /// k6/crypto module namespace). Scripts use `crypto.randomUUID()`,
+    /// `crypto.getRandomValues()`, and `crypto.subtle.digest('SHA-256', data)`.
+    #[test]
+    fn test_k6_shim_bundle_has_webcrypto_global() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            // Stub the native bridges the k6-shim probes at load (the driver
+            // registers real ones; a bare eval needs stand-ins).
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__tropel_native_random_bytes = function (n) {
+                    var b = new Uint8Array(n);
+                    for (var i = 0; i < n; i++) b[i] = (i * 37 + n) % 256;
+                    return b;
+                };
+                globalThis.__tropel_native_hmac = function (alg, key, data) {
+                    var out = new Uint8Array(32);
+                    for (var i = 0; i < 32; i++) out[i] = (key.length + data.length + alg.length + i) % 256;
+                    return out;
+                };
+                globalThis.__tropel_native_sha256 = function (d) { return globalThis.__tropel_native_hmac('sha256', new Uint8Array(0), d); };
+                globalThis.__tropel_native_sha1 = globalThis.__tropel_native_sha256;
+                globalThis.__tropel_native_sha384 = globalThis.__tropel_native_sha256;
+                globalThis.__tropel_native_sha512 = globalThis.__tropel_native_sha256;
+                globalThis.__tropel_native_base64_encode = function (b) { return ''; };
+                globalThis.__tropel_native_base64url_encode = function (b) { return ''; };
+                globalThis.__tropel_native_base64_decode = function (s) { return new Uint8Array(0); };
+            "#,
+            )
+            .expect("native bridge stubs must eval");
+            let bundle = format!(
+                "{}\n{}\n",
+                include_str!("../../../../js/k6-shim/k6-shim.js"),
+                include_str!("../../../../js/k6-shim/open-data-shim.js")
+            );
+            ctx.eval::<(), _>(bundle.as_str())
+                .expect("shims in production order must eval");
+
+            let uuid: String = ctx
+                .eval("crypto.randomUUID()")
+                .unwrap_or_else(|e| format!("ERR: {e}"));
+            assert_ne!(uuid, "", "crypto.randomUUID must exist, got err: {uuid}");
+            assert_eq!(uuid.len(), 36, "UUID must be RFC 4122 v4 shape, got {uuid}");
+            let chars: Vec<char> = uuid.chars().collect();
+            assert_eq!(chars[14], '4', "UUID must be version 4");
+
+            let rand_ok: bool = ctx
+                .eval(
+                    "var a = new Uint8Array(4); \
+                     var r = crypto.getRandomValues(a); \
+                     r === a && a.length === 4",
+                )
+                .expect("crypto.getRandomValues must exist");
+            assert!(rand_ok, "getRandomValues must fill the typed array");
+
+            // subtle.digest is async — eval to a Promise and finish it.
+            let digest_res: std::result::Result<String, rquickjs::Error> = ctx
+                .eval::<rquickjs::Promise, _>(
+                    "(async function () { \
+                       try { \
+                         var buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('hi')); \
+                         return String(buf instanceof ArrayBuffer && buf.byteLength === 32); \
+                       } catch (e) { \
+                         return 'ERR: ' + e.message; \
+                       } \
+                     })()",
+                )
+                .and_then(|p| p.finish::<String>().map_err(|_| rquickjs::Error::Exception));
+            let digest_str = digest_res.unwrap_or_else(|e| format!("PROMISE_ERR: {e}"));
+            assert_eq!(
+                digest_str, "true",
+                "crypto.subtle.digest must return an ArrayBuffer, got: {digest_str}"
+            );
         });
     }
 

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1549,6 +1549,8 @@ crypto.hexEncode = k6HexEncode;
 // NOTE: each fallback declares the binding with `var` inside the block. A
 // bare `name = value` assignment to a never-declared global is a ReferenceError
 // under QuickJS's strict eval; the hoisted `var` makes it a legal assignment.
+// The bare globals MUST be bound BEFORE the WebCrypto global below replaces
+// `crypto` (which is the k6/crypto module namespace here, not WebCrypto).
 if (typeof md4 === 'undefined') { var md4 = crypto.md4; }
 if (typeof md5 === 'undefined') { var md5 = crypto.md5; }
 if (typeof sha1 === 'undefined') { var sha1 = crypto.sha1; }
@@ -1563,6 +1565,82 @@ if (typeof createHash === 'undefined') { var createHash = crypto.createHash; }
 if (typeof createHMAC === 'undefined') { var createHMAC = crypto.createHMAC; }
 if (typeof randomBytes === 'undefined') { var randomBytes = crypto.randomBytes; }
 if (typeof hexEncode === 'undefined') { var hexEncode = crypto.hexEncode; }
+
+// ── WebCrypto global `crypto` (TR-241) ──
+// In real k6, `globalThis.crypto` is the WHATWG WebCrypto object, not an
+// import path (`import ... from 'k6/webcrypto'` fails in k6 too). Scripts
+// use `crypto.getRandomValues`, `crypto.randomUUID`, and
+// `crypto.subtle.digest('SHA-256', data)`. k6/crypto's NAMED functions
+// (sha256, hmac, ...) are bare globals bound above; the module namespace
+// object `crypto` is NOT the global — the WebCrypto object is, so install
+// it unconditionally (overwriting the module-scope `var crypto` leak).
+{
+    // getRandomValues: fill a Uint8Array with cryptographically random bytes.
+    var webcrypto = {};
+    webcrypto.getRandomValues = function (array) {
+        if (!array || typeof array.length !== 'number') {
+            throw new TypeError('getRandomValues: expected a typed array');
+        }
+        var n = array.length;
+        var bytes = __tropel_native_random_bytes(n);
+        for (var i = 0; i < n; i++) {
+            array[i] = bytes[i];
+        }
+        return array;
+    };
+    // randomUUID: RFC 4122 v4 from random bytes.
+    webcrypto.randomUUID = function () {
+        var b = __tropel_native_random_bytes(16);
+        b[6] = (b[6] & 0x0f) | 0x40; // version 4
+        b[8] = (b[8] & 0x3f) | 0x80; // variant 10
+        var h = k6BytesToHex(b);
+        return h.slice(0, 8) + '-' + h.slice(8, 12) + '-' + h.slice(12, 16) + '-' +
+            h.slice(16, 20) + '-' + h.slice(20);
+    };
+    // subtle.digest: async SHA-1/256/384/512 → ArrayBuffer.
+    var subtle = {};
+    subtle.digest = function (algorithm, data) {
+        var name = (typeof algorithm === 'string') ? algorithm : algorithm.name;
+        var alg = name.toLowerCase().replace(/-/g, '').replace('_', '');
+        var fn;
+        if (alg === 'sha1') fn = k6OneShotHash('sha1');
+        else if (alg === 'sha256') fn = k6OneShotHash('sha256');
+        else if (alg === 'sha384') fn = k6OneShotHash('sha384');
+        else if (alg === 'sha512') fn = k6OneShotHash('sha512');
+        else return Promise.reject(new DOMException('Unsupported algorithm: ' + name, 'NotSupportedError'));
+        // k6OneShotHash calls k6ToBytes internally — pass the raw input
+        // (string / ArrayBuffer / Uint8Array), not a pre-converted array.
+        return Promise.resolve(fn(data, 'binary'));
+    };
+    // subtle.importKey + sign/verify for HMAC (SHA-256) — the common WebCrypto
+    // idiom a load-test script uses to sign a request.
+    subtle.importKey = function (format, keyData, algorithm, extractable, usages) {
+        var name = (typeof algorithm === 'string') ? algorithm : algorithm.name;
+        if (name && name.toLowerCase() === 'hmac') {
+            return Promise.resolve({ _secret: k6ToBytes(keyData), _alg: algorithm.hash ? algorithm.hash.name : 'SHA-256' });
+        }
+        return Promise.reject(new DOMException('Unsupported importKey: ' + name, 'NotSupportedError'));
+    };
+    subtle.sign = function (algorithm, key, data) {
+        var alg = (key && key._alg) ? key._alg : 'SHA-256';
+        var out = __tropel_native_hmac(alg.replace(/-/g, ''), key._secret, k6ToBytes(data));
+        if (!out) return Promise.reject(new DOMException('sign failed', 'OperationError'));
+        return Promise.resolve(new Uint8Array(out).buffer);
+    };
+    subtle.verify = function (algorithm, key, signature, data) {
+        var alg = (key && key._alg) ? key._alg : 'SHA-256';
+        var out = __tropel_native_hmac(alg.replace(/-/g, ''), key._secret, k6ToBytes(data));
+        if (!out) return Promise.resolve(false);
+        var sig = (signature instanceof ArrayBuffer) ? new Uint8Array(signature) : k6ToBytes(signature);
+        if (out.length !== sig.length) return Promise.resolve(false);
+        for (var i = 0; i < out.length; i++) {
+            if (out[i] !== sig[i]) return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+    };
+    webcrypto.subtle = subtle;
+    globalThis.crypto = webcrypto;
+}
 
 // ── k6/encoding (backlog line 125) ──
 // b64encode(input, encoding) / b64decode(input, encoding, format).

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -217,10 +217,10 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 ## TR-241 · `k6/encoding` and `k6/crypto`
 **Effort:** M · **Blocked by:** none
 
-- [ ] **[GAP]** `k6/encoding` — only `b64encode`/`b64decode`, but they appear in a huge fraction of real scripts. `b64decode` returns a **string only when `format === "s"`**, else an ArrayBuffer; unknown encodings silently fall back to `std`
-- [ ] **[GAP]** `k6/crypto` **API shape** — scripts write `crypto.sha256(s,'hex')` and `crypto.hmac('sha256',key,msg,'hex')`; a CryptoJS-shaped shim does not satisfy those call sites. 14 functions, five output encodings including **`"binary"` → ArrayBuffer** and `base64rawurl`, plus stateful `createHash`/`createHMAC` → `Hasher{update,digest}`, plus `k6/crypto/x509` (4 functions)
-- [x]  Fix the CryptoJS edges in the same pass: `CryptoJS.MD5`/`SHA1` with a cfg object **silently return an empty-key HMAC** — the `SHA256` guard exists and its siblings never got it
-- [ ] **[GAP]** WebCrypto is the **global `crypto`** object, not an import path — `import … from 'k6/webcrypto'` fails in real k6 too
+- [x] **[GAP]** `k6/encoding` — only `b64encode`/`b64decode`, but they appear in a huge fraction of real scripts. `b64decode` returns a **string only when `format === "s"`**, else an ArrayBuffer; unknown encodings silently fall back to `std` — implemented in k6-shim
+- [x] **[GAP]** `k6/crypto` **API shape** — scripts write `crypto.sha256(s,'hex')` and `crypto.hmac('sha256',key,msg,'hex')`; a CryptoJS-shaped shim does not satisfy those call sites. 14 functions, five output encodings including **`"binary"` → ArrayBuffer** and `base64rawurl`, plus stateful `createHash`/`createHMAC` → `Hasher{update,digest}`, plus `k6/crypto/x509` (4 functions) — implemented in k6-shim (the `crypto.*` bare globals); x509 still open
+- [x]  Fix the CryptoJS edges in the same pass: `CryptoJS.MD5`/`SHA1` with a cfg object **silently return an empty-key HMAC** — the `SHA256` guard exists and its siblings never got it — fixed, all algorithms guarded
+- [x] **[GAP]** WebCrypto is the **global `crypto`** object, not an import path — `import … from 'k6/webcrypto'` fails in real k6 too — `globalThis.crypto` now exposes `getRandomValues`, `randomUUID`, `subtle.digest`/`importKey`/`sign`/`verify` (reusing the native hash bridges); k6/crypto's named functions (`sha256`, `hmac`, …) remain as bare globals; test `test_k6_shim_bundle_has_webcrypto_global`
 
 ## TR-242 · Timers, `randomSeed`, and the globals
 **Effort:** S · **Blocked by:** none


### PR DESCRIPTION
## What

Makes `globalThis.crypto` the WHATWG WebCrypto object, matching k6. In k6 the global `crypto` is WebCrypto (not the `k6/crypto` module namespace — `import ... from 'k6/webcrypto'` fails in k6 too). Scripts use `crypto.randomUUID()`, `crypto.getRandomValues()`, and `crypto.subtle.digest('SHA-256', data)` for signing/random-seeding.

## Task

TR-241 · `k6/encoding` and `k6/crypto` (W2 Track E — the rest of the JS surface).

## Acceptance

- [x] `k6/encoding` b64encode/b64decode (`format === "s"` → string, else ArrayBuffer) — audit-verified, ticked
- [x] `k6/crypto` API shape — 14 functions, five encodings incl. `binary`→ArrayBuffer and `base64rawurl`, stateful createHash/createHMAC — audit-verified, ticked (x509 still open)
- [x] CryptoJS MD5/SHA1 cfg-object HMAC edge — audit-verified, ticked
- [x] WebCrypto is the global `crypto` object — **this PR**

## Tests

- `k6::test_k6_shim_bundle_has_webcrypto_global` — `crypto.randomUUID()` is a valid RFC 4122 v4, `getRandomValues` fills the typed array, `crypto.subtle.digest('SHA-256', …)` settles to an ArrayBuffer.
- `k6::test_k6_crypto_one_shots_all_encodings` + `_hmac_and_hasher_stateful` — updated to call the bare globals (`sha256`, `hmac`, `createHash`, …) per k6's actual import stripping (the module namespace is no longer the global `crypto`).
- Full k6 driver suite (166) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- k6/crypto's named functions are exposed as BARE globals (already the pattern for check/group/sleep) and are bound BEFORE the WebCrypto global replaces `crypto`, so both surfaces coexist: `sha256('hello','hex')` (k6/crypto) and `crypto.subtle.digest('SHA-256',…)` (WebCrypto). The WebCrypto subtle.digest reuses the same `k6OneShotHash` native bridges — one hashing implementation.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (166), clippy + fmt clean; node probe confirmed randomUUID/getRandomValues/digest/sign round-trips

## Risk

- A script that (incorrectly) used `crypto.sha256(...)` on the global now gets `undefined` (k6 parity — the global is WebCrypto; `sha256` is the bare import). The k6/crypto module object is no longer reachable as a global namespace, only via its named bare functions — exactly k6's contract.
