### PR TITLE
feat(scheduler): ramping-vus validation — 1s floor, maxConcurrentVUs cap, name regex [TR-220]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/options.rs
+++ b/crates/inputs/tropel-input-k6/src/options.rs
@@ -188,6 +188,19 @@ impl K6Options {
             if !scenarios.is_empty() {
                 let mut map = HashMap::new();
                 for (name, sc) in scenarios {
+                    // TR-220: k6 `base_config.go` validates scenario names
+                    // against `^[0-9a-zA-Z_-]+$`. Names with other characters
+                    // (spaces, dots, special chars) are rejected.
+                    if !name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                    {
+                        tracing::warn!(
+                            "k6 scenario '{name}' contains invalid characters — \
+                             only [0-9a-zA-Z_-] are allowed, skipping"
+                        );
+                        continue;
+                    }
                     let Some(exec) = sc.to_execution() else {
                         tracing::warn!(
                             "k6 scenario '{name}' (executor '{}') is missing required \
@@ -753,6 +766,37 @@ mod tests {
             }
             other => panic!("expected ConstantArrivalRate, got {other:?}"),
         }
+    }
+
+    /// TR-220: k6 scenario names with invalid characters (dots, spaces) must
+    /// be rejected by the name regex, matching k6's `base_config.go`
+    /// `^[0-9a-zA-Z_-]+$`.
+    #[test]
+    fn test_scenario_name_with_special_chars_is_rejected() {
+        let opts = parse(
+            r#"{
+                "scenarios": {
+                    "valid_name": { "executor": "constant-vus", "vus": 1, "duration": "1s" },
+                    "bad.name": { "executor": "constant-vus", "vus": 1, "duration": "1s" },
+                    "spaced name": { "executor": "constant-vus", "vus": 1, "duration": "1s" }
+                }
+            }"#,
+        );
+        let decl = opts.to_declared().unwrap();
+        let scenarios = decl.scenarios.unwrap();
+        // Only the valid name should survive; invalid names are skipped with a
+        // warning (matching k6, which rejects the whole script — tropel is
+        // deliberately lenient and skips, so a partially-invalid script still
+        // runs its valid scenarios).
+        assert_eq!(
+            scenarios.len(),
+            1,
+            "only valid_name must survive, got {scenarios:?}"
+        );
+        assert!(
+            scenarios.contains_key("valid_name"),
+            "valid_name must be present"
+        );
     }
 
     #[test]

--- a/crates/tropel-scheduler/src/scheduler.rs
+++ b/crates/tropel-scheduler/src/scheduler.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
 use tropel_core::config::ExecutionConfig;
-use tropel_sdk::Result;
+use tropel_sdk::{Result, TropelError};
 
 /// Hard bound on the trailing VU-handle join. After `grace` expires the
 /// scheduler force-stops; if a VU still ignores that (e.g. a runaway JS
@@ -1953,23 +1953,55 @@ fn rate_per_second(rate: f64, time_unit: &str) -> Result<f64> {
 /// Public so the engine CLI can fail fast on `-d 30x` before the engine
 /// even constructs a scheduler (same backlog line 53 guarantee).
 pub fn validate_execution_config(config: &ExecutionConfig) -> Result<()> {
+    // k6 `executor/constant_vus.go:40` — the minimum duration for a
+    // `duration`/`maxDuration` field is 1s. 0-duration STAGES remain legal
+    // (instant VU jumps); only the executor-level run length is floored.
+    // `executor/ramping_vus.go:22` — `maxConcurrentVUs = 100_000_000` is the
+    // sanity cap on startVUs and every stage target.
+    const MAX_CONCURRENT_VUS: u32 = 100_000_000;
+    const MIN_RUN_DURATION: &str = "1s";
+
+    let floor_run_duration = |d: &str| -> Result<()> {
+        let parsed = parse_duration(d)?;
+        let floor = parse_duration(MIN_RUN_DURATION)?;
+        if parsed < floor {
+            return Err(TropelError::Config(format!(
+                "the duration must be at least {MIN_RUN_DURATION}, but is {d}"
+            )));
+        }
+        Ok(())
+    };
+
     match config {
         ExecutionConfig::ConstantVus { duration, .. } => {
-            parse_duration(duration)?;
+            floor_run_duration(duration)?;
         }
         ExecutionConfig::ConstantArrivalRate {
             duration,
             time_unit,
             ..
         } => {
-            parse_duration(duration)?;
+            floor_run_duration(duration)?;
             // W0 P0#1: a malformed timeUnit must fail the run loudly, not
             // silently default the rate to per-second.
             time_unit_seconds(time_unit)?;
         }
-        ExecutionConfig::RampingVus { stages, .. } => {
-            for stage in stages {
+        ExecutionConfig::RampingVus {
+            stages, start_vus, ..
+        } => {
+            if *start_vus > MAX_CONCURRENT_VUS {
+                return Err(TropelError::Config(format!(
+                    "the startVUs exceed the max limit of {MAX_CONCURRENT_VUS}"
+                )));
+            }
+            for (i, stage) in stages.iter().enumerate() {
                 parse_duration(&stage.duration)?;
+                if stage.target > MAX_CONCURRENT_VUS {
+                    return Err(TropelError::Config(format!(
+                        "target for stage {} exceeds the max limit of {MAX_CONCURRENT_VUS}",
+                        i + 1
+                    )));
+                }
             }
         }
         ExecutionConfig::RampingArrivalRate {
@@ -1983,12 +2015,12 @@ pub fn validate_execution_config(config: &ExecutionConfig) -> Result<()> {
         ExecutionConfig::SharedIterations { max_duration, .. }
         | ExecutionConfig::PerVUIterations { max_duration, .. } => {
             if let Some(d) = max_duration {
-                parse_duration(d)?;
+                floor_run_duration(d)?;
             }
         }
         ExecutionConfig::ExternallyControlled { duration, .. } => {
             if let Some(d) = duration {
-                parse_duration(d)?;
+                floor_run_duration(d)?;
             }
         }
     }
@@ -2020,6 +2052,71 @@ mod tests {
         );
         // And the executor must not have started any VU work.
         assert_eq!(sched.active_vus().await, 0);
+    }
+
+    /// TR-220: a `duration` below the 1s floor must be rejected at startup —
+    /// k6's `constant_vus.go` enforces `minDuration = 1s`.
+    #[test]
+    fn validate_rejects_duration_below_1s_floor() {
+        let cfg = ExecutionConfig::ConstantVus {
+            vus: 1,
+            duration: "500ms".to_string(),
+            graceful_stop: None,
+            think_time: Default::default(),
+        };
+        let err = validate_execution_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("at least 1s"),
+            "must mention the 1s floor, got: {}",
+            err
+        );
+    }
+
+    /// TR-220: a 1s duration is legal; 0-duration STAGES are legal (instant
+    /// VU jumps) — the floor applies only to executor-level run lengths.
+    #[test]
+    fn validate_accepts_1s_and_zero_duration_stages() {
+        assert!(validate_execution_config(&ExecutionConfig::ConstantVus {
+            vus: 1,
+            duration: "1s".to_string(),
+            graceful_stop: None,
+            think_time: Default::default(),
+        })
+        .is_ok());
+        assert!(validate_execution_config(&ExecutionConfig::RampingVus {
+            start_vus: 1,
+            stages: vec![tropel_core::config::Stage {
+                duration: "0s".to_string(),
+                target: 10,
+            }],
+            graceful_ramp_down: None,
+            graceful_stop: None,
+            think_time: Default::default(),
+        })
+        .is_ok());
+    }
+
+    /// TR-220: `startVUs` / stage targets above `maxConcurrentVUs`
+    /// (100_000_000) must be rejected — k6's sanity cap against OOM.
+    #[test]
+    fn validate_rejects_start_vus_over_max_concurrent() {
+        let over = 100_000_001u32;
+        let cfg = ExecutionConfig::RampingVus {
+            start_vus: over,
+            stages: vec![tropel_core::config::Stage {
+                duration: "1s".to_string(),
+                target: 1,
+            }],
+            graceful_ramp_down: None,
+            graceful_stop: None,
+            think_time: Default::default(),
+        };
+        let err = validate_execution_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("max limit of 100000000"),
+            "must mention the cap, got: {}",
+            err
+        );
     }
 
     /// VU ids are handed to `run_vu` for data-row rotation / worker pinning /

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -124,10 +124,10 @@ Tropel emits the **InfluxDB point shape** (`data.measurement`, `data.fields.valu
 
 Tropel's act-then-sleep leads by one step *and* accumulates drift, and its ramp-down re-arms surplus from the stage-start count and can overshoot to zero VUs. **A precomputed absolute-offset table makes both bugs structurally impossible** — port the model, don't patch the symptoms.
 
-- [ ] Interpolation rules (`:194-233`): `stageVUDiff == 0` → **HOLD, no steps at all**; `stageDuration == 0` → instant `GoTo`; ramp-down walks the index backwards with spacing `timeTillEnd - stageDuration*(stageEndVUs-unscaled+1)/stageVUDiff`
-- [ ] Defaults: `startVUs` 1, `gracefulRampDown` **30 s**, `gracefulStop` **30 s**, `maxConcurrentVUs = 100_000_000`
-- [ ] Scenario names must match `^[0-9a-zA-Z_-]+$`
-- [ ] A `1s` floor applies to `duration`/`maxDuration`, but **0-duration stages are legal**
+- [x] Interpolation rules (`:194-233`): `stageVUDiff == 0` → **HOLD, no steps at all**; `stageDuration == 0` → instant `GoTo`; ramp-down walks the index backwards with spacing `timeTillEnd - stageDuration*(stageEndVUs-unscaled+1)/stageVUDiff` — **already ported by TR-160/161** (absolute-offset `sleep_until(stage_start + offset)` per stage, forward-spaced ramp-down equivalent to k6's backward walk). Verified by PR #384.
+- [x] Defaults: `startVUs` 1, `gracefulRampDown` **30 s**, `gracefulStop` **30 s**, `maxConcurrentVUs = 100_000_000` — defaults already correct; `maxConcurrentVUs` cap added in `validate_execution_config` (PR #384)
+- [x] Scenario names must match `^[0-9a-zA-Z_-]+$` — added in k6 driver `to_declared()` (skip invalid names with warning) — PR #384
+- [x] A `1s` floor applies to `duration`/`maxDuration`, but **0-duration stages are legal** — added in `validate_execution_config` — PR #384
 
 ## TR-221 · Arrival rate — striped offsets and rational segment scaling
 **Effort:** L · **Blocked by:** TR-220


### PR DESCRIPTION
## What
Completes TR-220 (ramping-vus). The absolute-offset step-table interpolation was already ported by TR-160/161 (per-stage sleep_until(stage_start + offset) with u128 math, no drift accumulation; HOLD for 	arget == current; instant GoTo for 0-duration stages; forward-spaced ramp-down equivalent to k6's backward walk). This PR adds the remaining validation surface from the register:
- **1s duration floor** for duration/maxDuration on every non-stage executor (k6 constant_vus.go minDuration = 1s) � alidate_execution_config now rejects 500ms, while 0-duration STAGES stay legal.
- **maxConcurrentVUs = 100_000_000 cap** on ramping-vus startVUs and every stage target (k6's OOM sanity check).
- **Scenario-name regex** ^[0-9a-zA-Z_-]+$ (k6 ase_config.go) � invalid names (dots, spaces) are skipped with a warning instead of being silently accepted.

## Task
TR-220 � ramping-vus absolute-offset step table.

## Acceptance
- [x] Interpolation rules � already ported (TR-160/161); verified HOLD / 0-duration GoTo / forward ramp-down spacing are present and equivalent to k6's backward-walk formula
- [x] Defaults � startVUs 1, gracefulRampDown 30s, gracefulStop 30s already correct; **maxConcurrentVUs = 100_000_000 cap added**
- [x] Scenario names match ^[0-9a-zA-Z_-]+$ � added (k6 driver, skip-with-warning)
- [x] 1s floor on duration/maxDuration; 0-duration stages legal � added (scheduler validation)

## Tests
- alidate_rejects_duration_below_1s_floor � ConstantVus duration: "500ms" must error with "at least 1s" (fails on pre-fix code: no floor existed)
- alidate_accepts_1s_and_zero_duration_stages � 1s is legal; ramping-vus with a s stage is legal
- alidate_rejects_start_vus_over_max_concurrent � startVUs: 100_000_001 must error with the cap
- 	est_scenario_name_with_special_chars_is_rejected � ad.name / spaced name skipped, alid_name survives

## Twin check
- The 1s floor is applied in alidate_execution_config for ConstantVus, ConstantArrivalRate, SharedIterations, PerVUIterations, ExternallyControlled (max_duration/duration) � all five call sites handled. RampingVus/RampingArrivalRate STAGE durations intentionally exempt (k6 allows 0-duration stages).
- graceful_stop_duration already defaults to 30s for both gracefulRampDown and gracefulStop � no change needed.

## Evidence
EXEC � cargo test -p tropel-scheduler -p tropel-input-k6 all green (32 + 171); engine integration tests (behavior_parity 7, end_to_end 7) green. Clippy -D warnings clean. The behavior_parity ramping test (1s stages) still passes, confirming the floor allows exactly 1s.

## Risk
- The 1s floor could reject a config a user previously ran with a sub-second duration (e.g. -d 500ms). This is deliberate � k6 rejects it too ("the duration must be at least 1s") � and it prevents a silently-imprecise run. The error message names the floor.
- The scenario-name skip is lenient (skip + warn) vs k6's hard reject. Deliberate: a partially-invalid script still runs its valid scenarios; documented in the test.
