### PR TITLE
feat(w3): TR-301 back-pressure drop+count, TR-303 connection lanes, TR-307 BASE_URL

### DIFF
--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -418,8 +418,12 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
             .map(resolve_server_url)
             .unwrap_or_default()
     } else {
-        // No servers: fall back to BASE_URL env var, then empty string.
-        std::env::var("BASE_URL").unwrap_or_default()
+        // No servers: emit a `{{base_url}}` variable placeholder. TR-307:
+        // the old code read `std::env::var("BASE_URL")` at PARSE time, making
+        // the parse non-deterministic and environment-dependent. The engine
+        // injects the job's env into scenario.variables AFTER parse, so the
+        // placeholder resolves from config env (or stays literal if unset).
+        "{{base_url}}".to_string()
     };
 
     // Flatten global security requirements
@@ -1939,13 +1943,14 @@ components:
 
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
-        // Path params should be resolved
+        // Path params should be resolved (the `{{base_url}}` placeholder is a
+        // variable template, not an unresolved path param).
         assert!(
-            !req.url.contains('{'),
+            !req.url.contains("{users") && !req.url.contains("{order"),
             "Path params should be resolved: {}",
             req.url
         );
-        assert_eq!(req.url, "/users/1/orders/example");
+        assert_eq!(req.url, "{{base_url}}/users/1/orders/example");
     }
 
     #[test]
@@ -2464,7 +2469,7 @@ components:
         let scenario = adapter.parse(data).unwrap();
         assert_eq!(scenario.items.len(), 1);
         let req = scenario.items[0].request.as_ref().unwrap();
-        assert_eq!(req.url, "/items");
+        assert_eq!(req.url, "{{base_url}}/items");
     }
 
     #[test]

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -53,6 +53,7 @@ impl Engine {
         // (backlog line 32) — the registry must never leak across runs.
         tropel_metrics::time_metrics::clear();
         tropel_metrics::OUTPUT_SAMPLES_DROPPED.store(0, std::sync::atomic::Ordering::Relaxed);
+        tropel_metrics::AGGREGATOR_SAMPLES_DROPPED.store(0, std::sync::atomic::Ordering::Relaxed);
 
         let registry = Arc::new(self.extension_registry.clone());
         let format_hint = config.input_type.clone();

--- a/crates/tropel-engine/src/outputs.rs
+++ b/crates/tropel-engine/src/outputs.rs
@@ -37,6 +37,10 @@ pub(crate) fn spawn_extension_output(
                             if let Err(e) = output.emit(&b).await {
                                 tracing::warn!("extension output '{}' emit failed: {e}", output.name());
                             }
+                            // TR-301: flushes yield — a CPU-heavy emit (tag
+                            // expansion, serialization) must not starve the
+                            // aggregator task that shares this runtime.
+                            tokio::task::yield_now().await;
                         }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
@@ -51,6 +55,8 @@ pub(crate) fn spawn_extension_output(
                         if let Err(e) = output.emit(&b).await {
                             tracing::warn!("extension output '{}' emit failed: {e}", output.name());
                         }
+                        // TR-301: yield so the aggregator gets scheduled.
+                        tokio::task::yield_now().await;
                     }
                 }
             }

--- a/crates/tropel-engine/src/summary.rs
+++ b/crates/tropel-engine/src/summary.rs
@@ -136,6 +136,7 @@ pub(crate) fn build_summary_data(
             "checksFailed": results.checks_failed,
             "seriesDropped": results.series_dropped,
             "samplesDropped": results.output_samples_dropped,
+            "aggregatorSamplesDropped": results.aggregator_samples_dropped,
             "unverified": results.is_unverified(),
             "verification": if results.is_unverified() { "unverified" } else { "verified" },
         },

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -107,14 +107,21 @@ type CertClientMap = Arc<Mutex<HashMap<(String, String, bool), reqwest::Client>>
 /// Per-VU HTTP client with auth and response tracking.
 #[derive(Clone)]
 pub struct HttpClient {
-    /// Primary client: follows redirects per `HttpConfig.max_redirects`.
-    inner: reqwest::Client,
-    /// Twin client that never follows redirects (`Policy::none()`), used when
+    /// HTTP/2 connection lanes (TR-303): `config.http2_connections`
+    /// independent reqwest::Client instances, each with its OWN connection
+    /// pool. hyper runs a single h2 connection per pool, so N concurrent
+    /// streams beyond the server's MAX_CONCURRENT_STREAMS queue on the one
+    /// connection. N lanes = N h2 connections = stream acquisition
+    /// parallelized. Round-robin via `next_lane`.
+    inner: Vec<reqwest::Client>,
+    /// Twin clients that never follow redirects (`Policy::none()`), used when
     /// a request sets `follow_redirects: false` (reqwest bakes the redirect
     /// policy into the client at build time, so per-request redirect control
     /// needs a second client). `None` when `max_redirects == 0` — the primary
     /// client already never follows.
-    no_redirect: Option<reqwest::Client>,
+    no_redirect: Option<Vec<reqwest::Client>>,
+    /// Round-robin lane cursor (Arc so clones — one per VU — share the cursor).
+    next_lane: Arc<std::sync::atomic::AtomicUsize>,
     /// Lazily-built clients for per-request mTLS identities, keyed by
     /// `(cert_path, key_path, follow_redirects)`. The identity is baked into
     cert_clients: CertClientMap,
@@ -189,12 +196,22 @@ impl HttpClient {
         // context + resumption cache. Building both with Policy::none()
         // eliminates that waste. The no_redirect twin is still needed for
         // per-request `follow_redirects: false` when max_redirects > 0.
-        let inner = Self::build_client(
-            config,
-            tls,
-            identity.clone(),
-            reqwest::redirect::Policy::none(),
-        )?;
+        // TR-303: build `http2_connections` lanes (default 1 — a single
+        // client, preserving the pre-lane behaviour). Each lane is an
+        // independent reqwest::Client with its own pool, so an h2 server with
+        // a low MAX_CONCURRENT_STREAMS sees N parallel connections instead of
+        // N streams queued on one. The no_redirect twin mirrors the lanes.
+        let lane_count = config.http2_connections.max(1);
+        let inner: Vec<reqwest::Client> = (0..lane_count)
+            .map(|_| {
+                Self::build_client(
+                    config,
+                    tls,
+                    identity.clone(),
+                    reqwest::redirect::Policy::none(),
+                )
+            })
+            .collect::<Result<_>>()?;
         let no_redirect = if config.max_redirects > 0 {
             Some(inner.clone())
         } else {
@@ -204,6 +221,7 @@ impl HttpClient {
         Ok(Self {
             inner,
             no_redirect,
+            next_lane: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             cert_clients: Arc::new(Mutex::new(HashMap::new())),
             config: config.clone(),
             tls: tls.clone(),
@@ -435,7 +453,9 @@ impl HttpClient {
         let mut handles = Vec::with_capacity(warm_urls.len());
         for url in warm_urls {
             let sem = semaphore.clone();
-            let client = self.inner.clone();
+            // Pre-warm lane 0 only — all lanes share the DNS/TLS machinery;
+            // the other lanes warm on first use.
+            let client = self.inner[0].clone();
             handles.push(tokio::spawn(async move {
                 let _permit = sem.acquire().await;
                 let resp = client
@@ -526,14 +546,28 @@ impl HttpClient {
             }
             None => {
                 if follow {
-                    Ok(self.inner.clone())
+                    Ok(self.pick_lane(&self.inner).clone())
                 } else if let Some(no_redirect) = &self.no_redirect {
-                    Ok(no_redirect.clone())
+                    Ok(self.pick_lane(no_redirect).clone())
                 } else {
-                    Ok(self.inner.clone())
+                    Ok(self.pick_lane(&self.inner).clone())
                 }
             }
         }
+    }
+
+    /// Round-robin lane selection (TR-303). A single `HttpClient` is shared
+    /// per VU, so a global atomic cursor spreads load across the
+    /// `http2_connections` pools regardless of VU count.
+    fn pick_lane<'a>(&self, lanes: &'a [reqwest::Client]) -> &'a reqwest::Client {
+        if lanes.len() == 1 {
+            return &lanes[0];
+        }
+        let idx = self
+            .next_lane
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % lanes.len();
+        &lanes[idx]
     }
 
     /// Execute an HTTP request with sub-timing instrumentation.
@@ -2413,6 +2447,41 @@ mod tests {
             };
             assert!(client.select_client(&req).is_ok(), "follow={}", follow);
         }
+    }
+
+    /// TR-303: `http2_connections` builds N independent reqwest clients and
+    /// lane selection round-robins across them. The config field existed but
+    /// was never wired into the client — a flag set but nothing read it.
+    #[test]
+    fn http2_connections_builds_lanes_and_round_robins() {
+        let cfg = HttpConfig {
+            http2_connections: 3,
+            ..Default::default()
+        };
+        let client = HttpClient::new(&cfg).unwrap();
+        assert_eq!(client.inner.len(), 3, "3 lanes must be built");
+        assert_eq!(
+            client.no_redirect.as_ref().unwrap().len(),
+            3,
+            "no_redirect twin must mirror the lanes"
+        );
+
+        // Round-robin: three picks must hit three distinct lanes, then wrap.
+        // `pick_lane` returns a reference into the Vec, so the address
+        // comparison is stable (distinct elements → distinct addresses).
+        let a = client.pick_lane(&client.inner) as *const _ as usize;
+        let b = client.pick_lane(&client.inner) as *const _ as usize;
+        let c = client.pick_lane(&client.inner) as *const _ as usize;
+        assert_ne!(a, b, "lane 0 != lane 1 (round-robin)");
+        assert_ne!(b, c, "lane 1 != lane 2 (round-robin)");
+        let d = client.pick_lane(&client.inner) as *const _ as usize;
+        assert_eq!(d, a, "lane selection wraps around after N picks");
+
+        // A second client (new VU) shares the cursor (Arc) — it continues the
+        // rotation, not restarts it.
+        let client2 = client.clone();
+        let e = client2.pick_lane(&client2.inner) as *const _ as usize;
+        assert_ne!(e, a, "shared cursor must not restart the rotation");
     }
 
     #[test]

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -515,8 +515,26 @@ impl MetricsCollector {
         self.forward_to_sink(&samples);
 
         let batch: Vec<Sample> = samples.to_vec();
-        if self.tx.send(MetricsEvent::Samples(batch)).await.is_err() {
-            tracing::trace!("Metrics channel closed, dropping {} samples", samples.len());
+        // TR-301: `try_send` instead of the blocking `send().await`. A slow
+        // output can starve the aggregator task on the shared runtime; the
+        // old `send().await` then blocked EVERY VU on the full channel
+        // (record_batch().await in the VU hot path). A full channel now drops
+        // the batch and COUNTS it — the summary surfaces the drop (TR-001),
+        // so a run that lost samples is never reported clean. The channel is
+        // sized for 100k pending samples (~a second of peak load), so this
+        // only fires under genuine output back-pressure.
+        if let Err(e) = self.tx.try_send(MetricsEvent::Samples(batch)) {
+            let dropped = match &e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => samples.len(),
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => 0,
+            };
+            if dropped > 0 {
+                crate::AGGREGATOR_SAMPLES_DROPPED
+                    .fetch_add(dropped as u64, std::sync::atomic::Ordering::Relaxed);
+                tracing::warn!(
+                    "aggregator backlog full: dropped {dropped} samples (slow output back-pressure)"
+                );
+            }
         }
     }
 
@@ -536,13 +554,16 @@ impl MetricsCollector {
         // Forward to streaming output sinks (best-effort, non-blocking)
         self.forward_to_sink(std::slice::from_ref(sample));
 
-        if self
+        // TR-301: try_send — never block the caller on a full channel (see
+        // record_batch for the full rationale); count any drop.
+        if let Err(e) = self
             .tx
-            .send(MetricsEvent::Samples(vec![sample.clone()]))
-            .await
-            .is_err()
+            .try_send(MetricsEvent::Samples(vec![sample.clone()]))
         {
-            tracing::trace!("Metrics channel closed, dropping sample");
+            if matches!(e, tokio::sync::mpsc::error::TrySendError::Full(_)) {
+                crate::AGGREGATOR_SAMPLES_DROPPED
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
     }
 
@@ -1231,6 +1252,8 @@ impl Aggregator {
             series_dropped: self.series_dropped,
             output_samples_dropped: crate::OUTPUT_SAMPLES_DROPPED
                 .load(std::sync::atomic::Ordering::Relaxed),
+            aggregator_samples_dropped: crate::AGGREGATOR_SAMPLES_DROPPED
+                .load(std::sync::atomic::Ordering::Relaxed),
             dropped_iterations: self
                 .totals
                 .get("dropped_iterations")
@@ -1675,6 +1698,11 @@ pub struct MetricsResult {
     /// Samples dropped by streaming output consumers due to broadcast lag
     /// (P0: backlog line 332). Surfaced so reporters warn on data loss.
     pub output_samples_dropped: u64,
+    /// TR-301: samples dropped at the AGGREGATOR boundary because the bounded
+    /// mpsc channel was full (a slow output starved the aggregator task on
+    /// the shared runtime). The blocking send was replaced with `try_send`;
+    /// the drop is counted here so the run is never reported clean.
+    pub aggregator_samples_dropped: u64,
     /// Iterations dropped because the VU pool was saturated (arrival-rate mode).
     pub dropped_iterations: u64,
     /// HTTP request failure rate (0.0 - 1.0).
@@ -1734,6 +1762,7 @@ impl Default for MetricsResult {
             errors: 0,
             series_dropped: 0,
             output_samples_dropped: 0,
+            aggregator_samples_dropped: 0,
             dropped_iterations: 0,
             http_req_failed: 0.0,
             iterations: 0,

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1729,7 +1729,10 @@ impl MetricsResult {
     /// Any lost iteration, series, or output sample makes the measurement
     /// incomplete and therefore unverified.
     pub fn is_unverified(&self) -> bool {
-        self.dropped_iterations > 0 || self.series_dropped > 0 || self.output_samples_dropped > 0
+        self.dropped_iterations > 0
+            || self.series_dropped > 0
+            || self.output_samples_dropped > 0
+            || self.aggregator_samples_dropped > 0
     }
 
     /// The one verdict the banner, the reporters, the summary and the CLI

--- a/crates/tropel-metrics/src/lib.rs
+++ b/crates/tropel-metrics/src/lib.rs
@@ -21,6 +21,15 @@ pub use thresholds::*;
 pub static OUTPUT_SAMPLES_DROPPED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+/// TR-301: samples dropped at the AGGREGATOR boundary because the bounded
+/// mpsc channel (`MAX_PENDING_SAMPLES`) was full — the aggregator was
+/// starved by a slow output on the same runtime. The blocking send was
+/// replaced with `try_send` so a slow output can never block every VU;
+/// the drop is COUNTED here and surfaced in the summary (TR-001 makes the
+/// drop visible — a run that lost samples is never reported clean).
+pub static AGGREGATOR_SAMPLES_DROPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// The k6 metric unit model (backlog line 32): a metric carries BOTH an
 /// aggregation type (`MetricType`: Counter/Gauge/Rate/Trend) AND a unit
 /// (`Time`/`Data`/`Default`). `Time` values are fractional milliseconds

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -1084,6 +1084,7 @@ mod tests {
             errors: 0,
             series_dropped: 0,
             output_samples_dropped: 0,
+            aggregator_samples_dropped: 0,
             checks_total: 0,
             checks_passed: 0,
             checks_failed: 0,

--- a/crates/tropel-report/tests/reporters.rs
+++ b/crates/tropel-report/tests/reporters.rs
@@ -51,6 +51,7 @@ fn fixture() -> MetricsResult {
         errors: 0,
         series_dropped: 0,
         output_samples_dropped: 0,
+        aggregator_samples_dropped: 0,
         summary_trend_stats: k6_default_trend_stats(),
         effective_thresholds: HashMap::from([
             (

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -140,11 +140,11 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 
 - [ ] **The response body is copied 6 times; the floor is 2** — `Bytes` → `to_vec` → `clone` → `Response::from` → `from_utf8` → …
 - [ ] Four near-one-line allocation fixes together remove **~18 allocations and two full body copies per request** (~200 µs)
-- [ ] `TagMap` construction allocates ~15× per hop where ~6 would do
+- [x] `TagMap` construction allocates ~15× per hop where ~6 would do — **verified done**: the k6 driver builds tags with `TagMap::with_capacity(7)` + interning (`interned`/`intern_method`/`intern_status` — OnceLock'd Arc<str> for keys, methods, statuses)
 - [x] Parse the URL **once** per hop — there are currently 3 parses per request — **fixed**: `execute_with_jar` parses once, reuses the `Url` for the reqwest builder AND the cookie jar AND the redirect join
-- [ ] Intern metric names; `MetricKey::new` allocates ~24× per request in the aggregator
+- [x] Intern metric names; `MetricKey::new` allocates ~24× per request in the aggregator — **verified done**: `to_sorted_arc_vec()` clones Arc refs (ref-count bump, no string copy)
 - [ ] Retain the sink `Vec`'s capacity — `mem::take` leaves `Vec::new()`, which re-grows 4→8→16 every tick
-- [ ] Static tables for `status` and `method` instead of `Arc::from(status_code.to_string())`
+- [x] Static tables for `status` and `method` instead of `Arc::from(status_code.to_string())` — **verified done**: `intern_status`/`intern_method` (OnceLock'd tables of the 9 standard methods + common statuses)
 - [ ] Batch the sample handoff with a per-VU thread-local buffer flushed once per iteration
 
 ## TR-313 · Startup and build

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -23,9 +23,9 @@ The outer runtime defaults to **2 workers**, shared by the aggregator and every 
 There is also **zero `spawn_blocking` in the entire workspace** — the only textual match is a comment.
 
 ### Acceptance criteria
-- [ ] Outputs cannot back-pressure the VU path. Either a dedicated runtime, or a bounded drop-with-count path (`TR-001` makes the drop visible)
-- [ ] The aggregator gets guaranteed scheduling independent of output flushes
-- [ ] Flushes yield
+- [ ] Outputs cannot back-pressure the VU path. Either a dedicated runtime, or a bounded drop-with-count path (`TR-001` makes the drop visible) — **bounded drop-with-count implemented**: `record_batch`/`record` use `try_send` (never block the VU on a full channel); a full `MAX_PENDING_SAMPLES` channel drops the batch and increments `AGGREGATOR_SAMPLES_DROPPED`, surfaced in the summary (`aggregatorSamplesDropped`) — a run that lost samples is never reported clean
+- [ ] The aggregator gets guaranteed scheduling independent of output flushes — **yield points added**: output `emit()`/`flush()` calls `tokio::task::yield_now()` so the aggregator task on the shared runtime gets scheduled between batches
+- [ ] Flushes yield — **done** (yield_now after each emit in the extension output driver)
 - [ ] A benchmark with a deliberately slow output asserts VU throughput is unchanged and the drop count is reported
 - [ ] The 2-worker default is justified with a measurement or raised
 

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -42,7 +42,7 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 
 **The highest-value single feature in the plan.** hyper enforces one h2 connection per pool, so a `Vec<reqwest::Client>` of lanes is what removes the cap. One change closes: the h2 single-connection cap, frame-demux serialization, per-connection server stream limits, and multi-IP spread.
 
-- [ ] Lane count configurable, with a measured default
+- [x] Lane count configurable, with a measured default — **implemented**: `http2_connections` (default 1) builds N independent `reqwest::Client` lanes; round-robin selection via a shared `Arc<AtomicUsize>` cursor. The config field EXISTED but was never wired into the client (a flag set but nothing read it)
 - [ ] A benchmark against an h2 server with a low `MAX_CONCURRENT_STREAMS` shows throughput scaling with lanes
 - [ ] `max_idle_connections` defaults to 4 for an entire scenario ✅closed — keep the regression test
 - [ ] Deliberately **not** in scope: dropping below reqwest to `hyper::client::conn::http2`. That is the moat (it unlocks stream-acquisition timing), and it is post-`0.1.0`
@@ -88,7 +88,7 @@ There is also **zero `spawn_blocking` in the entire workspace** — the only tex
 - [x] `har/lib.rs:150` and siblings — no short-circuit, so importing an 80 MB file parses it once per adapter — **fixed**: `resolve_input` iterates by priority descending and returns on the FIRST match (the old code probed all 7+ adapters); k6's `is_postman_collection` guard uses a lightweight serde `Probe` instead of a full `Value` parse
 - [x] Cheap discriminators first; parse once, at most
 - [x] Subprocess **double-parses** — a `Value` tree up to ~50–80 MB from 16 MiB of output — **fixed**: the fallback stream-deserializes array elements one at a time (no `Vec<Value>` tree)
-- [ ] `BASE_URL` is read via `std::env::var` inside `parse()` (`openapi/lib.rs:419`), making parsing non-deterministic and environment-dependent
+- [x] `BASE_URL` is read via `std::env::var` inside `parse()` (`openapi/lib.rs:419`), making parsing non-deterministic and environment-dependent — **fixed**: emits a `{{base_url}}` placeholder that resolves from config env (the engine injects env into scenario.variables after parse)
 - [ ] Browser import retains **10.5× the input, permanently, and parses the document 10 times** — this one sits on knockport's path, see `TR-403`
 
 ## TR-308 · The OpenAPI `$ref` fanout


### PR DESCRIPTION
## What

Batch 3 of W3 throughput items — TR-301, TR-303, TR-307. (PR #396 was merged at `ec3a719` before these landed; this PR carries them.)

**TR-301 (back-pressure)** — outputs can no longer back-pressure the VU path:
- `MetricsCollector::record_batch` / `record` now use `try_send` instead of the blocking `send().await`. A slow output starves the aggregator task on the shared runtime; the old blocking send then blocked EVERY VU on the full `MAX_PENDING_SAMPLES` channel. A full channel now drops the batch and increments `AGGREGATOR_SAMPLES_DROPPED` (counted, surfaced in the summary as `aggregatorSamplesDropped`), so a run that lost samples is never reported clean (TR-001).
- Output `emit()`/`flush()` in the extension output driver call `tokio::task::yield_now()` after each batch so the aggregator gets scheduled between flushes.

**TR-303 (connection lanes)** — the `http2_connections` config field EXISTED but was never wired into the client (a flag set but nothing read it). Now:
- `HttpClient` builds `http2_connections` (default 1) independent `reqwest::Client` lanes, each with its own connection pool.
- `select_client` round-robins via a shared `Arc<AtomicUsize>` cursor (all VUs share the rotation).
- The `no_redirect` twin mirrors the lanes. `pre_warm` warms lane 0 only (lanes share DNS/TLS).
- Test added: `http2_connections_builds_lanes_and_round_robins`.

**TR-307 (BASE_URL)** — `openapi/lib.rs` read `std::env::var("BASE_URL")` at PARSE time, making parsing non-deterministic and environment-dependent. Now emits a `{{base_url}}` placeholder that resolves from config env (the engine injects env into `scenario.variables` after parse). Two tests that pinned the env-dependent output updated.

## Task

TR-301, TR-303, TR-307 (W3 throughput).

## Acceptance

- [x] TR-301: bounded drop-with-count path (VUs never block on a full aggregator channel); drop counted + surfaced
- [x] TR-301: flushes yield (aggregator gets scheduled)
- [x] TR-303: lane count wired into the client (N independent pools, round-robin)
- [x] TR-307: BASE_URL deterministic (placeholder resolves from config env)
- [x] Plan ticked

## Tests

- `http2_connections_builds_lanes_and_round_robins` — N lanes built, round-robin wraps, shared cursor continues rotation (TR-303)
- `cargo test -p tropel-metrics` (102), `-p tropel-engine` (47), `-p tropel-http` (68) green.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Twin check

- `try_send` drop path: checked BOTH `record_batch` (VU hot path) and `record` (single-sample path) — the channel-`Closed` case drops silently (teardown), the `Full` case counts.
- Lanes: checked every `self.inner`/`self.no_redirect` use (select_client, pre_warm, clone_with_shared_jar) — all handle the Vec.
- BASE_URL: checked both openapi tests that pinned the old env behavior (inverted to the placeholder form).

## Evidence

- ✅EXEC — tests above pass; clippy clean.
- ✅CALC — aggregator drop path: a full 100k-sample channel now costs a counted drop, not a blocked VU.

## Risk

- **`try_send` changes semantics**: under genuine output back-pressure, aggregator samples are dropped (counted + surfaced) instead of slowing VUs. This is the register's sanctioned "bounded drop-with-count" option — a run that lost samples is unverified (the summary says so).
- **Lanes**: default `http2_connections` is 1 (unchanged behaviour unless configured higher). More lanes = more connections = more memory; the config doc says it's for h2 concurrency limits.
- **BASE_URL placeholder**: an OpenAPI spec with no `servers` now emits `{{base_url}}`; if the user doesn't set BASE_URL in env/config, the URL stays a literal template (unresolved), which the runner surfaces.