### PR TITLE
fix(k6): exec.test.abort maps to exit code 108 [TR-244]

### DIFF
--- a/crates/tropel-engine/src/cli.rs
+++ b/crates/tropel-engine/src/cli.rs
@@ -642,6 +642,14 @@ async fn run_command(cli: Cli) -> Result<()> {
         )));
     }
 
+    // TR-244: `exec.test.abort()` maps to k6's exit code 108 (ScriptAborted)
+    // — a specific non-zero distinct from generic failures. The message has
+    // already been logged by the VU loop; exit immediately with the right code.
+    if let Some(msg) = &result.abort_message {
+        tracing::error!("Test aborted: {}", msg);
+        std::process::exit(108);
+    }
+
     // Evaluate thresholds and drive exit code. Uses the engine's EFFECTIVE
     // threshold set (job thresholds merged with script-declared ones, e.g.
     // k6 `export const options` thresholds) so k6 SLOs are reported too.

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -499,7 +499,7 @@ impl Engine {
                             input_path,
                             e
                         );
-                        return (0, 0);
+                        return (0, 0, None);
                     }
                 };
 
@@ -510,7 +510,7 @@ impl Engine {
                 // to its registered protocol (the runner's scheme lookup).
                 let protocols: Arc<HashMap<String, Arc<dyn Protocol>>> =
                     Arc::new(registry_sc.instantiate_protocols());
-                let (init_failures, script_failures) = match resolved {
+                let (init_failures, script_failures, abort_message) = match resolved {
                     ResolvedInput::Scenario(scenario) => {
                         run_scenario_vus(
                             sc_name,
@@ -566,7 +566,7 @@ impl Engine {
                 };
 
                 tracing::info!("Scenario '{}': completed", sc_name_log);
-                (init_failures, script_failures)
+                (init_failures, script_failures, abort_message)
             });
 
             scenario_handles.push(handle);
@@ -581,11 +581,16 @@ impl Engine {
         // where every script throws must exit non-zero.
         let mut total_vu_init_failures = 0u32;
         let mut total_script_failures = 0u64;
+        let mut total_abort_message: Option<String> = None;
         for handle in scenario_handles {
             match handle.await {
-                Ok((init_failures, script_failures)) => {
+                Ok((init_failures, script_failures, abort_message)) => {
                     total_vu_init_failures += init_failures;
                     total_script_failures += script_failures;
+                    // First VU to abort wins; later scenarios are idempotent.
+                    if abort_message.is_some() {
+                        total_abort_message = total_abort_message.or(abort_message);
+                    }
                 }
                 // P0 (backlog): a PANICKED scenario task (e.g. worker-pool
                 // thread/runtime creation failing under fd exhaustion) used
@@ -677,6 +682,9 @@ impl Engine {
             // that errored during the run. Non-zero means scripts kept
             // failing; the CLI exits non-zero (backlog line 98).
             script_failures: total_script_failures,
+            // TR-244: `exec.test.abort(msg?)` message, if any — the CLI maps
+            // it to k6's exit code 108.
+            abort_message: total_abort_message,
         })
     }
 
@@ -806,4 +814,8 @@ pub struct EngineResult {
     /// line 98: script failures used to be swallowed — warn only, no failed
     /// check, exit 0).
     pub script_failures: u64,
+    /// Message from `exec.test.abort(msg?)`, if any. Set when a VU called
+    /// abort during the run. The CLI uses this to exit with k6's exit code
+    /// 108 (ScriptAborted) instead of a generic non-zero (TR-244).
+    pub abort_message: Option<String>,
 }

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -241,6 +241,14 @@ async fn run_vu_loop(
 
             if let Some(msg) = outcome.abort_message {
                 tracing::warn!("test.abort(): {} — stopping", msg);
+                // TR-244: store the message so the CLI can exit with
+                // k6's 108 (ScriptAborted) instead of a generic non-zero.
+                {
+                    let mut slot = shared.abort_message.lock().unwrap();
+                    if slot.is_none() {
+                        *slot = Some(msg);
+                    }
+                }
                 sched.request_stop();
             }
 
@@ -295,6 +303,10 @@ struct VuRunShared {
     /// [`VuIterationOutcome::script_failures`] so a run where scripts keep
     /// throwing exits non-zero instead of reporting success (backlog line 98).
     script_failures: Arc<AtomicU64>,
+    /// Set when `exec.test.abort()` is called. First VU to abort wins; later
+    /// calls are idempotent. Read after the run so the CLI can exit with
+    /// k6's 108 (script aborted) instead of a generic non-zero (TR-244).
+    abort_message: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 /// Shared VU-run scaffolding used by both the scenario and driver paths:
@@ -334,7 +346,7 @@ async fn run_vus<F>(
     control_port: Option<u16>,
     setup_data: Option<String>,
     run_vu: F,
-) -> (u32, u64)
+) -> (u32, u64, Option<String>)
 where
     F: Fn(Arc<VUScheduler>, u32, &VuRunShared) -> tokio::task::JoinHandle<()>
         + Send
@@ -469,6 +481,8 @@ where
 
     let vu_init_failures = Arc::new(AtomicU32::new(0));
     let script_failures = Arc::new(AtomicU64::new(0));
+    let abort_message: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
     let last_active_vus = Arc::new(AtomicU32::new(0));
 
     // Single scheduler-wide vus/vus_max sampler (backlog line 165): the
@@ -504,7 +518,11 @@ where
         executor_name,
         vu_init_failures: vu_init_failures.clone(),
         script_failures: script_failures.clone(),
+        abort_message: abort_message.clone(),
     };
+    // Clone the abort-message handle before `shared` is moved into the
+    // executor.run closure below — it is read after the run (TR-244).
+    let abort_message_handle = shared.abort_message.clone();
 
     // Backlog line 423: warn when per-VU JS init cost makes the ramp
     // physically impossible. At ~1ms per VU init, a 0→10000 ramp in 1s
@@ -654,7 +672,10 @@ where
     if let Some(handle) = control_server {
         handle.abort();
     }
-    (init_failures, script_failures.load(Ordering::SeqCst))
+    // TR-244: read the abort message so the CLI can exit with k6's 108
+    // (ScriptAborted) instead of a generic non-zero.
+    let abort_message = abort_message_handle.lock().unwrap().clone();
+    (init_failures, script_failures.load(Ordering::SeqCst), abort_message)
 }
 
 // ── Driver HTTP client adapter ──
@@ -748,7 +769,7 @@ pub(crate) async fn run_scenario_vus(
     control_port: Option<u16>,
     rps_limiter: Option<Arc<tropel_http::RpsLimiter>>,
     input_path: &str,
-) -> (u32, u64) {
+) -> (u32, u64, Option<String>) {
     // Expected statuses are read by every VU's ScenarioRunner — snapshot them once
     // and share (the closure no longer captures the whole HttpConfig, which
     // is consumed into the shared client build below).
@@ -779,7 +800,7 @@ pub(crate) async fn run_scenario_vus(
                     lane_count,
                     e
                 );
-                return (1, 0);
+                return (1, 0, None);
             }
         }
     }
@@ -955,13 +976,13 @@ pub(crate) async fn run_driver_vus(
     // shared map into every VU's VuContext so drivers dispatch non-HTTP
     // schemes through the same lookup the declarative runner uses.
     protocols: Arc<HashMap<String, Arc<dyn Protocol>>>,
-) -> (u32, u64) {
+) -> (u32, u64, Option<String>) {
     let driver_id = driver.id().to_string();
     let input_bytes = match std::fs::read(input_path) {
         Ok(b) => Arc::new(b),
         Err(e) => {
             tracing::error!("Scenario '{}': failed to read input: {}", sc_name, e);
-            return (0, 0);
+            return (0, 0, None);
         }
     };
     let input_p = std::path::Path::new(input_path).to_path_buf();
@@ -989,7 +1010,7 @@ pub(crate) async fn run_driver_vus(
                     lane_count,
                     e
                 );
-                return (1, 0);
+                return (1, 0, None);
             }
         }
     }
@@ -1176,12 +1197,13 @@ pub(crate) async fn run_driver_vus(
         metrics_after_run.record_batch(&teardown_samples).await;
     }
 
-    // `run_vus` returns (vu_init_failures, script_failures) — VUs that
-    // failed to START and driver iterations that errored. Propagate them so
-    // the engine can fail the run loudly (silent truncation / throwing
-    // scripts must not report green).
-    let (init_failures, script_failures) = run_vus_result;
-    (init_failures, script_failures)
+    // `run_vus` returns (vu_init_failures, script_failures, abort_message) —
+    // VUs that failed to START, driver iterations that errored, and the
+    // `exec.test.abort()` message if any. Propagate them so the engine can
+    // fail the run loudly (silent truncation / throwing scripts must not
+    // report green) and the CLI can exit 108 on abort.
+    let (init_failures, script_failures, abort_message) = run_vus_result;
+    (init_failures, script_failures, abort_message)
 }
 // Helpers
 // ══════════════════════════════════════════════════════════════════

--- a/crates/tropel/tests/exit_code.rs
+++ b/crates/tropel/tests/exit_code.rs
@@ -131,3 +131,45 @@ async fn passing_threshold_exits_zero() {
     );
     let _ = std::fs::remove_file(&script);
 }
+
+/// Write a script that calls `exec.test.abort()` on the first iteration.
+fn write_abort_script(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("tropel-abort-{}-{}.js", std::process::id(), tag));
+    let script = r#"import exec from 'k6/execution';
+export const options = { vus: 1, iterations: 3 };
+export default function () {
+  exec.test.abort('stop now');
+}
+"#;
+    std::fs::write(&path, script).unwrap();
+    path
+}
+
+/// TR-244: `exec.test.abort(msg)` must map to exit code 108 (k6
+/// `ScriptAborted`), NOT a generic non-zero. CI pipelines that branch on
+/// "aborted" vs "failed" depend on the distinction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_abort_exits_108() {
+    let script = write_abort_script("abort108");
+    let out = Command::new(env!("CARGO_BIN_EXE_tropel"))
+        .arg("run")
+        .arg(&script)
+        .arg("--format")
+        .arg("k6")
+        .arg("-u")
+        .arg("1")
+        .arg("-d")
+        .arg("5s")
+        .output()
+        .expect("failed to spawn the tropel binary");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(108),
+        "test.abort() must exit with code 108, exited {:?}\nstderr: {}",
+        out.status.code(),
+        stderr
+    );
+    let _ = std::fs::remove_file(&script);
+}

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -245,7 +245,9 @@ Grammar (`metrics/thresholds_parser.go`): aggregations **`value`, `count`, `rate
 **Effort:** M · **Blocked by:** TR-212
 
 - [x] **[GAP]** `exec.vu.tags`, `exec.vu.metrics.tags` and `exec.vu.metrics.metadata` are live **mutable** DynamicObjects — writing to them is how scripts tag metrics dynamically. Everything else on `exec` is getter-only. Values restricted to String/Boolean/Number — `exec.vu.tags` (and `exec.vu.metrics.tags`/`metadata`) are mutable objects; the http bridge merges `exec.vu.tags` into sample tags (single + batch); test `test_exec_vu_tags_reach_http_samples`
-- [x] **[GAP]** `exec.test.abort(msg?)` → exit code **108**, and **`exec.test.fail(msg?)`**, which marks the run failed *without stopping it*. Two distinct things — `abort` reaches the engine stop (exit non-zero); `fail` throws (iteration marked failed, run continues), test `test_exec_members_are_value_properties`
+- [x] **[GAP]** `exec.test.abort(msg?)` → exit code **108**, and **`exec.test.fail(msg?)`**, which marks the run
+  failed *without stopping it*. Two distinct things — `abort` reaches the engine stop (exit 108); `fail` throws
+  (iteration marked failed, run continues), test `test_exec_members_are_value_properties` — **exit-code 108 mapping added** (PR #387)
 
 ## TR-245 · The remaining modules, ranked by demand
 **Effort:** L · **Blocked by:** TR-241


### PR DESCRIPTION
## What
exec.test.abort(msg) now maps to **exit code 108** � k6's ScriptAborted exit code � instead of a generic non-zero. The abort message set by exec.test.abort() in a VU iteration is propagated through the shared run state ? un_vus ? the engine EngineResult.abort_message, and the CLI exits with std::process::exit(108) when it is set.

## Task
TR-244 residue � exec.test.abort must map to exit code 108 specifically (currently just non-zero).

## Acceptance
- [x] exec.test.abort(msg) ? process exit code 108 (k6 errext/exitcodes: ScriptAborted = 108)
- [x] exec.test.fail(msg) unchanged � throws per-iteration (run continues), no exit-code change
- [x] All other failure modes keep their existing exit codes (1 for thresholds/script failures, 0 for success)

## Tests
- 	ropel::tests::exit_code::test_abort_exits_108 � a script calling exec.test.abort('stop now') must exit with code **exactly 108** (fails on pre-fix code, which exited 1). Runs the real binary end-to-end.

## Twin check
- Two un_vus callers (un_scenario_vus, un_driver_vus) both return the 3-tuple (init_failures, script_failures, abort_message); both paths (declarative scenario + k6 driver) propagate the abort message identically.
- The VuRunShared.abort_message slot is written by the VU loop when an abort is observed and read after the run � the Arc handle is cloned before shared is moved into the executor closure.

## Evidence
EXEC � cargo test -p tropel --test exit_code 3/3 green (new 108 test passes); engine lib 47/47 green; clippy -D warnings clean.

## Risk
- std::process::exit(108) bypasses normal unwinding � safe here because it runs after the summary has printed and all reporters have flushed (it's placed after un_cli's run/completion, before threshold evaluation, mirroring where k6 exits with the abort code).
- The abort message is only captured for VUs whose un_iteration observed the abort (VuIterationOutcome.abort_message); the driver path already sets it (vu_sources.rs:157).
