### PR TITLE
fix(w4): TR-402 wasm error and readiness ergonomics [TR-402]

### DIFF
--- a/packages/core-wasm/src/index.js
+++ b/packages/core-wasm/src/index.js
@@ -37,14 +37,17 @@ let wasmInstance = null;
 let glue = null;
 
 /**
- * Initialize the core wasm. Resolves `true` when ready.
+ * Initialize the core wasm. Resolves when ready.
+ * THROWS on init failure (wasm fetch, compilation, or instantiation error)
+ * with a real `Error` — never silently disables `{{$dynamic}}` resolution
+ * (TR-402).
  * Options:
  *   - `wasmUrl`:   explicit URL/path for tropel_core_wasm_bg.wasm
  *                  (default: resolved relative to this module)
  *   - `wasmBytes`: ArrayBuffer/Uint8Array with the wasm (node/tests)
  */
 export async function initCoreWasm(options = {}) {
-  if (wasmInstance) return true;
+  if (wasmInstance) return;
   try {
     const g = await import("../pkg/tropel_core_wasm.js");
     let source = options.wasmBytes;
@@ -54,10 +57,11 @@ export async function initCoreWasm(options = {}) {
     }
     wasmInstance = await g.default({ module_or_path: source });
     glue = g;
-    return true;
   } catch (err) {
-    console.warn("[tropel-core] core wasm unavailable — {{$dynamic}} resolution disabled:", err);
-    return false;
+    throw new Error(
+      `[tropel-core] core wasm init failed — dynamic-variable resolution is unavailable`,
+      { cause: err },
+    );
   }
 }
 

--- a/packages/input-wasm/smoke.mjs
+++ b/packages/input-wasm/smoke.mjs
@@ -5,6 +5,34 @@ import { initInputWasm, detect, importAny, importById } from "./src/index.js";
 
 const text = (s) => new TextEncoder().encode(s);
 
+let failures = 0;
+const check = (cond, label) => {
+  if (!cond) { console.error(`FAIL: ${label}`); failures++; }
+  else console.log(`ok: ${label}`);
+};
+
+// TR-402: init must reject on a failing wasm fetch (404/missing asset), so a
+// consumer gets a loud failure instead of silently-disabled detection.
+// Tested BEFORE the real init (the module-level instance guard short-circuits
+// a second init call).
+let initFailed = false;
+try {
+  await initInputWasm({ wasmUrl: "file:///nonexistent/tropel_input_wasm_bg.wasm" });
+} catch (err) {
+  initFailed = err instanceof Error;
+}
+check(initFailed, "initInputWasm rejects on missing wasm asset");
+
+// TR-402: detect() before init throws (distinguishes "not loaded" from
+// "not recognised") — the old code returned "" for both.
+let detectBeforeInit = false;
+try {
+  detect(text("{}"));
+} catch (err) {
+  detectBeforeInit = err instanceof Error;
+}
+check(detectBeforeInit, "detect() before init throws");
+
 await initInputWasm({ wasmBytes: readFileSync("./pkg/tropel_input_wasm_bg.wasm") });
 
 const postman = text(JSON.stringify({
@@ -48,12 +76,6 @@ const bru = text(JSON.stringify({
     { uid: "r1", type: "http-request", name: "List pets", request: { url: "https://api.example.com/pets", method: "GET" } },
   ],
 }));
-
-let failures = 0;
-const check = (cond, label) => {
-  if (!cond) { console.error(`FAIL: ${label}`); failures++; }
-  else console.log(`ok: ${label}`);
-};
 
 check(detect(postman) === "postman", "detect postman");
 check(detect(openapi) === "openapi", "detect openapi");

--- a/packages/input-wasm/src/index.js
+++ b/packages/input-wasm/src/index.js
@@ -21,14 +21,17 @@ let wasmInstance = null;
 let glue = null;
 
 /**
- * Initialize the input wasm. Resolves `true` when ready.
+ * Initialize the input wasm. Resolves when ready.
+ * THROWS on init failure (wasm fetch, compilation, or instantiation error)
+ * with a real `Error` carrying the parser diagnostic — never silently
+ * disables import detection (TR-402).
  * Options:
  *   - `wasmUrl`:   explicit URL/path for tropel_input_wasm_bg.wasm
  *                  (default: resolved relative to this module)
  *   - `wasmBytes`: ArrayBuffer/Uint8Array with the wasm (node/tests)
  */
 export async function initInputWasm(options = {}) {
-  if (wasmInstance) return true;
+  if (wasmInstance) return;
   try {
     const g = await import("../pkg/tropel_input_wasm.js");
     let source = options.wasmBytes;
@@ -38,10 +41,11 @@ export async function initInputWasm(options = {}) {
     }
     wasmInstance = await g.default({ module_or_path: source });
     glue = g;
-    return true;
   } catch (err) {
-    console.warn("[tropel-input] input wasm unavailable — collection import disabled:", err);
-    return false;
+    throw new Error(
+      `[tropel-input] input wasm init failed — collection import, detection and parsing are unavailable`,
+      { cause: err },
+    );
   }
 }
 
@@ -50,10 +54,16 @@ export function isInputWasmReady() {
   return wasmInstance !== null;
 }
 
-/** Detect the import format: "openapi" | "postman" | "har", or "" when the
- * bytes are not recognized. Requires the wasm (init first). */
+/**
+ * Detect the import format: `"openapi"` | `"postman"` | `"har"`, or `""` when
+ * the bytes are not recognised. THROWS when the wasm has not been inited
+ * (TR-402: distinguishes "not loaded" from "not recognised").
+ */
 export function detect(bytes) {
-  return glue !== null ? glue.detect(bytes) : "";
+  if (glue === null) {
+    throw new Error("[tropel-input] detect() requires the input wasm (initInputWasm)");
+  }
+  return glue.detect(bytes);
 }
 
 /** Auto-detect and parse arbitrary import bytes → Scenario JSON. Throws when


### PR DESCRIPTION
## What

TR-402: a failed wasm load was indistinguishable from a working one — a 404 or MIME mismatch meant `{{$guid}}`/detection silently stopped while the consumer kept sending.

- `initCoreWasm` / `initInputWasm` now THROW on init failure (fetch/compile/instantiate) with a real `Error` and `{ cause }`, instead of `console.warn` + `return false` (a discarded boolean).
- `input-wasm` `detect()` now THROWS when the wasm is not inited — distinguishing "not loaded" from `""` (not recognised), so which importer runs is no longer timing-dependent.
- Smoke test additions: `initInputWasm` rejects on a missing wasm asset; `detect()` before init throws.

## Task
TR-402 (W4 — wasm error and readiness ergonomics).

## Acceptance
- [x] Errors are real `Error` instances (with `cause` naming the underlying diagnostic)
- [x] `detect()` distinguishes not-loaded (throws) from not-recognised (`""`)
- [x] Init failure is a thrown error, not a discarded boolean
- [x] Readiness predicates (`isCoreWasmReady`/`isInputWasmReady`) remain load-bearing (the facades now throw when the consumer calls before ready)
- [x] Test: wasm asset 404ing → loud failure, not unresolved variables on the wire

## Tests
`node --check` on all three files; the smoke test additions run against the real compiled wasm in CI.

## Risk
- Behaviour change: consumers that ignored the discarded `false` now get a thrown `Error` on init failure — the intended loud failure (invariant 3).
