### PR TITLE
fix(k6): batch per-host limiter, del body, GET/HEAD null body [TR-233]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,6 +4544,7 @@ dependencies = [
  "tropel-metrics",
  "tropel-native",
  "tropel-sdk",
+ "url",
 ]
 
 [[package]]

--- a/crates/inputs/tropel-input-k6/Cargo.toml
+++ b/crates/inputs/tropel-input-k6/Cargo.toml
@@ -31,6 +31,7 @@ futures-util.workspace = true
 http.workspace = true
 flate2.workspace = true
 simd-json.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -2235,6 +2235,9 @@ fn register_http_bridges<'js>(
     let group_stack_batch = group_stack.clone();
     let deadline_batch = deadline.clone();
     let max_exec_batch = max_exec;
+    // TR-233: batch concurrency limiter — k6 defaults: 20 global, 6 per-host.
+    // TODO: wire `batch`/`batchPerHost` from k6 options; these are placeholders.
+    let batch_limit = Arc::new(tokio::sync::Semaphore::new(20));
     let _ = globals.set(
         "__tropel_k6_http_batch",
         Func::from(
@@ -2245,6 +2248,10 @@ fn register_http_bridges<'js>(
                     serde_json::from_str(&requests_json).unwrap_or_default();
 
                 let http_for_io = http_client.clone();
+                let batch_limit = batch_limit.clone();
+                // Per-host limiters (lazily created on first request to a host).
+                let per_host_limits: Arc<std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Semaphore>>>> =
+                    Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
                 let futures = batch_requests.into_iter().map(move |entry| {
                     let key = entry
                         .get("key")
@@ -2274,22 +2281,16 @@ fn register_http_bridges<'js>(
                         .and_then(|v| v.as_str())
                         .unwrap_or("text")
                         .to_string();
-                    // W2 line 169: ONE canonical extras shape shared with the
-                    // single-request bridge (timeoutMs/tags/auth/redirects/
-                    // compression/bodyB64) — the old tags_json/auth_json/
-                    // body_b64/timeout_ms variants disagreed on four of seven
-                    // wire fields (and the batch dropped the whole tag map on
-                    // any non-string value).
+                    // TR-233: k6 nulls the body for GET/HEAD in object form
+                    // (parseBatchRequest in request.go). The body is relevant
+                    // only for the send path; the bridge entry carries it for
+                    // sample construction, but the actual HTTP request body
+                    // is nulled by build_k6_request for GET/HEAD.
                     let extras: serde_json::Value = entry
                         .get("extras")
                         .and_then(|v| v.as_str())
                         .and_then(|s| serde_json::from_str(s).ok())
                         .unwrap_or(serde_json::Value::Null);
-                    // Same loud-failure guard as the single bridge: an invalid
-                    // method token must not silently become GET. Carried as an
-                    // immediate Err result inside the async block (never
-                    // executed) — the caller maps it to a status-0 response +
-                    // failure samples.
                     let (req, params, method_error) = build_k6_request(
                         method,
                         url,
@@ -2298,8 +2299,24 @@ fn register_http_bridges<'js>(
                         response_type.clone(),
                         &extras,
                     );
+                    // Extract the host for per-host limiting.
+                    let host = url::Url::parse(&req.url)
+                        .ok()
+                        .and_then(|u| u.host_str().map(|h| h.to_string()))
+                        .unwrap_or_default();
                     let http_client = http_for_io.clone();
+                    let batch_limit = batch_limit.clone();
+                    let per_host_limits = per_host_limits.clone();
                     async move {
+                        // Acquire a global permit first, then a per-host permit.
+                        let _global = batch_limit.acquire().await.expect("batch semaphore");
+                        let host_limit = {
+                            let mut map = per_host_limits.lock().unwrap();
+                            map.entry(host.clone())
+                                .or_insert_with(|| Arc::new(tokio::sync::Semaphore::new(6)))
+                                .clone()
+                        };
+                        let _host = host_limit.acquire().await.ok();
                         let start = std::time::Instant::now();
                         let resp = match &method_error {
                             Some(msg) => Err(TropelError::Other(msg.clone())),
@@ -5223,6 +5240,94 @@ mod tests {
                 ctx.eval::<bool, _>("__threwMissing").expect("read threwMissing"),
                 "missing native key must throw, not fabricate status-0"
             );
+        });
+    }
+
+    /// TR-233: `http.del` takes a body; `http.get`/`http.head` do not. The
+    /// single-request shim must forward the del body (k6: `del(url, body,
+    /// params)` via getMethodClosure) while get/head never carry one. Also
+    /// the batch OBJECT-form entry nulls the body for GET/HEAD (k6
+    /// parseBatchRequest) — the array-form entry keeps the caller's body.
+    #[test]
+    fn test_del_body_and_batch_get_head_body_nulling() {
+        let rt = rquickjs::Runtime::new().unwrap();
+        let ctx = rquickjs::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<(), _>(include_str!("../../../../js/k6-shim/k6-shim.js"))
+                .expect("k6 shim should eval");
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.__captured = [];
+                globalThis.__tropel_k6_http_request = function (method, url, headersJson, body, responseType, extrasJson) {
+                    globalThis.__captured.push({ method: method, url: url, body: body, responseType: responseType });
+                    return { status: 200, code: 200, status_text: 'OK', body: '', headers: [], timings: {}, error: '', error_code: 0 };
+                };
+                // del with a body: the body must reach the bridge.
+                http.del('https://example.com/thing', 'payload-delete', { tags: { name: 'd1' } });
+                // get / head: no body argument.
+                http.get('https://example.com/g');
+                http.head('https://example.com/h');
+
+                globalThis.__tropel_k6_http_batch = function (requestsJson) {
+                    var reqs = JSON.parse(requestsJson);
+                    globalThis.__captured.push({ method: 'BATCH', entries: reqs });
+                    var out = {};
+                    for (var ri = 0; ri < reqs.length; ri++) {
+                        out[reqs[ri].key] = { status: 200, code: 200, body: 'ok', headers: {}, timings: {} };
+                    }
+                    return JSON.stringify(out);
+                };
+                // Batch object form: GET/HEAD bodies nulled, POST body kept.
+                http.batch([
+                    { key: 'get', url: 'https://example.com/a', method: 'GET', body: 'should-null' },
+                    { key: 'head', url: 'https://example.com/b', method: 'HEAD', body: 'should-null' },
+                    { key: 'post', url: 'https://example.com/c', method: 'POST', body: 'keep-me' },
+                ]);
+                // Batch array form: caller's body preserved for all methods.
+                http.batch([
+                    ['GET', 'https://example.com/d', 'arr-get-body'],
+                    ['DELETE', 'https://example.com/e', 'arr-del-body'],
+                ]);
+            "#,
+            )
+            .expect("script should eval");
+
+            // Single-request path: del carries the body; get/head have none.
+            let captured_json: String = ctx
+                .eval("JSON.stringify(__captured)")
+                .expect("read captured");
+            let reqs: Vec<serde_json::Value> =
+                serde_json::from_str(&captured_json).expect("captured is JSON");
+            assert_eq!(reqs[0]["method"], "DELETE");
+            assert_eq!(reqs[0]["body"], "payload-delete", "del body must reach the bridge");
+            assert_eq!(reqs[1]["method"], "GET");
+            // serializeK6Body maps null → '' on the wire; the bridge treats
+            // '' as "no body" (build_k6_request: `body.is_empty()` → None).
+            assert_eq!(reqs[1]["body"], "", "get must not carry a body");
+            assert_eq!(reqs[2]["method"], "HEAD");
+            assert_eq!(reqs[2]["body"], "", "head must not carry a body");
+
+            // Batch object form (captured[3] is the BATCH marker).
+            let batch_obj: serde_json::Value = reqs
+                .iter()
+                .find(|r| r["method"] == "BATCH" && r["entries"].as_array().is_some_and(|a| a.len() == 3))
+                .expect("object-form batch captured")
+                .clone();
+            let entries = batch_obj["entries"].as_array().unwrap();
+            // serializeK6Body maps null → '' on the wire; '' means "no body".
+            assert_eq!(entries[0]["body"], "", "GET object-form body must be nulled");
+            assert_eq!(entries[1]["body"], "", "HEAD object-form body must be nulled");
+            assert_eq!(entries[2]["body"], "keep-me", "POST object-form body must be kept");
+
+            // Batch array form (4 entries).
+            let batch_arr: serde_json::Value = reqs
+                .iter()
+                .find(|r| r["method"] == "BATCH" && r["entries"].as_array().is_some_and(|a| a.len() == 2))
+                .expect("array-form batch captured")
+                .clone();
+            let entries = batch_arr["entries"].as_array().unwrap();
+            assert_eq!(entries[0]["body"], "arr-get-body", "array-form GET body must be preserved (k6 array form)");
+            assert_eq!(entries[1]["body"], "arr-del-body", "array-form DELETE body must be preserved");
         });
     }
 

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -682,8 +682,8 @@ var http = {};
 http.get = function (url, params) { return k6HTTPRequest('GET', url, null, params); };
 http.post = function (url, body, params) { return k6HTTPRequest('POST', url, body, params); };
 http.put = function (url, body, params) { return k6HTTPRequest('PUT', url, body, params); };
-http.del = function (url, params) { return k6HTTPRequest('DELETE', url, null, params); };
-http.delete = function (url, params) { return k6HTTPRequest('DELETE', url, null, params); };
+http.del = function (url, body, params) { return k6HTTPRequest('DELETE', url, body, params); };
+http.delete = function (url, body, params) { return k6HTTPRequest('DELETE', url, body, params); };
 http.patch = function (url, body, params) { return k6HTTPRequest('PATCH', url, body, params); };
 
 // Backlog line 150: k6's http.file(data, filename, contentType) → K6File.
@@ -1016,24 +1016,32 @@ function normalizeBatchEntry(req, defaultKey) {
             params: req.length > 3 ? req[3] : {}
         };
     }
-    if (typeof req === 'object') {
-        // Preserve the object-form entry's responseType (k6: params.responseType)
-        var entryParams = req.params || {};
-        return {
-            key: req.name != null ? req.name : defaultKey,
-            method: req.method || 'GET',
-            url: req.url || '',
-            // Backlog §3: `req.body || null` dropped 0/''/false — only
-            // undefined/null mean "no body".
-            body: req.body !== undefined ? req.body : null,
-            params: {
-                headers: req.headers || entryParams.headers || {},
-                tags: req.tags || entryParams.tags || {},
-                // Backlog §3: object-form entries forced `timeout:'30s'`,
-                // overriding the global HttpConfig.request_timeout. Mirror
-                // the single path — leave it unset so timeoutMs stays 0 and
-                // the driver applies the client-level global.
-                timeout: req.timeout || entryParams.timeout,
+      if (typeof req === 'object') {
+          // Preserve the object-form entry's responseType (k6: params.responseType)
+          var entryParams = req.params || {};
+          // TR-233: k6 nulls the body for GET/HEAD in object form
+          // (parseBatchRequest in request.go: `if method == GET || method ==
+          // HEAD { body = nil }`). GET/HEAD never carry a body on the wire.
+          var entryMethod = (req.method || 'GET').toUpperCase();
+          var entryBody = req.body !== undefined ? req.body : null;
+          if (entryMethod === 'GET' || entryMethod === 'HEAD') {
+              entryBody = null;
+          }
+          return {
+              key: req.name != null ? req.name : defaultKey,
+              method: entryMethod,
+              url: req.url || '',
+              // Backlog §3: `req.body || null` dropped 0/''/false — only
+              // undefined/null mean "no body".
+              body: entryBody,
+              params: {
+                  headers: req.headers || entryParams.headers || {},
+                  tags: req.tags || entryParams.tags || {},
+                  // Backlog §3: object-form entries forced `timeout:'30s'`,
+                  // overriding the global HttpConfig.request_timeout. Mirror
+                  // the single path — leave it unset so timeoutMs stays 0 and
+                  // the driver applies the client-level global.
+                  timeout: req.timeout || entryParams.timeout,
                 responseType: entryParams.responseType || req.responseType || 'text',
                 // Backlog §3: object-form entries dropped auth/redirects/
                 // compression/cookies that the single path honors.

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -199,8 +199,8 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 - [x] `http.cookieJar()` / `new http.CookieJar()` — 4 methods; `cookiesForURL` returns **values only**; `set` parses `expires` as **RFC1123**; `clear`/`delete` work by re-setting `MaxAge=-1` — shim surface added (cookiesForURL/set/clear/delete; expires via Date); the native per-VU jar bridge wiring is a follow-up
 - [x] `http.setResponseCallback` / `http.expectedStatuses` — **default range 200–399 inclusive**; `null` suppresses `http_req_failed` entirely (pairs with `TR-004`) — added
 - [x] `http.asyncRequest`, `http.head`, `http.options`, and the `TLS_1_*` / `OCSP_*` constants — head/options already existed; asyncRequest + TLS/OCSP constants added
-- [ ] **[GAP]** `batch` per-host limiter — `batch`=20 global, `batchPerHost`=6; the return container mirrors the input; only the **first** error surfaces; GET/HEAD bodies nulled in object form
-- [ ] **[GAP]** `del` takes a body; `get`/`head` do not
+- [ ] **[GAP]** `batch` per-host limiter — `batch`=20 global, `batchPerHost`=6; the return container mirrors the input; only the **first** error surfaces; GET/HEAD bodies nulled in object form — **limiter added** (20 global / 6 per-host via two-level semaphore, k6 defaults); **return container mirrors input + first-error-only already implemented** in the batch bridge; **GET/HEAD bodies nulled in object form added** (shim). Custom `batch`/`batchPerHost` values remain a follow-up (currently warned as unknown options). PR #386
+- [ ] **[GAP]** `del` takes a body; `get`/`head` do not — **fixed** in the shim (`http.del(url, body, params)`); `get`/`head` never carry one. PR #386
 
 ---
 


### PR DESCRIPTION
## What
TR-233 residue � the batch per-host limiter and HTTP method body semantics.

- **Batch per-host limiter**: http.batch now bounds concurrency � 20 global (k6 atch default), 6 per-host (k6 atchPerHost default) via 	okio::sync::Semaphore (a global permit first, then a lazily-created per-host permit), matching k6's lib.SlotLimiter/MultiSlotLimiter. Script-provided custom atch/atchPerHost values remain unwired (they land in the TR-201 unknown-options warning set); the register's defaults are the deliverable.
- **del takes a body**: http.del(url, body, params) � the shim previously dropped the body (del(url, params) ? body 
ull). Now forwarded like k6's getMethodClosure.
- **GET/HEAD bodies nulled in batch object form**: the shim's 
ormalizeBatchEntry nulls the body for GET/HEAD object-form entries (k6 parseBatchRequest); array-form entries keep the caller's body (k6 array form).

## Task
TR-233 residue � batch per-host limiter (atch=20 global, atchPerHost=6); del takes a body; get/head do not.

## Acceptance
- [x] Batch concurrency bounded � 20 global, 6 per-host (k6 defaults), via two-level semaphore in the native __tropel_k6_http_batch bridge
- [x] del takes a body; get/head do not (shim)
- [x] GET/HEAD bodies nulled in batch object form (shim, k6 parseBatchRequest parity)

## Tests
- 	est_del_body_and_batch_get_head_body_nulling � http.del carries the body to the bridge; get/head send no body; batch object-form GET/HEAD bodies nulled while POST kept; batch array-form bodies preserved (fails on pre-fix code: del sent 
ull, GET/HEAD object bodies passed through)

## Twin check
- The batch bridge is the only join_all fan-out in the k6 driver; the single-request bridge is unaffected (it never had a limiter, matching k6's single Request path).
- The shim change is JS-only; the native bridge's uild_k6_request already treats "" as "no body", so the nulled value lands as None on the wire (verified via existing body-handling tests).

## Evidence
EXEC � cargo test -p tropel-input-k6 172+1 green; clippy -D warnings clean.

## Risk
- Per-host limiters live in a Mutex<HashMap<String, Arc<Semaphore>>> inside the bridge closure � created per http.batch call (not cached across calls). k6 caches per-host limiters in a MultiSlotLimiter across the run; tropel re-creates them per batch call, so per-host state doesn't leak between batches. Global semaphore is per-bridge (per-VU-context), matching k6's per-VU state.
- Custom atch/atchPerHost values are not wired from script options � documented in the bridge comment as a follow-up; they currently surface in the TR-201 unknown-options warning instead of being silently applied.
