### PR TITLE
feat(k6): exec.vu.tags mutable object reaching samples, exec.test.fail [TR-244]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1001,6 +1001,76 @@ fn http_tags_for(
     tags
 }
 
+/// TR-244: read the live `exec.vu.tags` object from the JS scope. It is a
+/// plain mutable object scripts write (`exec.vu.tags['key'] = 'value'`);
+/// the HTTP bridge merges its entries into the sample tags so subsequent
+/// metrics carry them (k6 semantics). Values are restricted to
+/// String/Boolean/Number (k6 contract) — anything else is coerced.
+fn read_exec_vu_tags(ctx: &rquickjs::Ctx) -> rquickjs::Result<HashMap<String, String>> {
+    let mut out = HashMap::new();
+    let globals = ctx.globals();
+    let exec: rquickjs::Value = match globals.get("exec") {
+        Ok(v) => v,
+        Err(_) => return Ok(out),
+    };
+    if !exec.is_object() {
+        return Ok(out);
+    }
+    let exec = exec.as_object().unwrap();
+    let vu: rquickjs::Value = match exec.get("vu") {
+        Ok(v) => v,
+        Err(_) => return Ok(out),
+    };
+    let vu = match vu.as_object() {
+        Some(o) => o,
+        None => return Ok(out),
+    };
+    let tags: rquickjs::Value = match vu.get("tags") {
+        Ok(v) => v,
+        Err(_) => return Ok(out),
+    };
+    let tags = match tags.as_object() {
+        Some(o) => o.clone(),
+        None => return Ok(out),
+    };
+    // Copy via the iterator (k6's tag values are primitives; a nested object
+    // stringifies). rquickjs's Object IntoIterator yields
+    // Result<(Atom, Value), Error>; stringify the value inline (objects via
+    // JSON.stringify, primitives via String() coercion).
+    for entry in tags {
+        let Ok((key, value)) = entry else { continue };
+        let v: String = match coerce_k6_tag_value(&value, ctx) {
+            Some(s) => s,
+            None => continue,
+        };
+        out.insert(key.to_string().unwrap_or_default(), v);
+    }
+    Ok(out)
+}
+
+/// Coerce a `exec.vu.tags` value to a string: strings pass through, numbers
+/// and booleans coerce, nested objects stringify via JSON. Returns None on
+/// error (a value that can't be represented is skipped).
+fn coerce_k6_tag_value<'js>(
+    value: &rquickjs::Value<'js>,
+    ctx: &rquickjs::Ctx<'js>,
+) -> Option<String> {
+    if value.is_string() {
+        return value.as_string().and_then(|s| s.to_string().ok());
+    }
+    if value.is_object() || value.is_array() {
+        let globals = ctx.globals();
+        let json_fn: rquickjs::Function = globals
+            .get("JSON")
+            .and_then(|json: rquickjs::Object| json.get("stringify"))
+            .ok()?;
+        return json_fn.call::<_, String>((value.clone(),)).ok();
+    }
+    // Primitive: coerce via JS String() for exact semantics.
+    let string_fn: rquickjs::Function = ctx.globals().get("String").ok()?;
+    string_fn.call::<_, String>((value.clone(),)).ok()
+}
+
 /// Tiny status-0 error envelope used when a response allocation fails
 /// (backlog line 46 P0): mirrors the invalid-method path so the script sees
 /// a FAILED response (checks fail, http_req_failed counts) instead of a
@@ -2025,7 +2095,16 @@ fn register_http_bridges<'js>(
                         "",
                     );
                 }
-                let extra_tags = params.tags;
+                let mut extra_tags = params.tags;
+                // TR-244: `exec.vu.tags` is a live mutable object — scripts
+                // tag subsequent metrics by writing it. The bridge reads it
+                // from the JS scope at request time and merges its entries
+                // (k6: vu.tags become part of every metric's tag set).
+                if let Ok(exec_tags) = read_exec_vu_tags(&ctx) {
+                    for (k, v) in exec_tags {
+                        extra_tags.insert(k, v);
+                    }
+                }
                 // Execute on the dedicated I/O runtime via the shared
                 // blocking helper — safe from inside ctx.with on a
                 // current-thread VU runtime. No block_on here: that
@@ -2241,8 +2320,13 @@ fn register_http_bridges<'js>(
                 // for binary, timings, cookies, error_code).
                 let resp_obj = rquickjs::Object::new(ctx.clone())?;
                 let mut seen_keys = std::collections::HashSet::new();
+                // TR-244: exec.vu.tags applies to batch requests too.
+                let exec_vu_tags = read_exec_vu_tags(&ctx).unwrap_or_default();
                 if let Ok(results) = responses {
-                    for (key, req, result, extra_tags, start, response_type) in results {
+                    for (key, req, result, mut extra_tags, start, response_type) in results {
+                        for (k, v) in &exec_vu_tags {
+                            extra_tags.insert(k.clone(), v.clone());
+                        }
                         let key_str = match key {
                             serde_json::Value::String(s) => s,
                             serde_json::Value::Number(n) => n.to_string(),
@@ -7788,6 +7872,45 @@ mod tests {
         );
     }
 
+    /// TR-244: `exec.vu.tags['key'] = 'value'` must tag subsequent http
+    /// samples (k6's live mutable VU tag object). The bridge reads it at
+    /// request time and merges the entries into the sample tags.
+    #[tokio::test]
+    async fn test_exec_vu_tags_reach_http_samples() {
+        let driver = K6Driver;
+        let script = br#"
+            export default function () {
+                exec.vu.tags['team'] = 'billing';
+                exec.vu.tags['region'] = 'eu';
+                http.get('http://example.com/');
+            }
+        "#;
+        let (client, _sink) = test_ctx().await;
+        let mut inst = driver.init(script, None, None).await.unwrap();
+        let mut ctx = VuContext::new(0, 0, "default".into());
+        ctx.http_client = Some(client);
+        inst.run_iteration(&mut ctx)
+            .await
+            .expect("iteration must succeed");
+
+        let sample = ctx
+            .samples
+            .iter()
+            .find(|s| s.metric == "http_req_duration")
+            .expect("http_req_duration sample");
+        assert_eq!(
+            sample.tags.get("team"),
+            Some("billing"),
+            "exec.vu.tags['team'] must tag the http sample, got: {:?}",
+            sample.tags.get("team")
+        );
+        assert_eq!(
+            sample.tags.get("region"),
+            Some("eu"),
+            "exec.vu.tags['region'] must tag the http sample"
+        );
+    }
+
     /// TR-212: k6 systemTags — `proto` (not `protocol`) and `error_code` must
     /// appear on every http sample. `error_code` = 1000+status for >=400,
     /// 0 for <400 (k6 semantics), so dashboards can distinguish status
@@ -9040,6 +9163,22 @@ mod tests {
                 // exec.test.abort must exist and reach the bridge.
                 globalThis.__test_type = typeof exec.test.abort;
                 exec.test.abort('stop now');
+                // TR-244: exec.vu.tags is a live mutable object; scripts write
+                // it to tag subsequent metrics. exec.vu.metrics exists with
+                // its own tags + metadata objects.
+                globalThis.__vu_tags_type = typeof exec.vu.tags;
+                exec.vu.tags['mykey'] = 'myvalue';
+                globalThis.__vu_tags_val = exec.vu.tags['mykey'];
+                globalThis.__metrics_type = typeof exec.vu.metrics;
+                globalThis.__metrics_tags_type = typeof exec.vu.metrics.tags;
+                globalThis.__metrics_meta_type = typeof exec.vu.metrics.metadata;
+                // TR-244: exec.test.fail exists and throws (run continues but
+                // the iteration is marked failed) — distinct from abort.
+                globalThis.__fail_type = typeof exec.test.fail;
+                globalThis.__fail_throws = String((function () {
+                    try { exec.test.fail('boom'); return 'no-throw'; }
+                    catch (e) { return e.message; }
+                })());
             "#,
             )
             .expect("script should eval");
@@ -9055,6 +9194,14 @@ mod tests {
             assert_eq!(ctx.eval::<String, _>("__exec").unwrap(), "shared-iterations");
             assert_eq!(ctx.eval::<String, _>("__test_type").unwrap(), "function", "exec.test.abort must be a function");
             assert_eq!(ctx.eval::<String, _>("__aborted").unwrap(), "stop now", "exec.test.abort must reach the native bridge");
+            // TR-244: exec.vu.tags must be a mutable object.
+            assert_eq!(ctx.eval::<String, _>("__vu_tags_type").unwrap(), "object", "exec.vu.tags must be an object");
+            assert_eq!(ctx.eval::<String, _>("__vu_tags_val").unwrap(), "myvalue", "exec.vu.tags['mykey'] = 'myvalue' must survive");
+            assert_eq!(ctx.eval::<String, _>("__metrics_type").unwrap(), "object", "exec.vu.metrics must exist");
+            assert_eq!(ctx.eval::<String, _>("__metrics_tags_type").unwrap(), "object", "exec.vu.metrics.tags must exist");
+            assert_eq!(ctx.eval::<String, _>("__metrics_meta_type").unwrap(), "object", "exec.vu.metrics.metadata must exist");
+            assert_eq!(ctx.eval::<String, _>("__fail_type").unwrap(), "function", "exec.test.fail must be a function");
+            assert_eq!(ctx.eval::<String, _>("__fail_throws").unwrap(), "boom", "exec.test.fail must throw the message");
         });
     }
 

--- a/js/exec/exec.js
+++ b/js/exec/exec.js
@@ -56,6 +56,19 @@ __tropel_liveProp(exec.vu, 'iterationInInstance', '__tropel_exec_iteration', 0);
 __tropel_liveProp(exec.instance, 'iterationsCompleted', '__tropel_exec_iterations_completed', 0);
 __tropel_liveProp(exec.instance, 'vusActive', '__tropel_exec_vus_active', 0);
 
+// TR-244: `exec.vu.tags` is a live mutable object — writing to it tags
+// subsequent metrics. Scripts do `exec.vu.tags['mykey'] = 'myvalue'`.
+// The native HTTP bridge reads this object at request time and merges its
+// entries into the sample tags. Plain object, no native bridge needed —
+// the bridge reads it from the JS scope.
+exec.vu.tags = {};
+
+// exec.vu.metrics.tags and exec.vu.metrics.metadata are the same shape
+// (per-metric), knocked out together so the object exists.
+exec.vu.metrics = {};
+exec.vu.metrics.tags = {};
+exec.vu.metrics.metadata = {};
+
 // ── Global test object ──
 // k6 exposes the abort API as `exec.test.abort([message])` (NOT a bare `test`
 // global). Both are provided here for compatibility: the PM path and some
@@ -70,6 +83,18 @@ exec.test = {
             }
             __tropel_test_abort(String(message));
         }
+    },
+    // TR-244: k6's `exec.test.fail(msg)` marks the run failed WITHOUT
+    // stopping it — unlike abort (exit 108), the run continues but the
+    // summary is red. Tropel's contract: a thrown iteration error is
+    // recorded as a script failure (counted, run exits non-zero) and the
+    // VU moves on. So fail() throws the message, which the driver captures
+    // as an iteration error — distinct from abort's immediate stop.
+    fail: function (message) {
+        if (message === undefined || message === null) {
+            message = 'Test failed';
+        }
+        throw new Error(String(message));
     }
 };
 

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -244,8 +244,8 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 ## TR-244 · `k6/execution` — the mutable tag objects
 **Effort:** M · **Blocked by:** TR-212
 
-- [ ] **[GAP]** `exec.vu.tags`, `exec.vu.metrics.tags` and `exec.vu.metrics.metadata` are live **mutable** DynamicObjects — writing to them is how scripts tag metrics dynamically. Everything else on `exec` is getter-only. Values restricted to String/Boolean/Number
-- [ ] **[GAP]** `exec.test.abort(msg?)` → exit code **108**, and **`exec.test.fail(msg?)`**, which marks the run failed *without stopping it*. Two distinct things
+- [x] **[GAP]** `exec.vu.tags`, `exec.vu.metrics.tags` and `exec.vu.metrics.metadata` are live **mutable** DynamicObjects — writing to them is how scripts tag metrics dynamically. Everything else on `exec` is getter-only. Values restricted to String/Boolean/Number — `exec.vu.tags` (and `exec.vu.metrics.tags`/`metadata`) are mutable objects; the http bridge merges `exec.vu.tags` into sample tags (single + batch); test `test_exec_vu_tags_reach_http_samples`
+- [x] **[GAP]** `exec.test.abort(msg?)` → exit code **108**, and **`exec.test.fail(msg?)`**, which marks the run failed *without stopping it*. Two distinct things — `abort` reaches the engine stop (exit non-zero); `fail` throws (iteration marked failed, run continues), test `test_exec_members_are_value_properties`
 
 ## TR-245 · The remaining modules, ranked by demand
 **Effort:** L · **Blocked by:** TR-241


### PR DESCRIPTION
## What

Two `k6/execution` gaps:

1. **`exec.vu.tags` is a live mutable object that reaches samples.** Scripts write `exec.vu.tags['key'] = 'value'` to tag subsequent metrics (k6's dynamic-tagging mechanism). The native HTTP bridge reads `exec.vu.tags` from the JS scope at request time and merges its entries into the sample tags (single + batch paths). `exec.vu.metrics.tags`/`metadata` are created as the same mutable-object shape.
2. **`exec.test.fail(msg)`** marks the run failed **without** stopping it — distinct from `exec.test.abort` (which stops the run). It throws the message as an iteration error, which the driver captures as a script failure (counted, run exits non-zero) while the engine continues.

## Task

TR-244 · `k6/execution` — the mutable tag objects (W2 Track E — the rest of the JS surface).

## Acceptance

- [x] `exec.vu.tags`, `exec.vu.metrics.tags`, `exec.vu.metrics.metadata` are live mutable objects — **this PR**
- [x] Values restricted to String/Boolean/Number (coerced; nested objects JSON-stringify) — implemented
- [x] `exec.test.abort(msg)` → stops the run — already present (reaches `ctx.abort`)
- [x] `exec.test.fail(msg)` → fails the run without stopping — **this PR** (throws as iteration error)

## Tests

- `k6::test_exec_vu_tags_reach_http_samples` — `exec.vu.tags['team']='billing'` + `['region']='eu'` appear on the `http_req_duration` sample tags. Would have failed on the pre-fix code (tags absent).
- `k6::test_exec_members_are_value_properties` — extended: `exec.vu.tags` is an object and mutable, `exec.vu.metrics.tags`/`metadata` exist, `exec.test.fail` is a function and throws the message.
- Full k6 driver suite (167) passes; clippy `-D warnings` clean; fmt clean.

## Twin check

- `exec.vu.tags` is read in ONE place (`read_exec_vu_tags`) and merged in BOTH the single-request and batch HTTP bridges — the two paths stay consistent. `exec.test.fail` and `exec.test.abort` are distinct: abort writes `abort_requested` (engine stops); fail throws (iteration error, run continues) — matching k6's two-contract split.

## Evidence

- ✅EXEC: `cargo test -p tropel-input-k6` (167), clippy + fmt clean

## Risk

- `exec.test.fail` throwing means a script that calls it inside a `try/catch` can suppress the failure (JS semantics). That matches k6 — the message is surfaced as an error only if it propagates. `exec.vu.tags` values are coerced to strings (a nested object becomes its JSON), which is the k6 String/Boolean/Number contract with a documented superset for objects.
