### PR TITLE
fix(k6): multipart boundary is 60-hex; urlencoded arrays expand [TR-232]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4659,9 +4659,25 @@ mod tests {
             let mp_body: String = ctx
                 .eval("__captured[2].body")
                 .expect("read captured[2] body");
+            // TR-232: the boundary is a random 60-hex-char string (k6 uses
+            // crypto/rand hex); the body must be framed with it.
+            let boundary: String = mp_headers
+                .split("boundary=")
+                .nth(1)
+                .map(|s| s.chars().filter(|c| c.is_ascii_hexdigit()).collect())
+                .unwrap_or_default();
+            assert_eq!(
+                boundary.len(),
+                60,
+                "boundary must be 60 hex chars: {boundary}"
+            );
             assert!(
-                mp_body.contains("----TropelFormBoundary"),
-                "multipart body missing framing: {mp_body}"
+                boundary.chars().all(|c| c.is_ascii_hexdigit()),
+                "boundary must be hex: {boundary}"
+            );
+            assert!(
+                mp_body.contains(&boundary),
+                "multipart body missing boundary framing: {mp_body}"
             );
 
             // 5. A lowercase `content-type` declaration must be replaced (not
@@ -4679,6 +4695,38 @@ mod tests {
                     .to_lowercase()
                     .contains("\"content-type\":\"multipart/form-data\""),
                 "boundary-less content-type variant leaked into header: {mp_lower}"
+            );
+        });
+    }
+
+    /// TR-232: k6 expands ARRAY values in an object body into repeated
+    /// urlencoded keys (`{a: [1, 2]}` → `a=1&a=2`). The old `String(array)`
+    /// produced `a=1,2`.
+    #[test]
+    fn test_urlencoded_array_values_expand_to_repeated_keys() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/k6-shim/k6-shim.js"))
+                .expect("k6 shim should eval");
+            // Stub the native HTTP bridge; capture the body handed to it.
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__captured = [];
+                globalThis.__tropel_k6_http_request = function (method, url, headersJson, body) {
+                    globalThis.__captured.push({ headers: JSON.parse(headersJson), body: body });
+                    return { code: 200, status: 200, body: '{}', headers: {}, responseTime: 5 };
+                };
+                "#,
+            )
+            .expect("stub should eval");
+            let body: String = ctx
+                .eval("http.post('https://e.com/', { a: [1, 2], b: 'x' }); __captured[0].body")
+                .expect("eval must succeed");
+            // The body is the urlencoded serialization.
+            assert_eq!(
+                body, "a=1&a=2&b=x",
+                "array values must expand to repeated keys, got: {body}"
             );
         });
     }

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -440,7 +440,14 @@ function serializeK6Body(body, headers) {
 }
 
 function buildMultipartFormData(object) {
-    var boundary = '----TropelFormBoundary' + Math.random().toString(36).slice(2);
+    // TR-232: k6 generates a random 60-hex-char boundary (crypto/rand).
+    // Deterministic per request; reusing Math.random (not crypto) keeps the
+    // shim dependency-free and is collision-safe at this length.
+    var boundary = '';
+    var hexChars = '0123456789abcdef';
+    for (var bi = 0; bi < 60; bi++) {
+        boundary += hexChars[Math.floor(Math.random() * 16)];
+    }
     var body = '';
     var binary = false;
 
@@ -487,7 +494,18 @@ function serializeUrlEncoded(object) {
         if (value === undefined || value === null) {
             value = '';
         }
-        parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(String(value)));
+        // TR-232: k6 expands ARRAY values into repeated keys
+        // (`{a: [1, 2]}` → `a=1&a=2`). The old `String(array)` produced
+        // `a=1,2`, which a form parser reads as a single value.
+        if (Array.isArray(value)) {
+            for (var i = 0; i < value.length; i++) {
+                var v = value[i];
+                if (v === undefined || v === null) v = '';
+                parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(String(v)));
+            }
+        } else {
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(String(value)));
+        }
     }
     return parts.join('&');
 }

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -188,10 +188,10 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 ## TR-232 · `http.file()` and multipart
 **Effort:** M · **Blocked by:** TR-230
 
-- [ ] `http.file(data, filename?, contentType?)`; the multipart trigger is "any top-level body value is FileData"
-- [ ] 60-hex-char random boundary; file parts carry `Content-Disposition` + `Content-Type`; **non-file parts get no `Content-Type`** and are stringified with `%v`
-- [ ] Non-file object bodies fall back to `application/x-www-form-urlencoded`, arrays expanding to repeated keys
-- [ ] **[SUPERSET]** k6's part order is **non-deterministic** (Go map range) and it **doesn't escape the field name** for file parts — real k6 bugs. If tropel is deterministic and escapes both, **keep it and document the divergence**
+- [x] `http.file(data, filename?, contentType?)`; the multipart trigger is "any top-level body value is FileData" — `http.file` + `K6File` (data | ArrayBuffer | Uint8Array), used as body or inside a multipart object
+- [x] 60-hex-char random boundary; file parts carry `Content-Disposition` + `Content-Type`; **non-file parts get no `Content-Type`** and are stringified with `%v` — boundary is now a random 60-hex string (k6 crypto/rand parity); part framing + content-type rules verified
+- [x] Non-file object bodies fall back to `application/x-www-form-urlencoded`, arrays expanding to repeated keys — **arrays now expand** (`{a:[1,2]}` → `a=1&a=2`; test `test_urlencoded_array_values_expand_to_repeated_keys`)
+- [x] **[SUPERSET]** k6's part order is **non-deterministic** (Go map range) and it **doesn't escape the field name** for file parts — real k6 bugs. If tropel is deterministic and escapes both, **keep it and document the divergence** — tropel iterates keys in insertion order and escapes both field names and filenames (`escapeMultipartFieldName`); documented divergence
 
 ## TR-233 · Cookie jar, response callbacks, and the rest of the module
 **Effort:** M · **Blocked by:** TR-230


### PR DESCRIPTION
## What

Two TR-232 sub-items:

1. **Multipart boundary is now a random 60-hex-char string** (k6 uses crypto/rand hex). The old `----TropelFormBoundary` + random-alnum prefix was neither k6-shaped nor hex.
2. **k6 expands ARRAY values into repeated urlencoded keys** (`{a: [1, 2]}` → `a=1&a=2`). The old `String(array)` produced `a=1,2`, which a form parser reads as a single value.

`http.file`, file-part Content-Disposition/Content-Type, and the deterministic-order + field-name-escaping SUPERSET were already in place and are ticked + documented.

## Task

TR-232 · `http.file()` and multipart (W2 Track D — the `k6/http` surface).

## Acceptance

- [x] `http.file(data, filename?, contentType?)` + multipart trigger — already present
- [x] 60-hex-char random boundary; file parts carry Content-Disposition + Content-Type; non-file parts get no Content-Type — boundary fixed, rules verified
- [x] Non-file object bodies → urlencoded, arrays expand to repeated keys — **this PR**
- [x] SUPERSET (deterministic order + escaped names) — already present, documented

## Tests

- `k6::test_http_params_headers_not_mutated_and_multipart_boundary` — updated: asserts the generated boundary is 60 hex chars and frames the body (was `----TropelFormBoundary`).
- `k6::test_urlencoded_array_values_expand_to_repeated_keys` — NEW: `http.post(url, {a:[1,2], b:'x'})` sends `a=1&a=2&b=x`. Would have failed on the pre-fix code (`a=1,2`).
- Full k6 driver suite (167) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- The multipart boundary is generated in ONE place (`buildMultipartFormData`), used for both the body framing and the advertised Content-Type header — the two can't diverge. Array expansion is in `serializeUrlEncoded`, shared by the explicit `application/x-www-form-urlencoded` body and the k6 object-body default.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (167), clippy + fmt clean

## Risk

- The boundary change breaks any script that hardcoded the old `----TropelFormBoundary` literal (no real script does — it was an internal framing string). Array expansion changes `{a:[1,2]}` bodies from `a=1,2` to `a=1&a=2` — the k6-correct behavior; a server that relied on the comma-joined form was relying on the bug.
