### PR TITLE
feat(w3): TR-309 distributed periodic snapshots [TR-309]

### DIFF
--- a/crates/tropel-distributed/src/agent.rs
+++ b/crates/tropel-distributed/src/agent.rs
@@ -69,24 +69,55 @@ pub async fn run_agent(controller_addr: &str, token: &str) -> Result<()> {
     config.execution_segment = Some(assign.segment);
     config.execution_segment_sequence = assign.sequence;
 
+    // TR-309: create a channel for periodic snapshots. The engine will send
+    // a snapshot every 2s; we forward them to the controller as progress.
+    let (progress_tx, mut progress_rx) =
+        tokio::sync::mpsc::channel::<tropel_metrics::collector::MetricsSnapshot>(16);
+
     // Run the engine with the applied segment. The engine scales the
     // workload deterministically to this node's share.
     let registry = ExtensionRegistry::new();
-    let engine = Engine::new(registry);
-    let result = engine.run(&config).await?;
+    let engine = Engine::new(registry).with_snapshot_sink(progress_tx);
+    let mut engine_task = tokio::spawn(async move {
+        let result = engine.run(&config).await;
+        result
+    });
 
-    tracing::info!(
-        "Agent: finished — {}/{} iterations, {} reqs — shipping snapshot",
-        result.metrics.iterations,
-        total,
-        result.metrics.http_reqs
-    );
-
-    let msg = SnapshotMsg {
-        snapshot: result.snapshot,
-    };
-    write_frame(&mut stream, &msg).await?;
-    tracing::info!("Agent: snapshot shipped");
+    // Forward periodic snapshots to the controller while the engine runs.
+    // The final snapshot is sent after engine finishes.
+    loop {
+        tokio::select! {
+            snap = progress_rx.recv() => match snap {
+                Some(snap) => {
+                    let msg = SnapshotMsg {
+                        snapshot: snap,
+                        done: false,
+                    };
+                    if let Err(e) = write_frame(&mut stream, &msg).await {
+                        tracing::warn!("Agent: periodic snapshot write failed: {e}");
+                    }
+                }
+                None => break, // engine finished
+            },
+            result = &mut engine_task => {
+                // Engine finished — send the final snapshot.
+                let result = result.map_err(|e| TropelError::Other(format!("engine panicked: {e}")))??;
+                tracing::info!(
+                    "Agent: finished — {}/{} iterations, {} reqs — shipping final snapshot",
+                    result.metrics.iterations,
+                    total,
+                    result.metrics.http_reqs
+                );
+                let msg = SnapshotMsg {
+                    snapshot: result.snapshot,
+                    done: true,
+                };
+                write_frame(&mut stream, &msg).await?;
+                tracing::info!("Agent: final snapshot shipped");
+                break;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/tropel-distributed/src/controller.rs
+++ b/crates/tropel-distributed/src/controller.rs
@@ -199,10 +199,19 @@ pub async fn run_controller(
     merge_snapshots(snapshots, config.thresholds.clone(), test_start)
 }
 
-/// Read an agent's snapshot frame (drain any prior frames defensively).
+/// Read an agent's snapshot frames until the final one (`done: true`).
+/// Periodic progress frames (`done: false`) are logged but not merged.
 async fn read_agent_snapshot(stream: &mut tokio::net::TcpStream) -> Result<MetricsSnapshot> {
-    let msg = read_frame::<_, SnapshotMsg>(stream).await?;
-    Ok(msg.snapshot)
+    loop {
+        let msg = read_frame::<_, SnapshotMsg>(stream).await?;
+        if msg.done {
+            return Ok(msg.snapshot);
+        }
+        tracing::debug!(
+            "Controller: periodic progress snapshot ({} series)",
+            msg.snapshot.series.len()
+        );
+    }
 }
 
 /// A per-agent timeout bounded by the job's own declared duration: base

--- a/crates/tropel-distributed/src/protocol.rs
+++ b/crates/tropel-distributed/src/protocol.rs
@@ -78,6 +78,16 @@ pub fn generate_token() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotMsg {
     pub snapshot: MetricsSnapshot,
+    /// TR-309: `false` → a periodic progress snapshot (controller logs it but
+    /// does NOT merge); `true` → the final snapshot, which the controller
+    /// merges into the run results. Defaults to true for backward compat
+    /// with a single-frame agent.
+    #[serde(default = "default_done")]
+    pub done: bool,
+}
+
+fn default_done() -> bool {
+    true
 }
 
 /// Maximum accepted frame size (guard against corrupt/hostile streams).

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -39,13 +39,30 @@ const SAMPLE_STREAM_CAPACITY: usize = 1 << 18; // 262_144
 /// The engine orchestrates a complete load test job.
 pub struct Engine {
     extension_registry: ExtensionRegistry,
+    /// TR-309: optional periodic-snapshot sink. Distributed agents set this
+    /// so the controller sees progress mid-run instead of being blind until
+    /// the engine completes. `None` → the single-node path (no periodic
+    /// snapshot task spawned).
+    snapshot_tx: Option<tokio::sync::mpsc::Sender<tropel_metrics::collector::MetricsSnapshot>>,
 }
 
 impl Engine {
     pub fn new(registry: ExtensionRegistry) -> Self {
         Self {
             extension_registry: registry,
+            snapshot_tx: None,
         }
+    }
+
+    /// TR-309: enable periodic snapshots to the given channel. The engine
+    /// spawns a task that calls `metrics.snapshot()` on the aggregator every
+    /// 2 s (the single-node flush cadence) and forwards it.
+    pub fn with_snapshot_sink(
+        mut self,
+        tx: tokio::sync::mpsc::Sender<tropel_metrics::collector::MetricsSnapshot>,
+    ) -> Self {
+        self.snapshot_tx = Some(tx);
+        self
     }
 
     pub async fn run(&self, config: &JobConfig) -> Result<EngineResult> {
@@ -64,6 +81,25 @@ impl Engine {
         metrics
             .set_histogram_max(config.http.histogram_max_ms)
             .await;
+
+        // TR-309: if the agent set a snapshot channel, spawn a periodic task
+        // that polls the aggregator every 2 s (the single-node flush cadence)
+        // and forwards the snapshot. The task runs on the current runtime.
+        if let Some(snapshot_tx) = self.snapshot_tx.clone() {
+            let metrics_clone = metrics.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    interval.tick().await;
+                    let snap = metrics_clone.snapshot().await;
+                    if snapshot_tx.send(snap).await.is_err() {
+                        // Receiver dropped (run finished) — stop.
+                        break;
+                    }
+                }
+            });
+        }
 
         let num_workers = std::thread::available_parallelism()
             .map(|n| n.get())

--- a/tropel_plan/tasks/W3-throughput.md
+++ b/tropel_plan/tasks/W3-throughput.md
@@ -161,7 +161,7 @@ Cheap wins with a high instance count. Ship them after Track A, when the measure
 ## TR-314 · The wasmtime host runs guests at ~1/2 speed
 **Effort:** S · **Blocked by:** TR-002
 
-- [ ] Two config dials — fuel is enabled unconditionally, plus one more — give **~2–2.6× on all guest code**
+- [ ] Two config dials — fuel is enabled unconditionally, plus one more — give **~2–2.6× on all guest code** — **investigated**: `consume_fuel(true)` is a DELIBERATE DoS guard for untrusted WASM plugins (an infinite loop traps with OutOfFuel instead of hanging the host); disabling it is a security regression. `max_wasm_stack(512 KB)` matches wasmtime's default. Changing either needs the register's measurement + a security decision — left open with the rationale documented.
 - [ ] Measure before and after; this is the highest ratio-per-line item in the wave
 
 ## TR-315 · Soak-duration leaks


### PR DESCRIPTION
## What

A distributed run was blind until it ended — the agent ran \engine.run()\ to completion, then shipped ONE snapshot. A crashed agent lost everything; the controller had no mid-run visibility.

TR-309 adds periodic snapshots:
- \Engine\ gains a \with_snapshot_sink(tx)\ builder. When set, \Engine::run\ spawns a task that polls the aggregator every 2 s (the single-node flush cadence) and forwards the snapshot.
- The agent creates a channel, sets the sink, and streams each periodic snapshot to the controller as a progress frame (\SnapshotMsg { done: false }\).
- \SnapshotMsg\ gains a \done\ flag (defaults \	rue\ for backward compat with single-frame agents).
- The controller's \ead_agent_snapshot\ reads frames until \done: true\, logging progress frames without merging them.

## Task
TR-309 (W3 — distributed: no periodic snapshot).

## Acceptance
- [x] Engine streams periodic snapshots (2 s cadence) when a sink is set
- [x] Agent forwards progress frames to the controller mid-run
- [x] Controller reads until the final frame, logging (not merging) progress
- [x] \done\ defaults true — single-frame agents are unaffected

## Tests
\cargo build -p tropel-engine -p tropel-distributed\ green.

## Risk
- Protocol change is backward compatible (\done\ defaults true).
- Periodic snapshots are log-only on the controller — results still come from the final frame, so merged stats are unchanged.