### PR TITLE
feat(w3): TR-313 module cache, TR-306 grpc memo, TR-307 detect, TR-308 ref, TR-304 otlp gzip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,6 +4663,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "flate2",
  "insta",
  "reqwest",
  "serde",

--- a/crates/extensions/tropel-x-grpc/src/lib.rs
+++ b/crates/extensions/tropel-x-grpc/src/lib.rs
@@ -79,6 +79,14 @@ pub struct GrpcProtocol {
     pools: Mutex<HashMap<u64, (PoolKey, Arc<DescriptorPool>)>>,
     /// Insertion order for the pool cache (FIFO eviction key).
     pool_order: Mutex<VecDeque<u64>>,
+    /// TR-306: memoized identity of the LAST seen pool key. The proto
+    /// source is stable within a run (same config/header/env), so after the
+    /// first request the SipHash over up to 1 MiB is skipped entirely —
+    /// a byte-identity `memcmp` (cheap for the common file-path source)
+    /// reuses the previously computed hash instead of re-hashing the full
+    /// text on every request.
+    last_key: Mutex<Option<PoolKey>>,
+    last_hash: std::sync::atomic::AtomicU64,
     /// Tonic channels pooled by authority (`scheme://host:port`).
     channels: Mutex<HashMap<String, Channel>>,
     /// Insertion order for the channel cache (FIFO eviction key).
@@ -90,10 +98,27 @@ use std::hash::{Hash, Hasher};
 
 /// Precompute a hash of the pool key outside any lock. The proto source
 /// can be up to 1 MiB — hashing it inside the mutex is the bottleneck.
-fn pool_hash(key: &PoolKey) -> u64 {
+/// TR-306: the hash is memoized per unique key so the (potentially MiB-
+/// sized) SipHash runs once per distinct source, not once per request.
+fn pool_hash(
+    memo_key: &Mutex<Option<PoolKey>>,
+    memo_hash: &std::sync::atomic::AtomicU64,
+    key: &PoolKey,
+) -> u64 {
+    {
+        let last = memo_key.lock().unwrap();
+        if let Some(prev) = last.as_ref() {
+            if prev.0 == key.0 && prev.1 == key.1 {
+                return memo_hash.load(std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+    }
     let mut h = DefaultHasher::new();
     key.hash(&mut h);
-    h.finish()
+    let hash = h.finish();
+    *memo_key.lock().unwrap() = Some(key.clone());
+    memo_hash.store(hash, std::sync::atomic::Ordering::Relaxed);
+    hash
 }
 
 /// Insert into a bounded cache: when the map is at capacity, evict the oldest
@@ -266,7 +291,7 @@ impl Protocol for GrpcProtocol {
             // SipHash over up to 1 MiB of proto source doesn't happen while
             // holding the mutex. Then hold the lock across compilation to
             // prevent a cold-start stampede.
-            let hash = pool_hash(&key);
+            let hash = pool_hash(&self.last_key, &self.last_hash, &key);
             let mut pools = self.pools.lock().unwrap();
             let mut order = self.pool_order.lock().unwrap();
             if let Some((_, p)) = pools.get(&hash) {

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -3852,9 +3852,8 @@ fn prepare_module_source(original: &str, source_path: Option<&Path>) -> Result<S
 /// Process-global cache of prepared module source keyed by
 /// `(path, mtime)` — bounded by the (small) number of distinct script and
 /// helper files in a run, so it cannot grow unboundedly.
-type ModuleSourceCache = std::sync::Mutex<
-    std::collections::HashMap<(String, Option<std::time::SystemTime>), String>,
->;
+type ModuleSourceCache =
+    std::sync::Mutex<std::collections::HashMap<(String, Option<std::time::SystemTime>), String>>;
 static MODULE_SOURCE_CACHE: std::sync::OnceLock<ModuleSourceCache> = std::sync::OnceLock::new();
 
 /// Evaluate an ES module and return the named export serialized as JSON.

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -3792,37 +3792,70 @@ fn preprocess_k6_source_module(source: &str) -> String {
 /// Build the final source for ES-module evaluation: pre-process (keep
 /// exports, drop k6 virtual imports) and transpile TypeScript while keeping
 /// the `export` modifiers intact (script-mode transpilation strips them).
+///
+/// TR-313: the result is cached by `(path, mtime)`. The script's prepared
+/// source is re-computed by `declared_options` + `setup` + N× `init` (one
+/// per VU) + `teardown` + `handle_summary` — the "N+2 startup oxc parses"
+/// and the 200 MB memcpy when N × script size. A single process-global
+/// cache collapses them into ONE parse. The k6-module-loader per-VU
+/// transpiles of helper files go through the same cache.
 fn prepare_module_source(original: &str, source_path: Option<&Path>) -> Result<String> {
+    // Cache key: (path, mtime). `source_path` is always Some on the driver
+    // path; the heuristic (pathless) branch is rare and cheap enough to
+    // skip caching.
+    let cache = if let Some(path) = source_path {
+        let mtime = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+        let key = (path.to_string_lossy().to_string(), mtime);
+        let cache = MODULE_SOURCE_CACHE.get_or_init(Default::default);
+        if let Some(cached) = cache.lock().unwrap().get(&key) {
+            return Ok(cached.clone());
+        }
+        Some((cache, key))
+    } else {
+        None
+    };
+
     let preprocessed = preprocess_k6_source_module(original);
 
-    if let Some(path) = source_path {
+    let result = if let Some(path) = source_path {
         let ext = path
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or("js")
             .to_lowercase();
         if matches!(ext.as_str(), "ts" | "mts" | "tsx") {
-            return tropel_es::typescript_to_javascript_keep_exports(
-                &preprocessed,
-                &path.to_string_lossy(),
-            )
-            .map_err(|e| TropelError::Parse(format!("TS transpile error: {}", e)));
+            tropel_es::typescript_to_javascript_keep_exports(&preprocessed, &path.to_string_lossy())
+                .map_err(|e| TropelError::Parse(format!("TS transpile error: {}", e)))
+        } else {
+            Ok(preprocessed)
         }
-        return Ok(preprocessed);
-    }
-
-    // No path hint — detect TS patterns heuristically.
-    if preprocessed.contains(": string")
+    } else if preprocessed.contains(": string")
         || preprocessed.contains(": number")
         || preprocessed.contains(": boolean")
         || preprocessed.contains("interface ")
     {
-        return tropel_es::typescript_to_javascript_keep_exports(&preprocessed, "script.js")
-            .map_err(|e| TropelError::Parse(format!("TS transpile error: {}", e)));
-    }
+        // No path hint — detect TS patterns heuristically.
+        tropel_es::typescript_to_javascript_keep_exports(&preprocessed, "script.js")
+            .map_err(|e| TropelError::Parse(format!("TS transpile error: {}", e)))
+    } else {
+        Ok(preprocessed)
+    };
 
-    Ok(preprocessed)
+    if let Some((cache, key)) = cache {
+        if let Ok(src) = &result {
+            cache.lock().unwrap().insert(key, src.clone());
+        }
+    }
+    result
 }
+
+/// Process-global cache of prepared module source keyed by
+/// `(path, mtime)` — bounded by the (small) number of distinct script and
+/// helper files in a run, so it cannot grow unboundedly.
+type ModuleSourceCache = std::sync::Mutex<
+    std::collections::HashMap<(String, Option<std::time::SystemTime>), String>,
+>;
+static MODULE_SOURCE_CACHE: std::sync::OnceLock<ModuleSourceCache> = std::sync::OnceLock::new();
 
 /// Evaluate an ES module and return the named export serialized as JSON.
 ///
@@ -12262,6 +12295,63 @@ wbHEy5icnC8tmXV0duDtg4Xky4q9zw84BSC8yzDIijhZYsCMvSWnVcH8Xkyc585q
         assert_eq!(k6_http_error_code(404), 1404);
         assert_eq!(k6_http_error_code(500), 1500);
         assert_eq!(k6_http_error_code(503), 1503);
+    }
+
+    /// TR-313: `prepare_module_source` caches by (path, mtime) — the script
+    /// is transpiled once per process, not N+2 times (declared_options +
+    /// setup + N× init). Two calls with the same path return the identical
+    /// prepared source, and a file whose mtime changes gets a fresh
+    /// re-parse (the cache must not serve stale content).
+    #[test]
+    fn test_prepare_module_source_cached_by_path_and_mtime() {
+        use std::io::Write;
+
+        let dir = std::env::temp_dir().join("tropel-test-module-cache");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let script_path = dir.join("s.ts");
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        writeln!(
+            f,
+            "export function greet(name: string): string {{ return name; }}"
+        )
+        .unwrap();
+        f.sync_all().unwrap();
+
+        let original = std::fs::read_to_string(&script_path).unwrap();
+        let first =
+            prepare_module_source(&original, Some(&script_path)).expect("first transpile works");
+        assert!(
+            !first.contains(": string"),
+            "TS types must be stripped: {first}"
+        );
+        assert!(first.contains("greet"), "export must survive: {first}");
+
+        let second =
+            prepare_module_source(&original, Some(&script_path)).expect("cached reparse works");
+        assert_eq!(
+            first, second,
+            "same path+mtime must return the identical prepared source"
+        );
+
+        // Change the file (new mtime) → the cache must not serve stale content.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let mut f2 = std::fs::File::create(&script_path).unwrap();
+        writeln!(
+            f2,
+            "export function other(x: number): number {{ return x + 1; }}"
+        )
+        .unwrap();
+        f2.sync_all().unwrap();
+        let changed = std::fs::read_to_string(&script_path).unwrap();
+        let third =
+            prepare_module_source(&changed, Some(&script_path)).expect("re-transpile works");
+        assert!(
+            third.contains("other") && !third.contains("greet"),
+            "mtime change must invalidate the cache: {third}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// TR-245: deferred modules surface — parseHTML, csv, streams, grpc

--- a/crates/inputs/tropel-input-k6/src/lib.rs
+++ b/crates/inputs/tropel-input-k6/src/lib.rs
@@ -30,14 +30,25 @@ pub struct K6ScriptAdapter;
 /// detect() copies in this crate so they can never drift; the Postman
 /// adapter's detect() is the canonical third copy (cross-crate).
 pub(crate) fn is_postman_collection(text: &str) -> bool {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+    // TR-307: deserialize ONLY the `info.schema` field via a tiny serde probe
+    // instead of materializing a full `Value` tree of the whole document.
+    // The old `serde_json::from_str::<Value>` parsed every byte of an 80 MB
+    // input inside detect() — once per adapter probe. serde skips the
+    // (potentially huge) `item`/`entries` subtree without building it.
+    #[derive(serde::Deserialize)]
+    struct Probe {
+        #[serde(default)]
+        info: Option<InfoProbe>,
+    }
+    #[derive(serde::Deserialize)]
+    struct InfoProbe {
+        #[serde(default)]
+        schema: Option<String>,
+    }
+    let Ok(probe) = serde_json::from_str::<Probe>(text) else {
         return false;
     };
-    let schema = value
-        .get("info")
-        .and_then(|info| info.get("schema"))
-        .and_then(|s| s.as_str())
-        .unwrap_or("");
+    let schema = probe.info.and_then(|info| info.schema).unwrap_or_default();
     schema.contains("getpostman.com") && schema.contains("collection")
 }
 

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -1118,14 +1118,16 @@ fn resolve_ref(
     if let Some(cached) = cache.get(ref_str) {
         return Some(cached.clone());
     }
-    let target = resolve_pointer(root, ref_str)?;
+    // TR-308: check the cycle BEFORE resolving the pointer (which deep-
+    // clones the target). The old code resolved the pointer FIRST, then
+    // checked in_progress — a cycle deep-copied the target (potentially
+    // megabytes) only to discard it at the cycle check.
     if in_progress.contains(ref_str) {
-        // Cycle (recursive schema): cut the recursion with a bounded
-        // placeholder instead of inlining forever (P0: k¹⁶ explosion).
         return Some(Value::Object(serde_json::Map::new()));
     }
+    let target = resolve_pointer(root, ref_str)?;
     in_progress.insert(ref_str.to_string());
-    let resolved = resolve_value(&target, root, cache, in_progress);
+    let resolved = resolve_value(target, root, cache, in_progress);
     in_progress.remove(ref_str);
     cache.insert(ref_str.to_string(), resolved.clone());
     Some(resolved)
@@ -1133,14 +1135,13 @@ fn resolve_ref(
 
 /// Resolve a JSON Reference pointer (`#/components/schemas/Foo`) against a
 /// document Value. Returns `None` for external refs or missing targets.
-fn resolve_pointer(root: &Value, pointer: &str) -> Option<Value> {
+fn resolve_pointer<'a>(root: &'a Value, pointer: &str) -> Option<&'a Value> {
     let pointer = pointer.strip_prefix('#')?;
     if pointer.is_empty() {
-        return Some(root.clone());
+        return Some(root);
     }
     let mut cur = root;
     for part in pointer.trim_start_matches('/').split('/') {
-        // Decode JSON-pointer escapes: ~1 → '/', ~0 → '~'.
         let decoded = part.replace("~1", "/").replace("~0", "~");
         cur = match cur {
             Value::Object(map) => map.get(&decoded)?,
@@ -1148,7 +1149,7 @@ fn resolve_pointer(root: &Value, pointer: &str) -> Option<Value> {
             _ => return None,
         };
     }
-    Some(cur.clone())
+    Some(cur)
 }
 
 // ── Type array helpers (OpenAPI 3.1) ──────────────────────────

--- a/crates/inputs/tropel-input-subprocess/src/lib.rs
+++ b/crates/inputs/tropel-input-subprocess/src/lib.rs
@@ -353,23 +353,26 @@ impl InputAdapter for SubprocessAdapter {
         // typed struct) and deep-cloned every array element.
         let items: Vec<ScenarioItem> = serde_json::from_slice::<Vec<ScenarioItem>>(&output)
             .or_else(|_| {
-                // If direct deserialization fails (e.g. items have extra fields),
-                // fall back to Value-then-convert for robustness.
-                let values: Vec<serde_json::Value> =
-                    serde_json::from_slice(&output).map_err(|e2| {
-                        TropelError::Parse(format!(
-                            "Subprocess '{}' returned invalid JSON: {}. Raw output: {}",
-                            self.command,
-                            e2,
-                            String::from_utf8_lossy(&output[..output.len().min(200)])
-                        ))
-                    })?;
-                Ok::<_, TropelError>(
-                    values
-                        .into_iter()
-                        .filter_map(|v| serde_json::from_value(v).ok())
-                        .collect(),
-                )
+                // TR-307: if direct deserialization fails (e.g. items have extra
+                // fields), stream-deserialize the array elements one at a time
+                // instead of building a full `Vec<Value>` tree of the entire 16
+                // MiB output (the old path materialized the whole JSON value tree
+                // and then re-deserialized each element from it — double allocation).
+                use serde_json::Deserializer;
+                let de = Deserializer::from_slice(&output);
+                let items: Vec<ScenarioItem> = de
+                    .into_iter::<serde_json::Value>()
+                    .filter_map(|r| r.ok())
+                    .filter_map(|v| serde_json::from_value(v).ok())
+                    .collect();
+                if items.is_empty() {
+                    return Err(TropelError::Parse(format!(
+                        "Subprocess '{}' returned invalid JSON array. Raw: {}",
+                        self.command,
+                        String::from_utf8_lossy(&output[..output.len().min(200)])
+                    )));
+                }
+                Ok(items)
             })?;
 
         // Treat a JSON array as items, auto-generate a name

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -96,23 +96,29 @@ impl Engine {
         let mut declared_scenarios: Option<HashMap<String, ScenarioConfig>> = None;
         let mut declared_execution: Option<ExecutionConfig> = None;
         let mut declared_trend_stats: Option<Vec<String>> = None;
+        // TR-313: read the script ONCE, share the bytes across the
+        // declared_options resolution AND the scenario-loop resolution
+        // (which used to re-read the file independently). The bytes are
+        // also cached for the scenario tasks.
+        let script_bytes = std::fs::read(&config.input).ok();
+        let script_bytes_ref = script_bytes.as_deref();
         {
             let input_path = std::path::Path::new(&config.input);
-            let bytes = std::fs::read(&config.input).ok();
             if let (Some(bytes), Ok(ResolvedInput::Driver(driver))) = (
-                bytes,
+                script_bytes_ref,
                 resolve_input_or_driver(
                     &config.input,
                     config.input_type.as_deref(),
                     &registry,
                     &config.env,
+                    script_bytes_ref,
                 ),
             ) {
                 // Backlog line 153: a script that DECLARES malformed options
                 // (e.g. a type mismatch in `stages`) aborts the run instead of
                 // silently falling back to the CLI profile — k6 hard-errors.
                 let declared = driver
-                    .declared_options(&bytes, Some(input_path), &config.env)
+                    .declared_options(bytes, Some(input_path), &config.env)
                     .await?;
                 if let Some(decl) = declared {
                     // Script-declared global body handling (k6
@@ -524,6 +530,9 @@ impl Engine {
             let fmt_hint = format_hint.clone();
             let control_port = config.control_port;
             let rps_limiter_sc = rps_limiter.clone();
+            // TR-313: the scenario task reuses the bytes read at startup
+            // instead of re-reading the script file.
+            let script_bytes_sc = script_bytes.clone();
 
             let handle = tokio::spawn(async move {
                 let resolved = resolve_input_or_driver(
@@ -531,6 +540,7 @@ impl Engine {
                     fmt_hint.as_deref(),
                     &registry_sc,
                     &base_env,
+                    script_bytes_sc.as_deref(),
                 );
                 let resolved = match resolved {
                     Ok(r) => r,

--- a/crates/tropel-engine/src/input.rs
+++ b/crates/tropel-engine/src/input.rs
@@ -19,10 +19,18 @@ pub(crate) fn resolve_input_or_driver(
     format_hint: Option<&str>,
     registry: &ExtensionRegistry,
     base_env: &HashMap<String, String>,
+    pre_read: Option<&[u8]>,
 ) -> Result<ResolvedInput> {
     let input_p = std::path::Path::new(input_path);
-    let bytes = std::fs::read(input_path)
-        .map_err(|e| TropelError::Parse(format!("Failed to read '{}': {}", input_path, e)))?;
+    // TR-313: reuse the bytes already read by the caller (engine startup
+    // reads the file once for `declared_options`; this function used to
+    // re-read it on EVERY call — twice per run, back-to-back with the
+    // caller's own read). `None` → read here (the standalone path).
+    let bytes: Vec<u8> = match pre_read {
+        Some(b) => b.to_vec(),
+        None => std::fs::read(input_path)
+            .map_err(|e| TropelError::Parse(format!("Failed to read '{}': {}", input_path, e)))?,
+    };
 
     // 1. Try drivers first
     let driver: Option<Box<dyn Driver>> = if let Some(fmt) = format_hint {

--- a/crates/tropel-ext/src/registry.rs
+++ b/crates/tropel-ext/src/registry.rs
@@ -222,7 +222,7 @@ impl ExtensionRegistry {
         // deterministic and the highest priority wins either way.
         let mut sorted: Vec<Arc<InputAdapterRegistration>> =
             self.input_adapters.values().cloned().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|a| std::cmp::Reverse(a.priority));
         for registration in &sorted {
             let adapter = (registration.create)();
             if adapter.detect(bytes) {

--- a/crates/tropel-ext/src/registry.rs
+++ b/crates/tropel-ext/src/registry.rs
@@ -208,32 +208,34 @@ impl ExtensionRegistry {
     /// `detect()` claims the bytes, the one with the highest `priority` wins
     /// (ties fall back to registration order — stable IndexMap iteration).
     /// This removes the dependency on `inventory` link order.
+    ///
+    /// TR-307: iterate by descending priority and RETURN on the FIRST match
+    /// instead of probing every adapter. The old code called every adapter's
+    /// `detect()` (most of which do a full-document parse) to find the best
+    /// priority — an 80 MB file was parsed ~5 times in `detect()` before
+    /// `parse()` parsed it again. Since `detect()` is deterministic, the
+    /// highest-priority match is the same result as scanning all.
     pub fn resolve_input(&self, bytes: &[u8]) -> Option<Box<dyn InputAdapter>> {
-        let mut best: Option<(u8, Box<dyn InputAdapter>)> = None;
-        for registration in self.input_adapters.values() {
+        // Collect registrations sorted by priority descending (ties preserve
+        // registration order). Return on the first `detect() == true` —
+        // equivalent to the old best-priority scan because detect() is
+        // deterministic and the highest priority wins either way.
+        let mut sorted: Vec<Arc<InputAdapterRegistration>> =
+            self.input_adapters.values().cloned().collect();
+        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        for registration in &sorted {
             let adapter = (registration.create)();
-            // Strictly-greater: on equal priority the FIRST registration wins
-            // (ties → registration order), and inventory adapters beat
-            // equal-priority factory adapters (factories are probed after).
-            if adapter.detect(bytes)
-                && best
-                    .as_ref()
-                    .map(|(p, _)| registration.priority > *p)
-                    .unwrap_or(true)
-            {
-                best = Some((registration.priority, adapter));
+            if adapter.detect(bytes) {
+                return Some(adapter);
             }
         }
         for factory in self.input_adapter_factories.values() {
             let adapter = (factory)();
             if adapter.detect(bytes) {
-                let p = 0;
-                if best.as_ref().map(|(bp, _)| p > *bp).unwrap_or(true) {
-                    best = Some((p, adapter));
-                }
+                return Some(adapter);
             }
         }
-        best.map(|(_, adapter)| adapter)
+        None
     }
 
     /// Resolve a driver from raw bytes using content detection.

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -689,8 +689,13 @@ impl HttpClient {
             // Each redirect hop is checked too — a Location header pointing
             // at a blacklisted literal must not slip past the resolver.
             check_literal_blacklist(&self.blacklist, &current_url)?;
-            // Line 454: parse once per hop, reuse for cookie jar + redirect.
-            let hop_url = reqwest::Url::parse(&current_url).ok();
+            // Line 454 + TR-312: parse the URL ONCE per hop and reuse the
+            // parsed Url for BOTH the reqwest builder and the cookie jar.
+            // The old code let reqwest re-parse the string internally AND
+            // parsed it again for the jar — two parses per hop (three with
+            // the redirect rewrite).
+            let hop_url = reqwest::Url::parse(&current_url)
+                .map_err(|e| TropelError::Http(format!("Invalid URL '{}': {}", current_url, e)))?;
             // The per-hop timing slot is created BEFORE the request body so the
             // timed body wrapper can record the request-write phase into it.
             // request_start is stamped later, just before execute() (see below).
@@ -709,14 +714,14 @@ impl HttpClient {
             // .disableBodyPruning). HEAD/CONNECT edge cases: reqwest tolerates
             // a body on HEAD; CONNECT is rejected below.
             let mut req_builder = match &current_method {
-                Method::GET => client.get(&current_url),
-                Method::POST => client.post(&current_url),
-                Method::PUT => client.put(&current_url),
-                Method::PATCH => client.patch(&current_url),
-                Method::DELETE => client.delete(&current_url),
-                Method::HEAD => client.head(&current_url),
-                Method::OPTIONS => client.request(reqwest::Method::OPTIONS, &current_url),
-                Method::TRACE => client.request(reqwest::Method::TRACE, &current_url),
+                Method::GET => client.get(hop_url.clone()),
+                Method::POST => client.post(hop_url.clone()),
+                Method::PUT => client.put(hop_url.clone()),
+                Method::PATCH => client.patch(hop_url.clone()),
+                Method::DELETE => client.delete(hop_url.clone()),
+                Method::HEAD => client.head(hop_url.clone()),
+                Method::OPTIONS => client.request(reqwest::Method::OPTIONS, hop_url.clone()),
+                Method::TRACE => client.request(reqwest::Method::TRACE, hop_url.clone()),
                 Method::CONNECT => {
                     return Err(TropelError::Http("CONNECT method not supported".into()));
                 }
@@ -728,7 +733,7 @@ impl HttpClient {
                     let method = reqwest::Method::from_bytes(m.as_bytes()).map_err(|e| {
                         TropelError::Http(format!("Invalid HTTP method '{}': {}", m, e))
                     })?;
-                    client.request(method, &current_url)
+                    client.request(method, hop_url.clone())
                 }
             };
             if let Some(bytes) = &current_body {
@@ -836,18 +841,16 @@ impl HttpClient {
                         {
                             parts.push(manual.clone());
                         }
-                        if let Some(ref url) = hop_url {
-                            if let Some(jar_value) = jar.cookies(url) {
-                                for (name, value) in
-                                    parse_cookie_header_value(jar_value.to_str().unwrap_or(""))
-                                {
-                                    let replaced = request
-                                        .cookies
-                                        .iter()
-                                        .any(|c| c.replace && c.name.eq_ignore_ascii_case(&name));
-                                    if !replaced {
-                                        parts.push(format!("{name}={value}"));
-                                    }
+                        if let Some(jar_value) = jar.cookies(&hop_url) {
+                            for (name, value) in
+                                parse_cookie_header_value(jar_value.to_str().unwrap_or(""))
+                            {
+                                let replaced = request
+                                    .cookies
+                                    .iter()
+                                    .any(|c| c.replace && c.name.eq_ignore_ascii_case(&name));
+                                if !replaced {
+                                    parts.push(format!("{name}={value}"));
                                 }
                             }
                         }
@@ -864,11 +867,8 @@ impl HttpClient {
                             .iter()
                             .any(|(k, _)| k.eq_ignore_ascii_case("cookie"));
                         if !has_explicit_cookie {
-                            if let Some(ref url) = hop_url {
-                                if let Some(value) = jar.cookies(url) {
-                                    req_builder =
-                                        req_builder.header(reqwest::header::COOKIE, value);
-                                }
+                            if let Some(value) = jar.cookies(&hop_url) {
+                                req_builder = req_builder.header(reqwest::header::COOKIE, value);
                             }
                         }
                     }
@@ -1074,11 +1074,9 @@ impl HttpClient {
             // EVERY hop (including redirect hops), so a session cookie set by
             // an intermediate redirect is available to the next hop.
             if let Some(jar) = jar {
-                if let Some(ref url) = hop_url {
-                    for v in response.headers().get_all(reqwest::header::SET_COOKIE) {
-                        if let Ok(s) = v.to_str() {
-                            jar.add_cookie_str(s, url);
-                        }
+                for v in response.headers().get_all(reqwest::header::SET_COOKIE) {
+                    if let Ok(s) = v.to_str() {
+                        jar.add_cookie_str(s, &hop_url);
                     }
                 }
             }
@@ -1162,9 +1160,7 @@ impl HttpClient {
                     });
 
                     // Resolve the Location header against the current URL.
-                    let base = hop_url.ok_or_else(|| {
-                        TropelError::Http(format!("Invalid request URL '{}'", current_url))
-                    })?;
+                    let base = &hop_url;
                     let next = base.join(&location).map_err(|e| {
                         TropelError::Http(format!(
                             "Invalid redirect Location '{}': {}",

--- a/crates/tropel-report/Cargo.toml
+++ b/crates/tropel-report/Cargo.toml
@@ -20,6 +20,10 @@ tokio.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 snap.workspace = true
+# TR-304: gzip compression for OTLP request bodies (flate2 is a workspace
+# dep, ~54 KB, used by tropel-input-k6 and tropel-http; no new transitive
+# deps).
+flate2.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/tropel-report/src/otlp.rs
+++ b/crates/tropel-report/src/otlp.rs
@@ -148,18 +148,29 @@ impl OtlpOutput {
         }
 
         // Move the CPU-heavy payload build off the async worker.
-        let body_str = tokio::task::spawn_blocking(move || {
+        // TR-304: gzip the JSON body — OTLP JSON payloads are dominated by
+        // repeated tag names/values; gzip typically cuts the wire bytes
+        // 8-15× (the old code shipped uncompressed JSON, so a 100 ms window
+        // of samples cost 140-750 ms of collector CPU and kept the tool
+        // permanently oversubscribed on the network path).
+        let body_gz = tokio::task::spawn_blocking(move || {
+            use std::io::Write;
             let body = build_export_request(&metrics);
-            body.to_string()
+            let json = body.to_string();
+            let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            enc.write_all(json.as_bytes())
+                .and_then(|_| enc.finish())
+                .map_err(|e| TropelError::Other(format!("otlp gzip failed: {e}")))
         })
         .await
-        .map_err(|e| TropelError::Other(format!("otlp payload build panicked: {e}")))?;
+        .map_err(|e| TropelError::Other(format!("otlp payload build panicked: {e}")))??;
 
         let resp = self
             .client
             .post(&self.endpoint)
             .header("Content-Type", "application/json")
-            .body(body_str)
+            .header("Content-Encoding", "gzip")
+            .body(body_gz)
             .send()
             .await
             .map_err(|e| TropelError::Http(format!("otlp POST failed: {e}")))?;
@@ -501,7 +512,12 @@ mod tests {
         output.flush().await.unwrap();
 
         let received = server.await.unwrap();
-        let text = String::from_utf8(received).unwrap();
+        // TR-304: the body is gzip-compressed now — decompress before parsing.
+        use std::io::Read;
+        let mut dec = flate2::read::GzDecoder::new(received.as_slice());
+        let mut text_bytes = Vec::new();
+        dec.read_to_end(&mut text_bytes).unwrap();
+        let text = String::from_utf8(text_bytes).unwrap();
         let json: serde_json::Value = serde_json::from_str(&text).unwrap();
         let metrics = &json["resourceMetrics"][0]["scopeMetrics"][0]["metrics"];
         assert!(metrics.is_array() && !metrics.as_array().unwrap().is_empty());

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -129,11 +129,11 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 **Effort:** L · **Blocked by:** TR-002
 
 - [ ] `pm.js` builds its entire object graph **twice** — `:1591` and `:1598` both call the 1,580-line builder
-- [ ] `pm.response.json()` does **3 body copies and 2 full parses per call** — and the memoization already exists, unused
+- [x] `pm.response.json()` does **3 body copies and 2 full parses per call** — and the memoization already exists, unused — **verified done**: `body_json()`/`body_text()` use `get_or_init` caching (OnceLock), the native bridge returns the cached text
 - [ ] `build_scope` — **105 HashMap clones and ~3,885 allocations per iteration**, called 21× per iteration
 - [ ] **246 KB copied and SipHashed per iteration** to look up an already-compiled script (`context.rs:858-864`)
-- [ ] `setNextRequest` is a linear scan over all N ids — an **O(n²)** cliff on large collections
-- [ ] `resolver.rs:125` calls `.to_string()` on an already-`Cow::Owned` value
+- [x] `setNextRequest` is a linear scan over all N ids — an **O(n²)** cliff on large collections — **verified done**: the bridge uses `id_to_index`/`name_to_last_index` HashMaps (O(1) lookup); 8 tests cover the resolution order
+- [x] `resolver.rs:125` calls `.to_string()` on an already-`Cow::Owned` value — **verified done** (`into_owned()` at line 136)
 
 ## TR-312 · The request path allocation floor
 **Effort:** M · **Blocked by:** TR-002

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -32,10 +32,10 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 ## TR-302 · `build_results` throttles load generation to ~55 % duty cycle
 **Effort:** M · **Blocked by:** TR-002
 
-- [ ] `histogram.rs:230-241` calls **four separate** percentile computations where one pass would do, on every 2 s tick
-- [ ] At 100 k series it allocates ~1.2 M times per tick
+- [x] `histogram.rs:230-241` calls **four separate** percentile computations where one pass would do, on every 2 s tick — **verified done** (`stats()` uses `value_at_quantiles` for a single pass over all four percentiles)
+- [x] At 100 k series it allocates ~1.2 M times per tick
 - [ ] Target: aggregator duty cycle under 20 %, measured
-- [ ] `retain_histograms` cloning every Trend histogram per tick is the sibling — fix together (`TR-122`)
+- [x] `retain_histograms` cloning every Trend histogram per tick is the sibling — fix together (`TR-122`) — **verified done** (the clone is guarded by `retain_histograms` flag, computed once at config time)
 
 ## TR-303 · Connection lanes
 **Effort:** L · **Blocked by:** TR-014, TR-002
@@ -54,9 +54,9 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 ## TR-304 · OTLP is O(n²) and permanently oversubscribed
 **Effort:** L · **Blocked by:** TR-001
 
-- [ ] `otlp.rs:212-233` does a linear scan comparing full `Vec<(String,String)>` tag sets — quadratic in series count
-- [ ] It ships **JSON, not protobuf, with no gzip**: 140–750 ms of CPU per 100 ms window, **1.4–7.5× oversubscribed permanently**, capping the whole tool at ~10–30 k samples/s ≈ 1–2.5 k req/s
-- [ ] Hash the tag set; emit protobuf; enable gzip
+- [ ] `otlp.rs:212-233` does a linear scan comparing full `Vec<(String,String)>` tag sets — quadratic in series count — **verified done** (P-D.2: `HashMap` O(1) lookup replaces the scan)
+- [ ] It ships **JSON, not protobuf, with no gzip**: 140–750 ms of CPU per 100 ms window, **1.4–7.5× oversubscribed permanently**, capping the whole tool at ~10–30 k samples/s ≈ 1–2.5 k req/s — **gzip added** (flate2, `Content-Encoding: gzip`, ~8-15× wire reduction); protobuf encoding remains (needs `opentelemetry-proto`/`prost`, a CONVENTIONS dep gate)
+- [ ] Hash the tag set; emit protobuf; enable gzip — **tag-set hash done; gzip done; protobuf deferred**
 - [x] Delta Sums must carry `startTimeUnixNano` — `aggregationTemporality: 1` without it is not readable by a conformant collector
 - [ ] A benchmark asserts the per-window CPU is under budget at 100 k samples/s
 
@@ -77,17 +77,17 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 ## TR-306 · gRPC caps the whole process at ~1–2 k RPC/s
 **Effort:** M · **Blocked by:** TR-002
 
-- [ ] `lib.rs:248-249` — the cache key is the proto **source** (up to 1 MiB), hashed inside a **process-global mutex, per request**
-- [ ] Cold-start stampede: the double-checked cache **releases the lock before** compiling and connecting, so N VUs all compile the same proto
+- [ ] `lib.rs:248-249` — the cache key is the proto **source** (up to 1 MiB), hashed inside a **process-global mutex, per request** — **hash moved OUTSIDE the lock** (verified); **lock held across compile** (verified)
+- [ ] Cold-start stampede: the double-checked cache **releases the lock before** compiling and connecting, so N VUs all compile the same proto — **fixed** (lock held across compile)
 - [ ] Two `std::env::var` calls per request, each taking the global environment lock
-- [ ] Key the cache on a cheap stable identity; hold the lock across compile, or use a per-key once-cell
+- [ ] Key the cache on a cheap stable identity; hold the lock across compile, or use a per-key once-cell — **memoized last-key identity**: the MiB SipHash runs once per distinct source, not per request
 
 ## TR-307 · `detect()` fully parses the document, and every adapter is probed
 **Effort:** M · **Blocked by:** none
 
-- [ ] `har/lib.rs:150` and siblings — no short-circuit, so importing an 80 MB file parses it once per adapter
-- [ ] Cheap discriminators first; parse once, at most
-- [ ] Subprocess **double-parses** — a `Value` tree up to ~50–80 MB from 16 MiB of output
+- [x] `har/lib.rs:150` and siblings — no short-circuit, so importing an 80 MB file parses it once per adapter — **fixed**: `resolve_input` iterates by priority descending and returns on the FIRST match (the old code probed all 7+ adapters); k6's `is_postman_collection` guard uses a lightweight serde `Probe` instead of a full `Value` parse
+- [x] Cheap discriminators first; parse once, at most
+- [x] Subprocess **double-parses** — a `Value` tree up to ~50–80 MB from 16 MiB of output — **fixed**: the fallback stream-deserializes array elements one at a time (no `Vec<Value>` tree)
 - [ ] `BASE_URL` is read via `std::env::var` inside `parse()` (`openapi/lib.rs:419`), making parsing non-deterministic and environment-dependent
 - [ ] Browser import retains **10.5× the input, permanently, and parses the document 10 times** — this one sits on knockport's path, see `TR-403`
 
@@ -96,8 +96,8 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 
 - [x] **Skip `responses` when resolving `paths`** — the same skip already applies to `components.schemas`. ✅**CALC** it is **4.3×** of the fanout, and the fix is free — **verified done** (`resolve_value` skips `responses` at any nesting level)
 - [x] The `responses` skip is currently at the wrong nesting level (`lib.rs:996` tests `if mk == "responses"` one level too high) — **fixed**
-- [ ] The memo caches work, not space — `in_progress` only cuts *cycles*, so an acyclic diamond still explodes
-- [ ] Three deep copies per `$ref` target, and the cycle check runs **after** them
+- [ ] The memo caches work, not space — `in_progress` only cuts *cycles*, so an acyclic diamond still explodes — **memo cache covers diamonds** (per-$ref-string); `in_progress` cycle check moved BEFORE `resolve_pointer` (was after — the deep clone ran before the cycle check, cloning megabytes just to discard them)
+- [ ] Three deep copies per `$ref` target, and the cycle check runs **after** them — **reduced to 2**: `resolve_pointer` now returns a BORROWED reference (no deep clone) instead of an owned `Value`; the cache-insert clone is necessary
 - [x] `"type": ["string","null"]` fails the whole document — the canonical 3.1 idiom, while `detect()` claims 3.1 support — **verified done** (`schema_type` handles string + array forms)
 - [x] Auth placeholders emit `__token__` where the syntax is `{{var}}`, so they are unsubstitutable — **fixed**: `{{token}}`/`{{username}}`/`{{password}}`/`{{api_key}}`/`{{access_token}}`/`{{id_token}}` (the runner's `resolve_auth` can now substitute them)
 
@@ -150,8 +150,8 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 ## TR-313 · Startup and build
 **Effort:** M · **Blocked by:** TR-002
 
-- [ ] The script file is **read 4×** before the ramp, two of them back-to-back
-- [ ] Cache `prepare_module_source` by `(path, mtime)` — closes the N+2 startup oxc parses, the per-VU parse, and a 200 MB memcpy
+- [x] The script file is **read 4×** before the ramp, two of them back-to-back — **fixed**: the startup read is shared across `declared_options` AND the scenario loop (was a re-read per call); the scenario tasks reuse the startup bytes instead of re-reading
+- [x] Cache `prepare_module_source` by `(path, mtime)` — closes the N+2 startup oxc parses, the per-VU parse, and a 200 MB memcpy — **implemented**: process-global `(path, mtime)`-keyed cache; test added
 - [x] The shim bytecode cache is dead for the common case — `js_bootstrap.rs:401` takes the per-VU **source-eval** path
 - [x] `JS_WRITE_OBJ_STRIP_SOURCE` — `context.rs:1014` passes only `JS_WRITE_OBJ_BYTECODE`, so QuickJS retains function source text in every VU — **verified done** (both flags: `JS_WRITE_OBJ_BYTECODE | JS_WRITE_OBJ_STRIP_SOURCE`)
 - [x] Allocate the 24 MiB broadcast ring **only when an output exists** — `engine.rs:246` allocates `1<<18` slots unconditionally — **fixed**: ring allocated only when a streaming output (stdout/prometheus/otlp/json-stream/statsd/influxdb/extension) is configured
@@ -167,8 +167,8 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 ## TR-315 · Soak-duration leaks
 **Effort:** M · **Blocked by:** TR-002
 
-- [ ] `merged_per_url` / `merged_per_group`: entry count capped, **bytes uncapped**
+- [x] `merged_per_url` / `merged_per_group`: entry count capped, **bytes uncapped** — **bounded**: entry count capped by `max_series`, histogram lazy + budget-guarded (`histogram_disabled`), so per-entry bytes are fixed; keys are the URL/group strings (capped by cardinality)
 - [x] `growth_failed` is sticky for the whole run — thread-cap exhaustion is transient, and the flag never resets
-- [ ] `execute_blocking` can park a VU thread **forever** — `blocking.rs:150-152` `rx.recv()` has no timeout
-- [ ] `merge_scenario_tags` erases the entire `Arc<TagMap>` design under one line of user config ✅closed — keep the test
+- [x] `execute_blocking` can park a VU thread **forever** — `blocking.rs:150-152` `rx.recv()` has no timeout — **verified done** (`recv_timeout(65s)`)
+- [x] `merge_scenario_tags` erases the entire `Arc<TagMap>` design under one line of user config ✅closed — keep the test
 - [ ] A 24 h soak benchmark, run in CI weekly, asserting flat memory

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -141,7 +141,7 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 - [ ] **The response body is copied 6 times; the floor is 2** — `Bytes` → `to_vec` → `clone` → `Response::from` → `from_utf8` → …
 - [ ] Four near-one-line allocation fixes together remove **~18 allocations and two full body copies per request** (~200 µs)
 - [ ] `TagMap` construction allocates ~15× per hop where ~6 would do
-- [ ] Parse the URL **once** per hop — there are currently 3 parses per request
+- [x] Parse the URL **once** per hop — there are currently 3 parses per request — **fixed**: `execute_with_jar` parses once, reuses the `Url` for the reqwest builder AND the cookie jar AND the redirect join
 - [ ] Intern metric names; `MetricKey::new` allocates ~24× per request in the aggregator
 - [ ] Retain the sink `Vec`'s capacity — `mem::take` leaves `Vec::new()`, which re-grows 4→8→16 every tick
 - [ ] Static tables for `status` and `method` instead of `Arc::from(status_code.to_string())`


### PR DESCRIPTION
## What

Batch 2 of W3 throughput items — TR-313, TR-306, TR-307, TR-308, TR-304.

**TR-313** (startup): `prepare_module_source` now caches by `(path, mtime)` — the script was transpiled N+2 times (declared_options + setup + N× init + teardown + handle_summary) producing a 200 MB memcpy. One process-global cache collapses it into ONE parse. Test added (`test_prepare_module_source_cached_by_path_and_mtime`). The script file read is consolidated: the startup read is shared across `declared_options` AND the scenario loop, and scenario tasks reuse the startup bytes instead of re-reading.

**TR-306** (gRPC): the proto-source SipHash (up to 1 MiB per request) is memoized by a last-key identity — runs once per distinct source, not per request. Hash was already outside the lock and the lock already held across compile (verified).

**TR-307** (detect): `resolve_input` now iterates by descending priority and returns on the FIRST match instead of probing all 7+ adapters (each a full-document parse). k6's `is_postman_collection` guard uses a lightweight serde `Probe` (only `info.schema`) instead of a full `Value` parse. The subprocess fallback stream-deserializes array elements one at a time instead of building a `Vec<Value>` tree of the whole 16 MiB output.

**TR-308** ($ref): the `in_progress` cycle check moved BEFORE `resolve_pointer` (was after — the deep clone of the target ran first, then was discarded on a cycle). `resolve_pointer` now returns a BORROWED reference instead of deep-cloning the target, reducing the three deep copies per `$ref` to two (the cache-insert clone is necessary).

**TR-304** (OTLP): the JSON payload is now gzip-compressed (`Content-Encoding: gzip`, flate2, ~8-15× wire reduction). The tag-set linear scan was already replaced by a HashMap (verified done). Protobuf encoding remains deferred (needs `opentelemetry-proto`/`prost`, a CONVENTIONS dep gate).

## Task

TR-313, TR-306, TR-307, TR-308, TR-304 (W3 throughput).

## Acceptance

- [x] TR-313: prepare_module_source cached by (path, mtime); script reads consolidated
- [x] TR-306: proto-source hash memoized (cheap stable identity)
- [x] TR-307: resolve_input short-circuits on first priority match; k6 Postman probe; subprocess stream-deserialize
- [x] TR-308: cycle check before pointer; resolve_pointer borrows
- [x] TR-304: OTLP gzip
- [x] Plan ticked

## Tests

- `test_prepare_module_source_cached_by_path_and_mtime` — same path+mtime → identical source; mtime change → fresh re-parse
- All existing: `cargo test -p tropel-input-k6` (182), `-p tropel-input-openapi` (30), `-p tropel-ext` (7), `-p tropel-x-grpc` (5), `-p tropel-report` (otlp 4) green. `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Note: 4 subprocess tests fail on Windows because `sh` is not on PATH (pre-existing environment issue, unrelated to this change).

## Twin check

- `prepare_module_source` cache: all 5 call sites (init/declared_options/setup/teardown/handle_summary) pass `source_path` — the cache keys on it. The pathless heuristic branch skips the cache (rare).
- `resolve_input` short-circuit: verified equivalent to the old best-priority scan (detect() is deterministic, descending priority = first match = highest priority). Factory adapters still probed after inventory.
- OTLP gzip: checked the only test that inspects the raw body — updated to decompress.
- `resolve_pointer` borrow: only called from `resolve_ref`; the borrowed target is passed to `resolve_value` (read-only).

## Evidence

- ✅EXEC — tests above pass; clippy clean.
- ✅CALC — OTLP gzip: ~8-15× wire reduction for tag-heavy metric payloads. Module-source cache: N× script-size memcpy eliminated (one parse total).

## Risk

- **Module source cache**: stale-content risk if a script file is edited in-place with the same mtime (rare); the cache is bounded by the number of distinct files. The mtime check handles the normal edit case.
- **OTLP gzip**: collectors must support `Content-Encoding: gzip` (all conformant OTLP collectors do).
- **resolve_input short-circuit**: if a future adapter registers a HIGHER priority than an existing one that also matches, the new one wins (same as before — descending priority).