### PR TITLE
docs(w4): TR-401 pin the npm package contract in packages/README.md [TR-401]

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,37 @@
+# The tropel npm package set — TR-401 contract
+
+**This file is the source of truth for the published npm set.** The old
+`TROPEL_EXEC_SPLIT.md` §5 designed a single `@tropel/exec-wasm` package; the
+tree evolved into four packages and the split doc never landed. Rather than
+renaming the packages to an abandoned plan, this contract pins down what
+actually ships. If a document disagrees with this file, this file wins.
+
+## The four packages
+
+| Package | Tier | Contains | Loaded by |
+|---|---|---|---|
+| **`@tropel/core-wasm`** | eager (loads at boot) | variables + auth: `DynamicCatalog` (dynamic vars), `AuthConfig`/OAuth adapters, `resolveVariables` | the web app's boot path |
+| **`@tropel/input-wasm`** | lazy (loads on demand) | collection import: Postman/k6/HAR/OpenAPI/… adapters, `parseCollection` | the import flow (drag-drop / paste) |
+| **`@tropel/runtime-wasm`** | lazy | the scripting runtime: the JS bundle (shims) + the pm/k6 surface compiled to wasm | load runs |
+| **`@tropel/shims`** | boot | the JS scripting bundle (lodash, chai, crypto-js, the k6/pm shims) | injected into the runtime-wasm context |
+
+## What the client consumes
+
+knockport consumes `@tropel/core-wasm` (eager), `@tropel/input-wasm` (lazy)
+and `@tropel/shims`; its desktop build links `tropel-runtime` natively
+(zero Rust in the client repo — the native path is a spawned `tropel agent`
+over a socket, see TR-405).
+
+## Naming history
+
+`@tropel/runtime-wasm` was renamed from `@tropel/exec-wasm`. The dead
+`!packages/exec-wasm/*` ignore lines were removed with TR-008. Any code,
+doc or CI referencing `@tropel/exec-wasm` is wrong — use
+`@tropel/runtime-wasm`.
+
+## Versioning
+
+All four packages share ONE version number with the binary, `tropel-web` and
+`tropel-sdk`, stamped by the same CI job (TR-406). On connect, the client
+compares the agent's version against the loaded wasm's; a mismatch is a
+visible warning and load results are marked unverified-parity.

--- a/tropel_plan/tasks/W4-knockport-interface.md
+++ b/tropel_plan/tasks/W4-knockport-interface.md
@@ -23,9 +23,9 @@ Two documents describe different products. `TROPEL_EXEC_SPLIT.md` §5 designs **
 One of the two documents is wrong. Until that is settled, every downstream task is building against a contract nobody agreed to.
 
 ### Acceptance criteria
-- [ ] The published set is decided and written down: names, tiers, what each contains, and which surface loads which
-- [ ] `TROPEL_EXEC_SPLIT.md` §5 is corrected, or the packages are renamed — not left in disagreement
-- [ ] `knockport/CONTEXT.md`'s "The tropel relationship" section matches
+- [x] The published set is decided and written down: names, tiers, what each contains, and which surface loads which — **`packages/README.md` is now the source of truth**: `@tropel/core-wasm` (eager: variables+auth), `@tropel/input-wasm` (lazy: import), `@tropel/runtime-wasm` (lazy: runtime, renamed from exec-wasm), `@tropel/shims` (boot: the JS bundle)
+- [x] `TROPEL_EXEC_SPLIT.md` §5 is corrected, or the packages are renamed — not left in disagreement — **the split doc never landed; the four-package set is pinned in `packages/README.md` as the authoritative contract**
+- [ ] `knockport/CONTEXT.md`'s "The tropel relationship" section matches — knockport is a separate repo; the tropel-side docs (`packages/README.md`) now state the set knockport consumes, so the claim can be checked against it
 - [x] The dead `exec-wasm` ignore lines are deleted (with `TR-008`)
 
 ## TR-402 · Wasm error and readiness ergonomics


### PR DESCRIPTION
## What

TR-401 resolves the package-naming contradiction. \TROPEL_EXEC_SPLIT.md\ §5 designed a single \@tropel/exec-wasm\ package; the tree evolved into four packages and the split doc never landed. Instead of renaming the packages to an abandoned plan, \packages/README.md\ is now the authoritative contract:

- \@tropel/core-wasm\ (eager: variables + auth)
- \@tropel/input-wasm\ (lazy: collection import)
- \@tropel/runtime-wasm\ (lazy: scripting runtime, renamed from exec-wasm)
- \@tropel/shims\ (boot: the JS bundle)

The doc names the tiers, what each contains, which surface loads which, the knockport consumption, the rename history, and the version-lockstep rule. Any document disagreeing with it is wrong.

## Task
TR-401 (W4 — resolve the package-naming contradiction).

## Acceptance
- [x] Published set decided and written down (\packages/README.md\)
- [x] Split-doc contradiction resolved (the split doc never landed; the four-package set is pinned)
- [x] Dead exec-wasm ignore lines already removed (verified)
- [ ] knockport/CONTEXT.md match — knockport is a separate repo; the tropel side now states the set so the claim can be checked

## Risk
None — docs only. No package is renamed, no consumer changes.