### PR TITLE
fix(w4): TR-404 eager-tier deps + dispatch docstring [TR-404]

### DIFF
--- a/crates/tropel-auth/Cargo.toml
+++ b/crates/tropel-auth/Cargo.toml
@@ -13,10 +13,14 @@ default = ["reqwest"]
 # The reqwest-coupled signers (signers.rs). Off for the browser core tier,
 # where reqwest cannot compile; `tropel-core-wasm` consumes the always-on
 # `oauth` module with `default-features = false`.
-reqwest = ["dep:reqwest", "dep:chrono"]
+reqwest = ["dep:reqwest", "dep:chrono", "dep:tropel-sdk"]
 
 [dependencies]
-tropel-sdk.workspace = true
+# TR-404: tropel-sdk is used ONLY by the reqwest-gated signers module (it
+# holds AuthConfig/Result); the always-on `oauth` module has ZERO tropel-sdk
+# references. Making it optional under `reqwest` drops simd-json + inventory
+# + rustc-hash out of the browser core tier at zero behavioural cost.
+tropel-sdk = { workspace = true, optional = true }
 # oauth module + signers module (pure hashing/encoding). sha1 is used by the
 # pure WSSE UsernameToken digest too, so it is NOT part of the reqwest feature.
 serde.workspace = true

--- a/crates/tropel-core-wasm/Cargo.toml
+++ b/crates/tropel-core-wasm/Cargo.toml
@@ -22,7 +22,10 @@ wasm-opt = false
 
 [dependencies]
 tropel-variables.workspace = true
-tropel-auth.workspace = true
+# TR-404: the browser oauth module needs ZERO tropel-sdk deps; disable
+# tropel-auth's default reqwest feature (signers + tropel-sdk) so simd-json,
+# inventory and rustc-hash drop out of the gated tier.
+tropel-auth = { workspace = true, default-features = false }
 wasm-bindgen = "0.2"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tropel-input-wasm/src/lib.rs
+++ b/crates/tropel-input-wasm/src/lib.rs
@@ -4,12 +4,21 @@
 //! gate), while the bulky collection parsers live HERE, loaded only when the
 //! import UI opens.
 //!
-//! Exports mirror the engine's `ExtensionRegistry::resolve_input` dispatch:
-//! iterate the registered input adapters in priority order and pick the
-//! HIGHEST-priority one whose `detect()` claims the bytes (ties → listed
-//! order). The adapter set is enumerated explicitly (not via `inventory`)
-//! so the dispatch is deterministic and independent of link order — same
-//! guarantee the engine's explicit-priority design provides natively.
+//! Exports use the same explicit-priority dispatch as the engine's
+//! `ExtensionRegistry::resolve_input`: iterate the input adapters in
+//! priority order and pick the HIGHEST-priority one whose `detect()` claims
+//! the bytes (ties → listed order). The adapter set is enumerated
+//! explicitly (not via `inventory`) so the dispatch is deterministic and
+//! independent of link order — same guarantee the engine's explicit-priority
+//! design provides natively.
+//!
+//! NOTE (TR-404): this is NOT a full mirror of the resolver. `k6`, `http`
+//! and `subprocess` are deliberately omitted — `k6` needs the QuickJS
+//! scripting runtime (a separate, heavy tier), `http` is a plain file
+//! adapter that only makes sense for local files (the browser talks HTTP
+//! through a relay), and `subprocess` shells out to a binary (impossible in
+//! the browser). The collection-import adapters (postman/insomnia/har/bru/
+//! openapi) are what a browser embedder can meaningfully import.
 //!
 //! The output is a protocol-agnostic `Scenario` JSON (the `tropel-sdk`
 //! shape: `info` / `items` / `variables` / `auth`); the embedder maps it to


### PR DESCRIPTION
## What

TR-404 (get the eager tier back under its gate):

1. **oauth optional dep** — `tropel-auth`'s `oauth` module has ZERO `tropel_sdk` references (verified: only the reqwest-gated `signers` module uses it). `tropel-sdk` is now `optional = true` behind the `reqwest` feature, and `tropel-core-wasm` depends on `tropel-auth` with `default-features = false` — dropping simd-json, inventory and rustc-hash from the browser tier at zero behavioural cost.
2. **Dispatch docstring** — the input-wasm dispatch table omits `k6`/`http`/`subprocess` (deliberately: QuickJS runtime, relay-only HTTP, no subprocess in the browser), but its docstring claimed to "mirror the resolver". The docstring now explains WHY the three are omitted — the table is a correct browser-safe subset, not a broken mirror.

## Task
TR-404 (W4 — get the eager tier back under its gate).

## Acceptance
- [x] `tropel-auth`'s oauth module is transport-free; tropel-sdk gated behind reqwest
- [x] `tropel-core-wasm` no-default-features (browser tier drops the sdk transitive deps)
- [x] Dispatch table docstring corrected (k6/http/subprocess omissions documented)
- [ ] Real post-wasm-opt size measurement + CI gate — needs the wasm build in CI (TR-002)
- [ ] README size number generated, not typed — needs the CI measurement

## Tests
`cargo build --workspace` green; `cargo build -p tropel-auth --no-default-features` green (oauth module compiles without tropel-sdk); `cargo build -p tropel-core-wasm` green.

## Risk
- `tropel-core-wasm` no longer gets tropel-auth's signers (they need reqwest). The browser core tier only uses the oauth module — the signers are native/desktop-only. If a future browser feature needs signers, re-enable the feature explicitly.
