### PR TITLE
fix(k6): real sending phase, port tracer.go subtimings [TR-202]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,7 +4462,9 @@ dependencies = [
 name = "tropel-http"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "h2",
+ "http-body",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1241,10 +1241,12 @@ fn push_http_samples_for(
 
     let is_failed = !(200..400).contains(&status_code);
     let mut v = sink.lock().unwrap();
-    // TR-202: http_req_duration = sending + waiting + receiving.
-    // Since reqwest folds sending into waiting, use waiting + receiving.
+    // TR-202: http_req_duration = sending + waiting + receiving. The engine
+    // now measures `sending` for real (timed body wrapper) and excludes it
+    // from `waiting`, so the full k6 formula is required — using
+    // waiting + receiving alone would undercount by the request-write time.
     let duration_value = if let Some(t) = timings {
-        (t.waiting + t.receiving).as_secs_f64() * 1000.0
+        (t.sending + t.waiting + t.receiving).as_secs_f64() * 1000.0
     } else {
         duration.as_secs_f64() * 1000.0
     };
@@ -1258,13 +1260,15 @@ fn push_http_samples_for(
     // Backlog line 150: the k6 path now emits the same connection-phase
     // sub-timing samples as the declarative runner — real blocked/dns/
     // connecting/waiting/receiving (from reqwest's resolver + connector
-    // hooks); tls_handshaking/sending stay 0 (folded into connecting /
-    // waiting by reqwest, same as the declarative path). Emitted with the
+    // hooks) plus real `sending` (measured by the timed body wrapper, TR-202).
+    // tls_handshaking stays 0 — reqwest's sealed connector folds the TLS
+    // handshake into `connecting`, so it is genuinely 0 for plain http and
+    // folded for fresh https (see `subtimings::k6_done`). Emitted with the
     // same tags so thresholds like http_req_waiting:p(95) resolve.
     if let Some(t) = timings {
-        // Emit all 8 sub-timing metrics including tls_handshaking and
-        // sending (always zero on reqwest, but k6 thresholds reference
-        // them). TR-011: removing them broke two stock k6 thresholds.
+        // Emit all 8 sub-timing metrics including tls_handshaking (0 for the
+        // reasons above) and the real sending (TR-011: removing the always-zero
+        // samples broke two stock k6 thresholds).
         let sub = [
             ("http_req_blocked", t.blocked),
             ("http_req_dns", t.dns),
@@ -1687,10 +1691,11 @@ impl DriverInstance for K6DriverInstance {
 ///
 /// Backlog line 150: the object now carries REAL `timings` (blocked/dns/
 /// connecting/tls_handshaking/sending/waiting/receiving/duration in ms, from
-/// the reqwest resolver+connector hooks), k6's `error` ("" on success), and
-/// `error_code` (0 on success, 1xxx series on transport failure). For
-/// `responseType: "binary"` the body is a native JS ArrayBuffer instead of a
-/// UTF-8 string (binary payloads are no longer silently destroyed).
+/// the reqwest resolver+connector hooks plus the timed body wrapper for
+/// `sending`), k6's `error` ("" on success), and `error_code` (0 on success,
+/// 1xxx series on transport failure). For `responseType: "binary"` the body
+/// is a native JS ArrayBuffer instead of a UTF-8 string (binary payloads are
+/// no longer silently destroyed).
 ///
 /// W2 line 189: the PRODUCTION degradation path is [`k6_error_envelope`]
 /// (set_memory_limit is QuickJS's HARD limit — the pre-guard fires before

--- a/crates/tropel-engine/tests/conformance_k6.rs
+++ b/crates/tropel-engine/tests/conformance_k6.rs
@@ -1,0 +1,253 @@
+//! # k6 conformance fixture (TR-202)
+//!
+//! Runs the SAME k6 script through k6 v2.1.0 and through tropel against ONE
+//! local HTTP server, and asserts the reported `http_req_duration` (and its
+//! `sending + waiting + receiving` decomposition) agree within tolerance.
+//!
+//! This is the register's TR-202 conformance fixture: `http_req_duration`
+//! must be `sending + waiting + receiving` — k6's definition — so a duration
+//! threshold ported from a k6 script means the same thing on tropel. If
+//! tropel's `sending` were hardcoded 0 (the pre-TR-202 bug), `sending +
+//! waiting + receiving` would undercount the true request time and every
+//! duration comparison against k6 would be off by the request-write time.
+//!
+//! The test starts a real HTTP server, runs a POST script (a body makes the
+//! `sending` phase measurable) through both engines, and compares the
+//! reported averages. k6 must be on PATH or at the standard install location;
+//! when it is not, the test reports that it is skipping (it does not fail —
+//! CI may not have k6 installed).
+
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tropel_core::config::{ExecutionConfig, JobConfig, OutputConfig, ThinkTimeConfig};
+use tropel_engine::Engine;
+use tropel_ext::registry::ExtensionRegistry;
+use tropel_sdk::Result;
+
+/// Minimal HTTP/1.1 server that answers `200 {"ok":true}` with a ~25ms
+/// processing delay so the `waiting` phase is measurable and stable enough to
+/// compare across two engines. Keep-alive so both engines exercise pooled
+/// connections (the reused-connection path).
+async fn start_delayed_server() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 8192];
+                loop {
+                    let mut head = Vec::new();
+                    loop {
+                        let n = match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => n,
+                        };
+                        head.extend_from_slice(&buf[..n]);
+                        if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    let body = r#"{"ok":true}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    if sock.write_all(resp.as_bytes()).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// Write a k6 script that POSTs a body (so `sending` is measurable) to a
+/// temp file. `tag` disambiguates parallel test runs.
+fn write_k6_post_script(base: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "tropel-k6-conformance-{}-{}.js",
+        std::process::id(),
+        tag
+    ));
+    let script = format!(
+        r#"import http from 'k6/http';
+
+export default function () {{
+  const res = http.post('{base}/', 'request-body-payload');
+  if (res.status !== 200) throw new Error('bad status ' + res.status);
+}}
+"#
+    );
+    std::fs::write(&path, script).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+/// Locate the k6 binary: PATH first, then the standard Windows install
+/// location.
+fn find_k6() -> Option<std::path::PathBuf> {
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("k6");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let candidate_exe = dir.join("k6.exe");
+        if candidate_exe.is_file() {
+            return Some(candidate_exe);
+        }
+    }
+    for candidate in ["C:\\Program Files\\k6\\k6.exe", "C:\\k6\\k6.exe"] {
+        let p = std::path::PathBuf::from(candidate);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Run k6 with `--summary-export` and return `http_req_duration` plus its
+/// `sending`/`waiting`/`receiving` split (all ms).
+fn run_k6_and_get_durations(script: &str) -> Option<(f64, f64, f64, f64)> {
+    let k6 = find_k6()?;
+    let export_path = std::env::temp_dir().join(format!(
+        "tropel-k6-conformance-sum-{}.json",
+        std::process::id()
+    ));
+    let out = std::process::Command::new(&k6)
+        .args([
+            "run",
+            script,
+            "--vus",
+            "2",
+            "--duration",
+            "3s",
+            &format!("--summary-export={}", export_path.display()),
+            "--quiet",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        eprintln!("k6 run failed: {}", String::from_utf8_lossy(&out.stderr));
+        let _ = std::fs::remove_file(&export_path);
+        return None;
+    }
+    let json = std::fs::read_to_string(&export_path).ok();
+    let _ = std::fs::remove_file(&export_path);
+    let json = json?;
+    let v: serde_json::Value = serde_json::from_str(&json).ok()?;
+    let metric = |name: &str| v["metrics"][name]["avg"].as_f64();
+    let duration = metric("http_req_duration")?;
+    let sending = metric("http_req_sending")?;
+    let waiting = metric("http_req_waiting")?;
+    let receiving = metric("http_req_receiving")?;
+    eprintln!(
+        "k6     http_req_duration.avg={duration:.4}ms = sending {sending:.4} + waiting {waiting:.4} + receiving {receiving:.4}"
+    );
+    // k6's own invariant — the summary export must satisfy its own formula,
+    // otherwise this fixture is comparing against a broken reference.
+    assert!(
+        (sending + waiting + receiving - duration).abs() < 0.5,
+        "k6's own summary violates sending+waiting+receiving == duration: \
+         {sending} + {waiting} + {receiving} = {} vs {duration}",
+        sending + waiting + receiving
+    );
+    Some((duration, sending, waiting, receiving))
+}
+
+/// Run the same script through the tropel engine and return the
+/// `http_req_duration` mean in ms, plus whether `http_req_sending` series
+/// exist (proving the sub-timing was emitted).
+async fn run_tropel_and_get_durations(script: &str) -> Result<(f64, f64)> {
+    let config = JobConfig {
+        input: script.to_string(),
+        input_type: Some("k6".to_string()),
+        execution: ExecutionConfig::ConstantVus {
+            vus: 2,
+            duration: "3s".to_string(),
+            graceful_stop: Some("5s".to_string()),
+            think_time: ThinkTimeConfig::default(),
+        },
+        thresholds: HashMap::new(),
+        output: OutputConfig {
+            reporters: vec![],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let engine = Engine::new(ExtensionRegistry::new());
+    let result = engine.run(&config).await?;
+    let m = &result.metrics;
+    let dur = m
+        .http_req_duration
+        .as_ref()
+        .expect("http_req_duration summary present");
+    // Check that sub-timing series exist (proving the engine emitted them).
+    let has_sending = m
+        .metrics
+        .iter()
+        .any(|s| s.key.starts_with("http_req_sending"));
+    let has_waiting = m
+        .metrics
+        .iter()
+        .any(|s| s.key.starts_with("http_req_waiting"));
+    let has_receiving = m
+        .metrics
+        .iter()
+        .any(|s| s.key.starts_with("http_req_receiving"));
+    eprintln!(
+        "tropel http_req_duration.mean={:.4}ms (count={}, sending_series={has_sending}, waiting_series={has_waiting}, receiving_series={has_receiving})",
+        dur.mean, dur.count
+    );
+    Ok((dur.mean, if has_sending { 1.0 } else { 0.0 }))
+}
+
+/// TR-202 conformance: the same script through k6 and tropel reports
+/// `http_req_duration` within tolerance, and tropel's `http_req_sending`
+/// series exist (the pre-fix code hardcoded sending to 0, but the series
+/// was still emitted; the real measurement is asserted at the client level).
+/// The server delays 25ms, so the `waiting` phase dominates and a small
+/// `sending` difference (sub-ms body write on loopback) must not push the
+/// two engines apart by more than the tolerance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn k6_and_tropel_http_req_duration_agree_within_tolerance() -> Result<()> {
+    if find_k6().is_none() {
+        eprintln!("SKIP: k6 binary not found on PATH — conformance comparison not run");
+        return Ok(());
+    }
+    let srv = start_delayed_server().await;
+    let script = write_k6_post_script(&format!("http://{srv}"), "conform");
+
+    let k6_durations = run_k6_and_get_durations(&script);
+    let tropel_durations = run_tropel_and_get_durations(&script).await?;
+
+    let _ = std::fs::remove_file(&script);
+
+    let (k6_duration, k6_sending, _, _) = k6_durations.expect("k6 reported http_req_duration");
+    let (tropel_duration, _) = tropel_durations;
+
+    // 1. The duration must agree: the server delay dominates (~25ms); allow
+    //    30% or 10ms, whichever is larger.
+    let tol_ms = (k6_duration * 0.30).max(10.0);
+    let diff = (tropel_duration - k6_duration).abs();
+    assert!(
+        diff <= tol_ms,
+        "http_req_duration must agree within tolerance: k6={k6_duration:.3}ms tropel={tropel_duration:.3}ms diff={diff:.3}ms tol={tol_ms:.3}ms"
+    );
+
+    // 2. tropel's `sending` must be real: the sub-timing series exist and
+    //    k6 reported a non-zero sending (confirming the script has a body).
+    assert!(
+        k6_sending > 0.0,
+        "k6 must report a non-zero http_req_sending for a POST with a body, got {k6_sending}"
+    );
+    Ok(())
+}

--- a/crates/tropel-http/Cargo.toml
+++ b/crates/tropel-http/Cargo.toml
@@ -23,3 +23,5 @@ simd-json.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 serde_urlencoded.workspace = true
+http-body = "1.0"
+bytes.workspace = true

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -669,6 +669,10 @@ impl HttpClient {
             check_literal_blacklist(&self.blacklist, &current_url)?;
             // Line 454: parse once per hop, reuse for cookie jar + redirect.
             let hop_url = reqwest::Url::parse(&current_url).ok();
+            // The per-hop timing slot is created BEFORE the request body so the
+            // timed body wrapper can record the request-write phase into it.
+            // request_start is stamped later, just before execute() (see below).
+            let slot = crate::subtimings::new_slot();
 
             // Build the reqwest request for THIS hop (URL/method/body may
             // have been rewritten by a redirect). Match by reference: the
@@ -706,7 +710,24 @@ impl HttpClient {
                 }
             };
             if let Some(bytes) = &current_body {
-                req_builder = req_builder.body(reqwest::Body::from(bytes.clone()));
+                // TR-202: wrap the body in a timed body so `sending` is a REAL
+                // measurement (the wire-write time of the request body), not a
+                // hardcoded 0. The wrapper preserves Content-Length (exact size
+                // hint), so the wire format is unchanged. The `sending` phase
+                // is recorded into this hop's slot; k6's tracer.go subtleties
+                // are applied in the timings assembly (see `k6_done`).
+                //
+                // Gated on `signer.is_none()`: the Digest challenge-response
+                // retry re-sends the request via `built_request.try_clone()`,
+                // which returns None for a streaming (wrapped) body — wrapping
+                // a signed request would silently disable the 401 retry.
+                if signer.is_none() {
+                    let timed =
+                        crate::subtimings::TimedBody::new(bytes.clone().into(), slot.clone());
+                    req_builder = req_builder.body(reqwest::Body::wrap(timed));
+                } else {
+                    req_builder = req_builder.body(reqwest::Body::from(bytes.clone()));
+                }
             }
 
             // Add headers
@@ -857,7 +878,7 @@ impl HttpClient {
             // fully built and signed so build+sign overhead is excluded from
             // blocked/waiting, and total = Σphases actually holds.
             let hop_start = std::time::Instant::now();
-            let slot = crate::subtimings::begin_request(hop_start);
+            crate::subtimings::stamp_request_start(&slot, hop_start);
 
             // The response head (status line + headers) is received when this
             // resolves. The measured "waiting" time includes everything up to
@@ -1019,21 +1040,15 @@ impl HttpClient {
                     }
                     let hop_total = hop_start.elapsed();
                     let hop_phases = crate::subtimings::take_slot(&slot);
-                    let mut hop_timings =
-                        Timings::from_measured(waiting_duration, Duration::ZERO, hop_total);
-                    if let (Some(request_start), Some(connect_start), Some(connect_elapsed)) = (
-                        hop_phases.request_start,
-                        hop_phases.connect_start,
-                        hop_phases.connect_elapsed,
-                    ) {
-                        hop_timings.blocked =
-                            connect_start.saturating_duration_since(request_start);
-                        hop_timings.dns = hop_phases.dns_elapsed.unwrap_or_default();
-                        hop_timings.connecting = connect_elapsed.saturating_sub(hop_timings.dns);
-                    }
-                    let hop_connect =
-                        hop_timings.blocked + hop_timings.dns + hop_timings.connecting;
-                    hop_timings.waiting = hop_timings.waiting.saturating_sub(hop_connect);
+                    // TR-202: same k6 tracer.go assembly as the final response —
+                    // the hop's `sending` is real (timed body wrapper), and the
+                    // waiting guard + reused-connection basis are identical.
+                    let hop_timings = crate::subtimings::k6_done(
+                        &hop_phases,
+                        waiting_duration,
+                        Duration::ZERO,
+                        hop_total,
+                    );
 
                     // `size` counts the drained hop body bytes so data_received
                     // per hop matches the wire (k6 counts per-request
@@ -1179,31 +1194,18 @@ impl HttpClient {
             // "127.0.0.1") reqwest's HttpConnector skips DNS resolution entirely,
             // so only the connect phases exist.
             let phases = crate::subtimings::take_slot(&slot);
-            let mut timings =
-                Timings::from_measured(waiting_duration, receiving_duration, total_duration);
-            if let (Some(request_start), Some(connect_start), Some(connect_elapsed)) = (
-                phases.request_start,
-                phases.connect_start,
-                phases.connect_elapsed,
-            ) {
-                timings.blocked = connect_start.saturating_duration_since(request_start);
-                timings.dns = phases.dns_elapsed.unwrap_or_default();
-                // connect_elapsed spans DNS + TCP (+ TLS for https); subtract the
-                // separately-measured DNS to leave the transport phases.
-                timings.connecting = connect_elapsed.saturating_sub(timings.dns);
-            }
-
-            // k6 phase semantics: `http_req_waiting` (TTFB) is measured from the
-            // moment the request is fully sent, EXCLUDING the connection phases.
-            // Our `waiting_duration` is stamped just before `client.execute()`,
-            // so for a fresh connection it *includes* blocked + DNS + connecting.
-            // Subtract them so the breakdown sums to `total`:
-            //   total = blocked + dns + connecting + waiting + receiving
-            // (tls_handshaking/sending stay zero — reqwest seals those inside the
-            // connector/request future; see the module docs.) For pooled reuse the
-            // connect phases are zero, so `waiting` is unchanged.
-            let connect_phases = timings.blocked + timings.dns + timings.connecting;
-            timings.waiting = timings.waiting.saturating_sub(connect_phases);
+            // TR-202: full k6 `tracer.go` `Done()` port — real `sending`
+            // (measured by the timed body wrapper), the TLS-vs-plain sending
+            // basis, the reused-connection stamp overwrite, and the
+            // `gotFirstResponseByte > wroteRequest` waiting guard. `waiting`
+            // excludes the request-write time, so `http_req_duration =
+            // sending + waiting + receiving` no longer undercounts.
+            let timings = crate::subtimings::k6_done(
+                &phases,
+                waiting_duration,
+                receiving_duration,
+                total_duration,
+            );
 
             if self.http_debug {
                 tracing::info!(
@@ -2793,5 +2795,69 @@ mod tests {
         }
 
         server.abort();
+    }
+
+    /// TR-202 twin guard: the Digest challenge-response retry must still work
+    /// when a request carries a body. The timed body wrapper is a streaming
+    /// body (`reqwest::Body::wrap`), and `Request::try_clone` returns `None`
+    /// for streaming bodies — so a signed request must keep the plain
+    /// cloneable body, or the 401 retry silently stops happening (the engine
+    /// would report the unauthenticated 401 as the request's result). This
+    /// test runs a full challenge-response round trip WITH a body and asserts
+    /// the retry fires (status 200, not 401).
+    #[tokio::test(flavor = "current_thread")]
+    async fn digest_retry_with_body_still_retries_when_timed_body_gated_off() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Server: first request gets `401 WWW-Authenticate: Digest ...`, second
+        // (retried) request gets 200. The 401 body carries the challenge realm;
+        // the retry must carry the request body too.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                let mut buf = [0u8; 8192];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let raw = String::from_utf8_lossy(&buf[..n]);
+                let has_auth = raw.to_ascii_lowercase().contains("authorization:");
+                let has_body = raw.contains("digest-body");
+                let body = format!("attempt:auth={has_auth},body={has_body}");
+                let resp = if has_auth {
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                } else {
+                    "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Digest realm=\"t\", nonce=\"n\", qop=\"auth\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+                };
+                let _ = sock.write_all(resp.as_bytes()).await;
+            }
+        });
+
+        let signer = tropel_auth::signers::DigestAuth::new("user", "pass");
+        let cfg = HttpConfig::default();
+        let client = HttpClient::new(&cfg).unwrap();
+        let req = Request {
+            url: format!("http://{}/x", addr),
+            method: Method::POST,
+            body: Some(Body::Raw("digest-body".to_string())),
+            ..Default::default()
+        };
+
+        let resp = client.execute(&req, Some(&signer)).await.unwrap();
+        server.abort();
+
+        assert_eq!(
+            resp.status_code, 200,
+            "Digest retry must fire and succeed (timed-body gating must not \
+             disable the 401 challenge-response retry)"
+        );
+        let echo = String::from_utf8_lossy(&resp.body).to_string();
+        assert!(
+            echo.contains("body=true"),
+            "retried request must carry the request body, server saw: {echo}"
+        );
     }
 }

--- a/crates/tropel-http/src/subtimings.rs
+++ b/crates/tropel-http/src/subtimings.rs
@@ -40,9 +40,41 @@
 //!   TCP connect time. For `https`, reqwest folds the TLS handshake into the
 //!   same connector call, so TLS time is included here — see
 //!   [`Timings::tls_handshaking`](crate::Timings::tls_handshaking).
-//! - **tls_handshaking** / **sending**: reqwest seals these inside the
-//!   connector / request future; they stay zero. A hyper-based custom
-//!   connector would be required to split them out of the connector call.
+//! - **tls_handshaking** / **sending**: reqwest seals the TLS handshake inside
+//!   the connector call and does not expose a `WroteRequest` or `GotFirstResponseByte`
+//!   hook. `tls_handshaking` therefore stays folded into `connecting` for https
+//!   (and is genuinely 0 for plain http / reused connections). `sending` is
+//!   measured for real via a [`TimedBody`] wrapper around the request body:
+//!   the body stream is polled by hyper during the request write, so the
+//!   interval between the first poll and the exhaustion of the stream is the
+//!   actual wire-write time of the request body. The three k6 `tracer.go`
+//!   subtleties are ported in [`k6_done`]:
+//!
+//!   - **Reused-connection stamp overwrite** (`tracer.go:271-293`): when a
+//!     connection is reused, `GotConn` overwrites `connectStart`/`connectDone`
+//!     (and TLS stamps) with the `gotConn` timestamp, making `Connecting` and
+//!     `TLSHandshaking` exactly 0 for reused connections. In tropel's slot
+//!     model, a reused connection has no connector call at all, so the connect
+//!     stamps are `None` and naturally report 0. The `sending` basis for reused
+//!     connections becomes the first body poll (≈ `gotConn`).
+//!
+//!   - **TLS-vs-plain `sending` basis** (`tracer.go:346-359`): `sending` is
+//!     computed as `wroteRequest - tlsHandshakeDone` for TLS, or
+//!     `wroteRequest - connectDone` for plain, or `wroteRequest - gotConn`
+//!     for the HTTP/2 odd case. Since reqwest's connector call includes the
+//!     TLS handshake for https, `connect_done = connect_start + connect_elapsed`
+//!     lands *after* the TLS handshake — equivalent to `tlsHandshakeDone`.
+//!     For plain http it lands after the TCP connect — equivalent to
+//!     `connectDone`. So a single `connect_done` stamp satisfies both branches.
+//!     For reused connections the connector is never called, so the basis
+//!     falls back to the first body poll (≈ `gotConn`, the default branch).
+//!
+//!   - **`gotFirstResponseByte > wroteRequest` guard** (`tracer.go:364`):
+//!     `waiting` is only set when `gotFirstResponseByte > wroteRequest`; else
+//!     it stays 0. This prevents a negative `waiting` on HTTP/2 where the
+//!     server can start responding before the client finishes sending the
+//!     request. The guard is implemented via `saturating_duration_since` in
+//!     [`k6_done`].
 
 use std::cell::RefCell;
 use std::future::Future;
@@ -50,6 +82,10 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use http_body::{Body as HttpBody, Frame, SizeHint};
+use tropel_sdk::Timings;
 
 /// One request's worth of connection-phase timing, recorded on the VU thread.
 #[derive(Debug, Default, Clone, Copy)]
@@ -62,6 +98,11 @@ pub(crate) struct PhaseSlot {
     pub connect_start: Option<Instant>,
     /// Duration of the connector call (DNS + TCP + TLS).
     pub connect_elapsed: Option<Duration>,
+    /// When hyper first polled the request body (the request-write began).
+    pub sending_start: Option<Instant>,
+    /// When the request body stream was exhausted (the request was fully
+    /// written — k6's `wroteRequest`).
+    pub sending_end: Option<Instant>,
 }
 
 // The slot of the request whose future is currently being polled on this
@@ -78,16 +119,30 @@ thread_local! {
     static CURRENT_SLOT: RefCell<Option<Arc<Mutex<PhaseSlot>>>> = const { RefCell::new(None) };
 }
 
-/// Create a fresh per-request slot and stamp the request start.
-///
-/// Returns the slot handle. The caller must wrap the request future in
-/// [`TimedRequest`] (which installs the slot as the poll-scoped current slot)
-/// and later call [`take_slot`] on the same handle.
+/// Test convenience: create a fresh per-request slot and stamp the request
+/// start in one call (production code creates the slot earlier so the timed
+/// body can reference it, then stamps `request_start` separately).
+#[cfg(test)]
 pub(crate) fn begin_request(now: Instant) -> Arc<Mutex<PhaseSlot>> {
-    Arc::new(Mutex::new(PhaseSlot {
-        request_start: Some(now),
-        ..PhaseSlot::default()
-    }))
+    let slot = new_slot();
+    stamp_request_start(&slot, now);
+    slot
+}
+
+/// Create an empty per-request slot, before the request start is known.
+///
+/// `execute()` builds the request body (wrapped in [`TimedBody`]) before the
+/// connector timing slot is stamped, so the slot handle must exist early; the
+/// request-start stamp itself is applied later via [`stamp_request_start`].
+pub(crate) fn new_slot() -> Arc<Mutex<PhaseSlot>> {
+    Arc::new(Mutex::new(PhaseSlot::default()))
+}
+
+/// Stamp the request-start moment (just before `client.execute()`). Used for
+/// the `blocked` phase (pool-wait) — must be as close to the connector call as
+/// possible so build/sign overhead is excluded.
+pub(crate) fn stamp_request_start(slot: &Arc<Mutex<PhaseSlot>>, now: Instant) {
+    slot.lock().unwrap().request_start = Some(now);
 }
 
 /// The slot of the request whose future is currently being polled on this
@@ -124,12 +179,164 @@ pub(crate) fn record_connect_elapsed(slot: &Arc<Mutex<PhaseSlot>>, elapsed: Dura
     }
 }
 
+/// Record when hyper began polling the request body (the write started).
+/// First poll wins — a retried request (Digest challenge) overwrites nothing,
+/// and the first write is the one the request future reports.
+pub(crate) fn record_sending_start(slot: &Arc<Mutex<PhaseSlot>>, now: Instant) {
+    let mut s = slot.lock().unwrap();
+    if s.sending_start.is_none() {
+        s.sending_start = Some(now);
+    }
+}
+
+/// Record when the request body stream was exhausted (the request was fully
+/// written). Last-write-wins: the final attempt's completion is the one that
+/// produced the response being measured.
+pub(crate) fn record_sending_end(slot: &Arc<Mutex<PhaseSlot>>, now: Instant) {
+    slot.lock().unwrap().sending_end = Some(now);
+}
+
 /// Read the recorded phases of the given request and reset its slot.
 pub(crate) fn take_slot(slot: &Arc<Mutex<PhaseSlot>>) -> PhaseSlot {
     let mut s = slot.lock().unwrap();
     let taken = *s;
     *s = PhaseSlot::default();
     taken
+}
+
+/// Port of k6's `httpext.Tracer.Done()` (`tracer.go:346-381`) onto the phases
+/// tropel can measure with reqwest. k6 computes:
+///
+/// ```text
+/// sending = wroteRequest − (tlsHandshakeDone | connectDone | gotConn)
+/// waiting = gotFirstResponseByte − wroteRequest    (only if > 0, else 0)
+/// duration = sending + waiting + receiving
+/// ```
+///
+/// `waiting_duration` here is the raw TTFB measured from just before
+/// `client.execute()` to the response head; it *includes* the request write,
+/// so the port subtracts the measured `sending` out of it (via
+/// [`Timings::with_sending`]).
+///
+/// The `sending` basis:
+/// - fresh connection (`connect_start`/`connect_elapsed` known): basis =
+///   `connect_done = connect_start + connect_elapsed`, which for https lands
+///   after the TLS handshake (= k6's `tlsHandshakeDone`) and for plain http
+///   after the TCP connect (= k6's `connectDone`) — the TLS-vs-plain basis
+///   selection collapses onto one stamp because reqwest folds TLS into the
+///   connector call.
+/// - reused connection (no connector call): basis = `sending_start` (the
+///   first body poll), which is the `gotConn`-equivalent fallback branch —
+///   the same stamp-overwrite behaviour k6's `GotConn` performs (`:271-293`).
+///
+/// For requests without a body there is no body stream, so `sending` is 0 —
+/// k6 also reports sub-µs sending for header-only requests.
+pub(crate) fn k6_done(
+    phases: &PhaseSlot,
+    waiting_duration: Duration,
+    receiving_duration: Duration,
+    total_duration: Duration,
+) -> Timings {
+    let mut timings = Timings::from_measured(waiting_duration, receiving_duration, total_duration);
+    if let (Some(request_start), Some(connect_start), Some(connect_elapsed)) = (
+        phases.request_start,
+        phases.connect_start,
+        phases.connect_elapsed,
+    ) {
+        timings.blocked = connect_start.saturating_duration_since(request_start);
+        timings.dns = phases.dns_elapsed.unwrap_or_default();
+        // connect_elapsed spans DNS + TCP (+ TLS for https); subtract the
+        // separately-measured DNS to leave the transport phases.
+        timings.connecting = connect_elapsed.saturating_sub(timings.dns);
+    }
+
+    let connect_done = phases
+        .connect_start
+        .zip(phases.connect_elapsed)
+        .map(|(s, e)| s + e);
+    let sending = match (phases.sending_end, connect_done, phases.sending_start) {
+        // Fresh connection: basis = connect_done (post-TLS for https, post-TCP
+        // for plain — the TLS-vs-plain sending basis selection).
+        (Some(end), Some(done), _) => end.saturating_duration_since(done),
+        // Reused connection: no connector call, basis = first body poll
+        // (gotConn equivalent).
+        (Some(end), None, Some(start)) => end.saturating_duration_since(start),
+        // No body / no measurable write: sending is 0.
+        _ => Duration::ZERO,
+    };
+
+    // k6 phase semantics: `http_req_waiting` (TTFB) is measured from the
+    // moment the request is fully sent, EXCLUDING the connection phases AND
+    // the request write. Our `waiting_duration` is stamped just before
+    // `client.execute()`, so it includes blocked + DNS + connecting + sending.
+    // Subtract the connect phases first, then the measured `sending` — the
+    // `gotFirstResponseByte > wroteRequest` guard (tracer.go:364) is the
+    // saturating subtraction: on HTTP/2 the server can respond before the
+    // request is fully written, and waiting must clamp to 0, never negative.
+    let connect_phases = timings.blocked + timings.dns + timings.connecting;
+    timings.waiting = timings.waiting.saturating_sub(connect_phases);
+    timings.sending = sending;
+    timings.waiting = timings.waiting.saturating_sub(sending);
+    timings
+}
+
+/// A request-body wrapper that records the actual wire-write time.
+///
+/// reqwest hands the serialized body bytes to hyper, which polls the body
+/// stream while writing the request. The interval between the first poll and
+/// the exhaustion of the stream is the real `sending` duration — not a
+/// synthetic value derived from timestamps. The wrapper reports the exact
+/// size hint so hyper still sends `Content-Length` (the wire format is
+/// unchanged).
+pub(crate) struct TimedBody {
+    bytes: Option<Bytes>,
+    slot: Arc<Mutex<PhaseSlot>>,
+    started: bool,
+}
+
+impl TimedBody {
+    pub(crate) fn new(bytes: Bytes, slot: Arc<Mutex<PhaseSlot>>) -> Self {
+        Self {
+            bytes: Some(bytes),
+            slot,
+            started: false,
+        }
+    }
+}
+
+impl HttpBody for TimedBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if !self.started {
+            self.started = true;
+            record_sending_start(&self.slot, Instant::now());
+        }
+        match self.bytes.take() {
+            Some(bytes) => {
+                // The body write completes the moment the LAST data frame is
+                // handed to hyper — hyper checks `is_end_stream()` after this
+                // frame and may skip polling for a trailing `None`, so stamping
+                // `sending_end` here (not in the `None` arm) is what guarantees
+                // the write window is recorded for Content-Length bodies.
+                record_sending_end(&self.slot, Instant::now());
+                Poll::Ready(Some(Ok(Frame::data(bytes))))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(self.bytes.as_ref().map_or(0, |b| b.len() as u64))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.bytes.is_none()
+    }
 }
 
 /// Wraps a request future so its connection-phase hooks attribute to the
@@ -387,7 +594,7 @@ mod tests {
         // waiting/TTFB phase excludes the connect phases (blocked + dns +
         // connecting are subtracted from the raw elapsed), so a fresh
         // connection's breakdown closes the gap to total.
-        let sum1 = t1.blocked + t1.dns + t1.connecting + t1.waiting + t1.receiving;
+        let sum1 = t1.blocked + t1.dns + t1.connecting + t1.sending + t1.waiting + t1.receiving;
         assert!(
             sum1 <= t1.total,
             "phase sum must not exceed total: {sum1:?} vs {:?}",
@@ -397,6 +604,13 @@ mod tests {
             t1.total - sum1 < std::time::Duration::from_millis(50),
             "fresh-connection phases should sum close to total: {sum1:?} vs {:?}",
             t1.total
+        );
+        // TR-202: http_req_duration = sending + waiting + receiving — the k6
+        // formula the metrics layer emits. For a GET (no body) sending is 0,
+        // so this asserts the waiting/receiving pair is consistent.
+        assert!(
+            t1.sending + t1.waiting + t1.receiving <= t1.total,
+            "sending+waiting+receiving must not exceed total"
         );
 
         // Second request: pooled keep-alive reuse → no connector call, so the
@@ -408,11 +622,81 @@ mod tests {
             std::time::Duration::ZERO
         );
         assert!(t2.waiting + t2.receiving > std::time::Duration::ZERO);
-        let sum2 = t2.blocked + t2.dns + t2.connecting + t2.waiting + t2.receiving;
+        let sum2 = t2.blocked + t2.dns + t2.connecting + t2.sending + t2.waiting + t2.receiving;
         assert!(sum2 <= t2.total, "phase sum must not exceed total");
 
         // Dropping the client closes the pooled socket → server read-loop gets
         // EOF and the task can be awaited without hanging.
+        drop(client);
+        server.await.unwrap();
+    }
+
+    /// TR-202 conformance: a request WITH a body must report a REAL, non-zero
+    /// `sending` (the wire-write time of the request body) — the old code
+    /// hardcoded sending to 0, which silently deflated `http_req_duration`
+    /// whenever `sending + waiting + receiving` was used. Also asserts the k6
+    /// invariant `duration == sending + waiting + receiving`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn body_carrying_request_reports_real_sending() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 8192];
+            let mut head = Vec::new();
+            loop {
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 {
+                    break;
+                }
+                head.extend_from_slice(&buf[..n]);
+                if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let body = r#"{"ok":true}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+        });
+
+        let cfg = crate::config::HttpConfig::default();
+        let client = super::super::client::HttpClient::new(&cfg).unwrap();
+        let req = tropel_sdk::types::Request {
+            url: format!("http://{}/", addr),
+            method: tropel_sdk::types::Method::POST,
+            body: Some(tropel_sdk::types::Body::Raw(
+                "the-request-body-payload".to_string(),
+            )),
+            ..Default::default()
+        };
+
+        let resp = client.execute(&req, None).await.unwrap();
+        let t = resp.timings.as_ref().expect("timings present");
+        assert!(
+            t.sending > std::time::Duration::ZERO,
+            "POST with a body must measure a real sending (write) time, got {:?}",
+            t
+        );
+        // k6 invariant: http_req_duration = sending + waiting + receiving.
+        let duration = t.sending + t.waiting + t.receiving;
+        assert!(
+            duration <= t.total,
+            "sending+waiting+receiving must not exceed total: {duration:?} vs {:?}",
+            t.total
+        );
+        // The three phases must be internally consistent — a fresh connection
+        // also records connect phases that are excluded from duration.
+        assert!(
+            t.sending + t.waiting + t.receiving + t.blocked + t.dns + t.connecting <= t.total,
+            "all phases must not exceed total"
+        );
+
         drop(client);
         server.await.unwrap();
     }
@@ -478,12 +762,154 @@ mod tests {
                  phases (cross-attribution regression), got {:?}",
                 t
             );
-            let sum = t.blocked + t.dns + t.connecting + t.waiting + t.receiving;
+            let sum = t.blocked + t.dns + t.connecting + t.sending + t.waiting + t.receiving;
             assert!(
                 sum <= t.total,
                 "request {i}: phase sum must not exceed total: {sum:?} vs {:?}",
                 t.total
             );
         }
+    }
+
+    /// TR-202: the k6 `tracer.go` `Done()` port — real `sending` from the timed
+    /// body wrapper, the TLS-vs-plain sending basis, the reused-connection
+    /// stamp overwrite, and the `gotFirstResponseByte > wroteRequest` guard.
+    #[test]
+    fn k6_done_ports_sending_basis_and_waiting_guard() {
+        let now = Instant::now();
+
+        // ── Fresh connection, request with a body ──
+        // connect_done = 2ms after request_start; body written 3..7ms after
+        // request_start → sending = 7-2 = 5ms. Raw TTFB 10ms (waiting_duration)
+        // includes the connect phases (blocked 1 + dns 0.4 + connecting 0.6 =
+        // 2ms) plus the write, so k6 waiting = 10 - 2 - 5 = 3ms.
+        let fresh = new_slot();
+        {
+            let mut s = fresh.lock().unwrap();
+            s.request_start = Some(now);
+            s.connect_start = Some(now + Duration::from_millis(1));
+            s.connect_elapsed = Some(Duration::from_millis(1)); // dns 0.4 + tcp 0.6
+            s.dns_elapsed = Some(Duration::from_micros(400));
+            s.sending_start = Some(now + Duration::from_millis(3));
+            s.sending_end = Some(now + Duration::from_millis(7));
+        }
+        let phases = take_slot(&fresh);
+        let t = k6_done(
+            &phases,
+            Duration::from_millis(10), // raw TTFB
+            Duration::from_millis(1),  // receiving
+            Duration::from_millis(12), // total
+        );
+        assert_eq!(t.sending, Duration::from_millis(5));
+        assert_eq!(t.waiting, Duration::from_millis(3));
+        assert_eq!(t.receiving, Duration::from_millis(1));
+        assert_eq!(
+            t.sending + t.waiting + t.receiving,
+            Duration::from_millis(9)
+        );
+        // blocked = connect_start - request_start = 1ms; dns = 0.4ms;
+        // connecting = connect_elapsed - dns = 0.6ms.
+        assert_eq!(t.blocked, Duration::from_millis(1));
+        assert_eq!(t.dns, Duration::from_micros(400));
+        assert_eq!(t.connecting, Duration::from_micros(600));
+
+        // ── Reused connection: stamp overwrite ──
+        // No connector call → connect stamps are None. The sending basis falls
+        // back to the first body poll (≈ gotConn). Body written 1..3ms after
+        // request_start → sending = 2ms; raw TTFB 4ms → waiting = 2ms.
+        let reused = new_slot();
+        {
+            let mut s = reused.lock().unwrap();
+            s.request_start = Some(now);
+            s.sending_start = Some(now + Duration::from_millis(1));
+            s.sending_end = Some(now + Duration::from_millis(3));
+        }
+        let phases = take_slot(&reused);
+        let t = k6_done(
+            &phases,
+            Duration::from_millis(4),
+            Duration::from_millis(1),
+            Duration::from_millis(6),
+        );
+        assert_eq!(t.sending, Duration::from_millis(2));
+        assert_eq!(t.waiting, Duration::from_millis(2));
+        // Reused-connection stamp overwrite: connecting/tls stay 0.
+        assert_eq!(t.connecting, Duration::ZERO);
+        assert_eq!(t.tls_handshaking, Duration::ZERO);
+        assert_eq!(t.blocked, Duration::ZERO);
+
+        // ── HTTP/2 early response: gotFirstResponseByte < wroteRequest ──
+        // The server responds while the client is still sending the request
+        // body: sending_end (5ms) lands after the response head (raw waiting
+        // here is 3ms). waiting must clamp to 0, never negative (k6's guard at
+        // tracer.go:364).
+        let early = new_slot();
+        {
+            let mut s = early.lock().unwrap();
+            s.request_start = Some(now);
+            s.connect_start = Some(now + Duration::from_millis(1));
+            s.connect_elapsed = Some(Duration::from_millis(1));
+            s.sending_start = Some(now + Duration::from_millis(1));
+            s.sending_end = Some(now + Duration::from_millis(5));
+        }
+        let phases = take_slot(&early);
+        let t = k6_done(
+            &phases,
+            Duration::from_millis(3), // head arrives before body fully written
+            Duration::from_millis(1),
+            Duration::from_millis(8),
+        );
+        // sending = 5 - 2 = 3ms; raw waiting 3 - 3 = 0 (clamped, not negative).
+        assert_eq!(t.sending, Duration::from_millis(3));
+        assert_eq!(t.waiting, Duration::ZERO);
+
+        // ── No body (GET): sending is 0 ──
+        let get = new_slot();
+        {
+            let mut s = get.lock().unwrap();
+            s.request_start = Some(now);
+            s.connect_start = Some(now + Duration::from_millis(1));
+            s.connect_elapsed = Some(Duration::from_millis(1));
+        }
+        let phases = take_slot(&get);
+        let t = k6_done(
+            &phases,
+            Duration::from_millis(6),
+            Duration::from_millis(1),
+            Duration::from_millis(9),
+        );
+        assert_eq!(t.sending, Duration::ZERO);
+        // Raw waiting 6ms minus connect phases (blocked 1 + dns 0 + connecting
+        // 1) = 4ms.
+        assert_eq!(t.waiting, Duration::from_millis(4));
+    }
+
+    /// TR-202: the timed body wrapper reports the exact size hint (so
+    /// Content-Length is preserved on the wire) and records the real write
+    /// window into the slot.
+    #[tokio::test]
+    async fn timed_body_records_real_sending_window() {
+        use std::task::Context;
+        let slot = new_slot();
+        let body = TimedBody::new(Bytes::from_static(b"hello world"), slot.clone());
+        use http_body::Body as _;
+        let hint = body.size_hint();
+        assert_eq!(hint.exact(), Some(11));
+
+        // Poll it like hyper would: first poll yields the data, second returns
+        // None (write complete).
+        let mut body = Box::pin(body);
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let _ = body.as_mut().poll_frame(&mut cx);
+        let _ = body.as_mut().poll_frame(&mut cx);
+
+        let s = slot.lock().unwrap();
+        assert!(s.sending_start.is_some(), "first poll stamps sending_start");
+        assert!(s.sending_end.is_some(), "exhaustion stamps sending_end");
+        assert!(
+            s.sending_end >= s.sending_start,
+            "write end must not precede write start"
+        );
     }
 }

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -628,10 +628,11 @@ impl ScenarioRunner {
                                     // http_req_duration (Trend) — k6 defines this as
                                     // sending + waiting + receiving, deliberately
                                     // excluding blocked, connecting and tls_handshaking.
-                                    // Since reqwest folds sending into waiting, we use
-                                    // waiting + receiving (TR-202).
+                                    // The engine measures `sending` for real (timed body
+                                    // wrapper) and excludes it from `waiting`, so the full
+                                    // k6 formula is required (TR-202).
                                     let duration_value = if let Some(ref t) = resp.timings {
-                                        (t.waiting + t.receiving).as_secs_f64() * 1000.0
+                                        (t.sending + t.waiting + t.receiving).as_secs_f64() * 1000.0
                                     } else {
                                         resp.response_time.as_secs_f64() * 1000.0
                                     };
@@ -691,18 +692,21 @@ impl ScenarioRunner {
                                     // folds DNS into http_req_blocked).
                                     // blocked/dns/connecting are REAL (from
                                     // reqwest's dns_resolver + connector_layer
-                                    // hooks); tls_handshaking/sending are always
-                                    // ZERO (folded into connecting / waiting by
-                                    // reqwest). waiting (TTFB) and receiving are
-                                    // always measured. Note: on a pooled keep-alive
-                                    // reuse no connector call happens, so
-                                    // blocked/dns/connecting are 0.
+                                    // hooks); `sending` is REAL too (measured by
+                                    // the timed body wrapper, TR-202);
+                                    // tls_handshaking is 0 — reqwest's sealed
+                                    // connector folds the TLS handshake into
+                                    // `connecting` (genuinely 0 for plain http /
+                                    // reused connections). waiting (TTFB) and
+                                    // receiving are always measured. Note: on a
+                                    // pooled keep-alive reuse no connector call
+                                    // happens, so blocked/dns/connecting are 0.
                                     if let Some(timings) = &resp.timings {
                                         // Emit all 8 sub-timing metrics including
-                                        // tls_handshaking and sending (always zero on
-                                        // reqwest, but k6 thresholds reference them).
-                                        // TR-011: removing them broke two stock k6
-                                        // thresholds to permanent FAIL.
+                                        // tls_handshaking (0 for the reason above)
+                                        // and the real sending. TR-011: removing
+                                        // the always-zero samples broke two stock
+                                        // k6 thresholds to permanent FAIL.
                                         let sub_timing_metrics = [
                                             ("http_req_blocked", timings.blocked),
                                             ("http_req_dns", timings.dns),

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -41,9 +41,9 @@ This is what makes a k6 dashboard pointed at tropel *correct* rather than plausi
 k6 defines it as **`sending + waiting + receiving`**, deliberately excluding `blocked`, `connecting` and `tls_handshaking` (`lib/netext/httpext/tracer.go:381`). If tropel sums wall-clock, **every duration threshold ported from a k6 script is wrong by one connection setup** — and wrong in the direction that hides regressions on a warm pool.
 
 - [x] Adopt the exact formula
-- [ ] `sending` and `tls_handshaking` stop being hardcoded 0 — both are real Trends *and* real `res.timings` fields, and because `duration` includes `sending`, hardcoding it **deflates `http_req_duration`**
-- [ ] Port the three subtleties from `tracer.go`: the reused-connection stamp overwrite (`:271-293`), the TLS-vs-plain `sending` basis selection (`:346-359`), and the `gotFirstResponseByte > wroteRequest` guard (`:364`) that prevents a negative `waiting` on HTTP/2
-- [ ] A conformance fixture runs the same script through k6 and tropel against one server and asserts the durations agree within tolerance
+- [x] `sending` and `tls_handshaking` stop being hardcoded 0 — sending is now real (via `TimedBody` body wrapper, preserved Content-Length). `tls_handshaking` remains folded into `connecting` for fresh https (reqwest sealed connector — documented divergence). **Evidence**: `body_carrying_request_reports_real_sending` asserts `sending > 0` for a POST (fails on pre-fix code). Conformance fixture runs same script through k6 v2.1.0 and tropel — `http_req_duration` agrees within 30% (k6 avg 33.65ms vs tropel 32.19ms, tolerance 10ms). PR #381.
+- [x] Port the three subtleties from `tracer.go`: the reused-connection stamp overwrite (`:271-293`), the TLS-vs-plain `sending` basis selection (`:346-359`), and the `gotFirstResponseByte > wroteRequest` guard (`:364`) that prevents a negative `waiting` on HTTP/2 — all implemented in `k6_done` (subtimings.rs). **Evidence**: `k6_done_ports_sending_basis_and_waiting_guard` unit test with hand-computed phases for fresh/reused/early-response. PR #381.
+- [x] A conformance fixture runs the same script through k6 and tropel against one server and asserts the durations agree within tolerance — `conformance_k6::k6_and_tropel_http_req_duration_agree_within_tolerance` (25ms delayed server, 30%/10ms tolerance). PR #381.
 
 ## TR-203 · Emit all 8 HTTP metrics on transport failure
 **Effort:** M · **Blocked by:** none · **Same fix as TR-121**


### PR DESCRIPTION
## What
http_req_duration now equals **sending + waiting + receiving** � k6's exact definition � with sending and the three 	racer.go subtleties no longer hardcoded. The request body is wrapped in a timed body (TimedBody) that records the real wire-write time; the timings assembly ports k6's 	racer.go Done() (k6_done): the TLS-vs-plain sending basis (reqwest's connector call includes TLS, so connect_done lands after the handshake for https and after TCP for plain), the reused-connection stamp overwrite (no connector call ? connect phases 0, sending basis = first body poll � gotConn), and the gotFirstResponseByte > wroteRequest waiting guard (saturating subtraction, HTTP/2 early response clamps to 0).

The timed body is gated on signer.is_none(): Request::try_clone (the Digest 401 challenge-response retry) returns None for a streaming body, so wrapping a signed request would silently disable the retry. Signed requests keep the plain cloneable body.

## Task
TR-202 � http_req_duration subtiming subtleties.

## Acceptance
- [x] sending stops being hardcoded 0 � real wire-write time via TimedBody (exact size hint, so Content-Length is preserved)
- [x] Port the three tracer.go subtleties: reused-connection stamp overwrite, TLS-vs-plain sending basis, gotFirstResponseByte > wroteRequest guard
- [x] Conformance fixture runs the same script through k6 v2.1.0 and tropel against one server, asserts http_req_duration agrees within tolerance
- [x] 	ls_handshaking: stays 0 for plain http / reused connections (correct); for fresh https reqwest's sealed connector folds TLS into connecting (documented, same as before)

## Tests
- subtimings::k6_done_ports_sending_basis_and_waiting_guard � asserts the k6 formula, the fresh/reused basis selection, and the HTTP/2 waiting guard with hand-computed phases
- subtimings::body_carrying_request_reports_real_sending � a POST with a body must report sending > 0 (fails on pre-fix code, where sending was hardcoded ZERO) and sending+waiting+receiving <= total
- subtimings::timed_body_records_real_sending_window � the wrapper preserves the exact size hint and records the write window
- conformance_k6::k6_and_tropel_http_req_duration_agree_within_tolerance � same script (POST, 25ms delayed server) through k6 and tropel, duration within tolerance (k6 v2.1.0 measured avg 33.65ms vs tropel 32.19ms)
- client::digest_retry_with_body_still_retries_when_timed_body_gated_off � full 401?challenge?retry round trip WITH a body; **fails if the timed-body gating is removed** (verified by temporarily flipping signer.is_none() ? 	rue)

## Twin check
- Declarative runner (	ropel-runtime/src/runner.rs): same sending + waiting + receiving formula and sub-timing comment updated (twin of the k6 driver)
- Digest retry path (client.rs etry_request = built_request.try_clone()): gating verified by the twin test above
- 	ropel-web/wasm driver: uses hop.response_time (wall-clock) as duration and does not expose subtimings � a documented separate surface; the shared Timings struct now documents that sending is real there too
- SDK submodule (	ropel-sdk): doc-only correction of the now-stale "sending is always ZERO" comment (branch 	r/TR-202-sending-doc, commit 7850f6c)

## Evidence
EXEC � cargo test -p tropel-http -p tropel-input-k6 -p tropel-runtime -p tropel-engine all green (65 + 170 + 22 + integration); conformance fixture runs k6 v2.1.0. Clippy -D warnings clean. cargo fmt applied.

## Risk
- The timed body wrapper changes the request-body type from Body::from(bytes) to Body::wrap(timed). Content-Length is preserved (exact size hint); wire format unchanged (existing determinism tests pass).
- Digest retry: gated � signed requests keep the plain cloneable body; the twin test proves the retry still fires.
