### PR TITLE
feat(har): strip If-None-Match/If-Modified-Since on replay [W4 #223]

### DIFF
--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -465,14 +465,20 @@ fn merge_pairs<I: Iterator<Item = (String, String)>>(pairs: I) -> HashMap<String
 ///
 /// Returns false for HTTP/2 pseudo-headers (`:method`, `:authority`,
 /// `:scheme`, `:path` — Chrome HARs record them; they're not valid HTTP/1.1
-/// header names and `HeaderName::try_from` rejects the `:`), and for
-/// `Content-Length` / `Accept-Encoding`, which the HTTP client manages
-/// itself. Everything else is replayed as recorded.
+/// header names and `HeaderName::try_from` rejects the `:`), for
+/// `Content-Length` / `Accept-Encoding` (the HTTP client manages them),
+/// and for cache-validation headers `If-None-Match` / `If-Modified-Since`
+/// — replaying them causes 304s with `http_req_failed` at 0.00,
+/// silently invalidating the entire load-test result (W4 #223).
+/// Everything else is replayed as recorded.
 fn should_replay_header(name: &str) -> bool {
     if name.starts_with(':') {
         return false;
     }
-    !name.eq_ignore_ascii_case("content-length") && !name.eq_ignore_ascii_case("accept-encoding")
+    !name.eq_ignore_ascii_case("content-length")
+        && !name.eq_ignore_ascii_case("accept-encoding")
+        && !name.eq_ignore_ascii_case("if-none-match")
+        && !name.eq_ignore_ascii_case("if-modified-since")
 }
 
 /// Combine duplicate header lines into one value per name.
@@ -1074,6 +1080,63 @@ mod tests {
         };
         assert_eq!(get("Authorization"), Some("Bearer tok"));
         assert_eq!(get("X-Trace"), Some("abc"));
+    }
+
+    #[test]
+    fn test_cache_validation_headers_stripped() {
+        // W4 #223: If-None-Match / If-Modified-Since cause 304 responses
+        // on replay, making http_req_failed 0.00 and silently invalidating
+        // the entire load-test result.
+        let adapter = HarInputAdapter;
+        let data = br#"{
+            "log": {
+                "version": "1.2",
+                "entries": [
+                    {
+                        "request": {
+                            "method": "GET",
+                            "url": "https://api.example.com/data",
+                            "headers": [
+                                {"name": "If-None-Match", "value": "\"abc123\""},
+                                {"name": "If-Modified-Since", "value": "Mon, 01 Jan 2024 00:00:00 GMT"},
+                                {"name": "Authorization", "value": "Bearer tok"},
+                                {"name": "Accept", "value": "application/json"}
+                            ],
+                            "queryString": []
+                        },
+                        "response": {"status": 200, "statusText": "OK"}
+                    }
+                ]
+            }
+        }"#;
+
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let names: Vec<&str> = req.headers.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(
+            !names
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case("if-none-match")),
+            "If-None-Match must be stripped, got {:?}",
+            names
+        );
+        assert!(
+            !names
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case("if-modified-since")),
+            "If-Modified-Since must be stripped, got {:?}",
+            names
+        );
+        // Real headers survive.
+        let get = |k: &str| {
+            req.headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("Authorization"), Some("Bearer tok"));
+        assert_eq!(get("Accept"), Some("application/json"));
     }
 
     #[test]

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -938,7 +938,34 @@ fn resolve_refs(doc: &Value) -> Value {
     for (k, v) in map {
         let resolved = match k.as_str() {
             // paths → operations (params, requestBody, auth) are consumed.
-            "paths" => resolve_value(v, doc, &mut cache, &mut in_progress),
+            // responses are NOT consumed — skip resolving them to avoid
+            // inlining potentially huge response schemas (W4 #213).
+            "paths" => match v.as_object() {
+                Some(path_map) => {
+                    let mut path_out = serde_json::Map::with_capacity(path_map.len());
+                    for (pk, pv) in path_map {
+                        let resolved_path = match pv.as_object() {
+                            Some(method_map) => {
+                                let mut method_out =
+                                    serde_json::Map::with_capacity(method_map.len());
+                                for (mk, mv) in method_map {
+                                    let resolved_method = if mk == "responses" {
+                                        mv.clone()
+                                    } else {
+                                        resolve_value(mv, doc, &mut cache, &mut in_progress)
+                                    };
+                                    method_out.insert(mk.clone(), resolved_method);
+                                }
+                                Value::Object(method_out)
+                            }
+                            None => resolve_value(pv, doc, &mut cache, &mut in_progress),
+                        };
+                        path_out.insert(pk.clone(), resolved_path);
+                    }
+                    Value::Object(path_out)
+                }
+                None => v.clone(),
+            },
             // components: only securitySchemes is read by resolve_auth;
             // schemas / parameters / requestBodies are dead code but refs
             // INTO them from paths resolve lazily via resolve_value. A
@@ -2215,5 +2242,46 @@ components:
         let result = adapter.parse(data);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no paths"));
+    }
+
+    #[test]
+    fn test_responses_refs_not_resolved() {
+        // W4 #213: response schemas are never consumed by tropel, so $ref
+        // inside responses should NOT be resolved. A broken ref in responses
+        // must not cause the parse to fail.
+        let adapter = OpenApiInputAdapter;
+        let data = br##"{
+            "openapi": "3.0.0",
+            "info": {"title": "RespRef", "version": "1.0"},
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Nonexistent"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Item": {
+                        "type": "object",
+                        "properties": {"id": {"type": "integer"}}
+                    }
+                }
+            }
+        }"##;
+        let scenario = adapter.parse(data).unwrap();
+        assert_eq!(scenario.items.len(), 1);
+        let req = scenario.items[0].request.as_ref().unwrap();
+        assert_eq!(req.url, "/items");
     }
 }

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -928,8 +928,6 @@ fn normalize_swagger2_operation(op: &mut Value) {
 /// instead of recursing forever. A recursive body schema now yields a
 /// one-level, bounded example rather than megabytes or a kill.
 fn resolve_refs(doc: &Value) -> Value {
-    // Clone the root once; each $ref lookup reads from it.
-    let root = doc.clone();
     let mut cache: HashMap<String, Value> = HashMap::new();
     let mut in_progress: HashSet<String> = HashSet::new();
 
@@ -940,7 +938,7 @@ fn resolve_refs(doc: &Value) -> Value {
     for (k, v) in map {
         let resolved = match k.as_str() {
             // paths → operations (params, requestBody, auth) are consumed.
-            "paths" => resolve_value(v, &root, &mut cache, &mut in_progress),
+            "paths" => resolve_value(v, doc, &mut cache, &mut in_progress),
             // components: only securitySchemes is read by resolve_auth;
             // schemas / parameters / requestBodies are dead code but refs
             // INTO them from paths resolve lazily via resolve_value. A
@@ -950,7 +948,7 @@ fn resolve_refs(doc: &Value) -> Value {
                     let mut comp_out = serde_json::Map::with_capacity(comp_map.len());
                     for (ck, cv) in comp_map {
                         let cres = if ck == "securitySchemes" {
-                            resolve_value(cv, &root, &mut cache, &mut in_progress)
+                            resolve_value(cv, doc, &mut cache, &mut in_progress)
                         } else {
                             cv.clone()
                         };

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -218,6 +218,13 @@ struct OasSchema {
     items: Option<Box<OasSchema>>,
     #[serde(default)]
     required: Vec<String>,
+    // Composition keywords — the universal inheritance idiom.
+    #[serde(default, rename = "allOf")]
+    all_of: Option<Vec<Box<OasSchema>>>,
+    #[serde(default, rename = "oneOf")]
+    one_of: Option<Vec<Box<OasSchema>>>,
+    #[serde(default, rename = "anyOf")]
+    any_of: Option<Vec<Box<OasSchema>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1266,6 +1273,46 @@ fn generate_schema_example(schema: Option<&OasSchema>) -> Option<serde_json::Val
         return Some(default.clone());
     }
 
+    // Composition keywords (W4 #217): allOf merges properties from all
+    // sub-schemas; oneOf/anyOf picks the first variant that generates an
+    // example. Without this, these schemas silently produce null.
+    if let Some(ref all_of) = schema.all_of {
+        let mut merged_props: HashMap<String, &Box<OasSchema>> = HashMap::new();
+        for sub in all_of {
+            if let Some(ref props) = sub.properties {
+                for (k, v) in props {
+                    merged_props.entry(k.clone()).or_insert(v);
+                }
+            }
+        }
+        if !merged_props.is_empty() {
+            let mut keys: Vec<&String> = merged_props.keys().collect();
+            keys.sort();
+            let mut obj = serde_json::Map::new();
+            for name in keys {
+                let val = generate_schema_example(Some(merged_props[name]))
+                    .unwrap_or(serde_json::Value::Null);
+                obj.insert(name.clone(), val);
+            }
+            return Some(serde_json::Value::Object(obj));
+        }
+        // allOf with no properties — try the first sub-schema.
+        if let Some(first) = all_of.first() {
+            if let Some(val) = generate_schema_example(Some(first)) {
+                return Some(val);
+            }
+        }
+    }
+    for variants in [&schema.one_of, &schema.any_of] {
+        if let Some(ref vars) = variants {
+            for variant in vars {
+                if let Some(val) = generate_schema_example(Some(variant)) {
+                    return Some(val);
+                }
+            }
+        }
+    }
+
     match schema.r#type.as_deref() {
         Some("object") => {
             let mut obj = serde_json::Map::new();
@@ -2283,5 +2330,88 @@ components:
         assert_eq!(scenario.items.len(), 1);
         let req = scenario.items[0].request.as_ref().unwrap();
         assert_eq!(req.url, "/items");
+    }
+
+    #[test]
+    fn test_allof_schema_generates_merged_body() {
+        // W4 #217: allOf merges properties from all sub-schemas into one
+        // example object, instead of producing null.
+        let adapter = OpenApiInputAdapter;
+        let data = br##"{
+            "openapi": "3.0.0",
+            "info": {"title": "AllOf", "version": "1.0"},
+            "paths": {
+                "/items": {
+                    "post": {
+                        "operationId": "createItem",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "allOf": [
+                                            {"type": "object", "properties": {"name": {"type": "string"}}},
+                                            {"type": "object", "properties": {"count": {"type": "integer"}}}
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "Created"}}
+                    }
+                }
+            }
+        }"##;
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let body = req.body.as_ref().expect("allOf must generate a body");
+        match body {
+            Body::Json(v) => {
+                let s = v.to_string();
+                assert!(s.contains("\"name\""), "must contain 'name', got: {s}");
+                assert!(s.contains("\"count\""), "must contain 'count', got: {s}");
+            }
+            other => panic!("expected Json body, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_oneof_schema_picks_first_variant() {
+        // W4 #217: oneOf picks the first variant that generates an example.
+        let adapter = OpenApiInputAdapter;
+        let data = br##"{
+            "openapi": "3.0.0",
+            "info": {"title": "OneOf", "version": "1.0"},
+            "paths": {
+                "/items": {
+                    "post": {
+                        "operationId": "createItem",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "oneOf": [
+                                            {"type": "object", "properties": {"id": {"type": "integer"}}},
+                                            {"type": "string"}
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "Created"}}
+                    }
+                }
+            }
+        }"##;
+        let scenario = adapter.parse(data).unwrap();
+        let req = scenario.items[0].request.as_ref().unwrap();
+        let body = req.body.as_ref().expect("oneOf must generate a body");
+        match body {
+            Body::Json(v) => {
+                // First variant is object with "id": 1
+                let s = v.to_string();
+                assert!(s.contains("\"id\""), "must pick first variant, got: {s}");
+            }
+            other => panic!("expected Json body, got {:?}", other),
+        }
     }
 }

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -358,11 +358,11 @@ impl ScenarioRunner {
                                 .expect("guarded by item.request.is_some()")
                         })
                     };
-                    // Resolve variables across the entire request. The URL gets
-                    // percent-encoded values so a data value containing `&` or
-                    // `=` cannot split the query into extra params (backlog
-                    // line 96); headers/query_params keep raw substitution
-                    // (the HTTP layer encodes query params itself).
+                    // Resolve variables across the entire request. URL resolution
+                    // uses EscapeMode::Url (currently a passthrough — the planned
+                    // percent-encoding was deliberately removed; backlog line 96).
+                    // The HTTP layer handles query-param encoding on the wire.
+                    // headers/query_params keep raw substitution.
                     let resolved_url = resolver.resolve_url_deep(
                         &request.url,
                         &scope,


### PR DESCRIPTION
## What

W4 #223: HAR replay must strip cache-validation request headers (\If-None-Match\/\If-Modified-Since\) so a replayed request isn't answered 304 by an upstream cache, silently producing a body-less success.

## Task
W4 #223.

## Risk
HAR import behaviour change — replayed requests no longer send stale conditional headers.