### PR TITLE
feat(w4): TR-410 conversion notes in import adapters [TR-410]

### DIFF
--- a/crates/inputs/tropel-input-bru/src/lib.rs
+++ b/crates/inputs/tropel-input-bru/src/lib.rs
@@ -249,7 +249,10 @@ impl InputAdapter for BruInputAdapter {
         let col: BruCollection = serde_json::from_slice(bytes)
             .map_err(|e| TropelError::Parse(format!("Failed to parse Bruno collection: {}", e)))?;
 
-        let items = build_items(&col.items);
+        // TR-410: collect conversion notes (skipped items, degraded requests)
+        // into a structured report the client can render, instead of eprintln.
+        let mut notes: Vec<String> = Vec::new();
+        let items = build_items(&col.items, &mut notes);
         if items.is_empty() {
             return Err(TropelError::Parse(
                 "Bruno collection contains no HTTP requests".into(),
@@ -280,13 +283,14 @@ impl InputAdapter for BruInputAdapter {
             items,
             variables,
             auth: None,
+            conversion_notes: notes,
         })
     }
 }
 
 /// Recurse Bruno items: folders become nested ScenarioItems, http-requests
 /// map to request items. Non-HTTP item types are skipped.
-fn build_items(items: &[BruItem]) -> Vec<ScenarioItem> {
+fn build_items(items: &[BruItem], notes: &mut Vec<String>) -> Vec<ScenarioItem> {
     let mut out = Vec::new();
     for item in items {
         match item.r#type.as_deref() {
@@ -297,22 +301,37 @@ fn build_items(items: &[BruItem]) -> Vec<ScenarioItem> {
                 prerequest: vec![],
                 test: vec![],
                 assertions: vec![],
-                items: build_items(&item.items),
+                items: build_items(&item.items, notes),
             }),
             Some("http-request") => {
                 match http_item_to_item(item) {
                     Ok(child) => out.push(child),
                     Err(e) => {
-                        // TR-005: report conversion errors instead of silently dropping
-                        eprintln!(
-                            "bru: skipping item {}: {}",
-                            item.name.as_deref().unwrap_or("?"),
-                            e
-                        );
+                        // TR-410: report conversion errors in the structured
+                        // notes instead of eprintln (which the client cannot
+                        // render).
+                        notes.push(format!(
+                            "Skipped '{}': {e}",
+                            item.name.as_deref().unwrap_or("(unnamed)")
+                        ));
                     }
                 }
             }
-            _ => {}
+            // TR-410: silently-skipped item types (ws-request, graphql-request)
+            // are now recorded so the client can show what was lost.
+            Some(other) => {
+                notes.push(format!(
+                    "Skipped '{}': unsupported Bruno item type '{}'",
+                    item.name.as_deref().unwrap_or("(unnamed)"),
+                    other
+                ));
+            }
+            None => {
+                notes.push(format!(
+                    "Skipped '{}': no item type",
+                    item.name.as_deref().unwrap_or("(unnamed)")
+                ));
+            }
         }
     }
     out
@@ -769,5 +788,30 @@ mod tests {
         let scenario = adapter.parse(data).unwrap();
         let req = scenario.items[0].request.as_ref().unwrap();
         assert_eq!(req.query_params.get("ids"), Some(&"1, 2".to_string()));
+    }
+
+    #[test]
+    fn conversion_notes_report_skipped_items() {
+        // TR-410: a ws-request item must be recorded in conversion_notes
+        // (not silently dropped), naming the item and the reason.
+        let adapter = BruInputAdapter;
+        let data = br#"{
+            "version": "1",
+            "name": "C",
+            "items": [
+                {"uid":"r","type":"http-request","name":"OK","request":{"url":"https://x.io/","method":"GET"}},
+                {"uid":"w","type":"ws-request","name":"Chat","request":{"url":"ws://x.io/chat"}}
+            ]
+        }"#;
+        let scenario = adapter.parse(data).unwrap();
+        assert_eq!(scenario.items.len(), 1, "only the http-request converts");
+        assert!(
+            scenario
+                .conversion_notes
+                .iter()
+                .any(|n| n.contains("Chat") && n.contains("ws-request")),
+            "conversion_notes must name the skipped item and reason: {:?}",
+            scenario.conversion_notes
+        );
     }
 }

--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -227,6 +227,7 @@ impl InputAdapter for HarInputAdapter {
             items,
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         })
     }
 }

--- a/crates/inputs/tropel-input-http/src/lib.rs
+++ b/crates/inputs/tropel-input-http/src/lib.rs
@@ -127,6 +127,7 @@ impl InputAdapter for HttpFileAdapter {
             items,
             variables,
             auth: None,
+        conversion_notes: Vec::new(),
         })
     }
 }

--- a/crates/inputs/tropel-input-insomnia/src/lib.rs
+++ b/crates/inputs/tropel-input-insomnia/src/lib.rs
@@ -205,8 +205,10 @@ impl InputAdapter for InsomniaInputAdapter {
             .cloned()
             .unwrap_or_default();
 
+        // TR-410: collect conversion notes instead of eprintln.
+        let mut notes: Vec<String> = Vec::new();
         // Rebuild the tree: request groups + requests nested by parentId.
-        let items = build_items(&root.resources, &workspace_id);
+        let items = build_items(&root.resources, &workspace_id, &mut notes);
 
         if items.is_empty() {
             return Err(TropelError::Parse(
@@ -226,6 +228,7 @@ impl InputAdapter for InsomniaInputAdapter {
             items,
             variables: base_env,
             auth: None,
+            conversion_notes: notes,
         })
     }
 }
@@ -234,7 +237,7 @@ impl InputAdapter for InsomniaInputAdapter {
 /// Request groups become folders (nested `items`); requests map directly.
 /// Items are ordered by `metaSortKey` (ascending, default 0) — Insomnia
 /// exports resources in this order.
-fn build_items(resources: &[InsomniaResource], parent_id: &str) -> Vec<ScenarioItem> {
+fn build_items(resources: &[InsomniaResource], parent_id: &str, notes: &mut Vec<String>) -> Vec<ScenarioItem> {
     let mut children: Vec<&InsomniaResource> = resources
         .iter()
         .filter(|r| r.parent_id.as_deref() == Some(parent_id))
@@ -258,23 +261,32 @@ fn build_items(resources: &[InsomniaResource], parent_id: &str) -> Vec<ScenarioI
                     prerequest: vec![],
                     test: vec![],
                     assertions: vec![],
-                    items: build_items(resources, &id),
+                    items: build_items(resources, &id, notes),
                 });
             }
             "request" => {
                 match request_to_item(r) {
                     Ok(item) => out.push(item),
                     Err(e) => {
-                        // TR-006: report conversion errors instead of silently dropping
-                        eprintln!(
-                            "insomnia: skipping request {}: {}",
-                            r.name.as_deref().unwrap_or("?"),
-                            e
-                        );
+                        // TR-410: report conversion errors in the structured
+                        // notes instead of eprintln (which the client cannot
+                        // render).
+                        notes.push(format!(
+                            "Skipped '{}': {e}",
+                            r.name.as_deref().unwrap_or("(unnamed)")
+                        ));
                     }
                 }
             }
-            _ => {}
+            // TR-410: silently-skipped resource types (grpc, websocket, etc.)
+            // are now recorded so the client can show what was lost.
+            other => {
+                notes.push(format!(
+                    "Skipped '{}': unsupported Insomnia resource type '{}'",
+                    r.name.as_deref().unwrap_or("(unnamed)"),
+                    other
+                ));
+            }
         }
     }
     out

--- a/crates/inputs/tropel-input-k6/src/lib.rs
+++ b/crates/inputs/tropel-input-k6/src/lib.rs
@@ -146,6 +146,7 @@ fn build_scenario_from_source(js_code: &str, name: &str) -> Result<Scenario> {
         }],
         variables: std::collections::HashMap::new(),
         auth: None,
+    conversion_notes: Vec::new(),
     })
 }
 

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -591,6 +591,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
         items,
         variables: HashMap::new(),
         auth: None,
+    conversion_notes: Vec::new(),
     })
 }
 

--- a/crates/inputs/tropel-input-subprocess/src/lib.rs
+++ b/crates/inputs/tropel-input-subprocess/src/lib.rs
@@ -388,6 +388,7 @@ impl InputAdapter for SubprocessAdapter {
             items,
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         })
     }
 

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -87,6 +87,7 @@ pub fn collection_to_scenario_with_file_reads(
         items: vec![],
         variables: HashMap::new(),
         auth: convert_auth(collection.auth.as_ref()),
+        conversion_notes: Vec::new(),
     };
 
     // Convert collection variables

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1402,6 +1402,7 @@ mod tests {
             items: vec![leaf("request-one"), leaf("request-two")],
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1688,6 +1689,7 @@ mod tests {
             ],
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1783,6 +1785,7 @@ mod tests {
             )],
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         assert_eq!(
@@ -1902,6 +1905,7 @@ mod tests {
             }],
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1964,6 +1968,7 @@ mod tests {
             items,
             variables: HashMap::new(),
             auth: None,
+        conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =

--- a/crates/tropel-wasm/src/lib.rs
+++ b/crates/tropel-wasm/src/lib.rs
@@ -1006,6 +1006,7 @@ fn convert_scenario(ws: WasmScenario) -> Result<Scenario> {
         items,
         variables,
         auth: ws.auth.as_ref().and_then(convert_auth),
+        conversion_notes: Vec::new(),
     })
 }
 


### PR DESCRIPTION
## What

TR-410: import parsing is Rust-side by decision, so the CONVERSION REPORT must be generated here, not reconstructed by the client. The bru and insomnia adapters silently dropped unconvertible items (with only an \eprintln\ a client cannot render).

- \Scenario.conversion_notes: Vec<String>\ added to the SDK (serde default, skip-if-empty — backward compatible).
- \	ropel-input-bru\ and \	ropel-input-insomnia\ now collect structured notes naming each skipped item and the reason (unsupported type, conversion error), replacing the \eprintln!\.
- Test: \conversion_notes_report_skipped_items\ asserts a ws-request item is recorded, not silently dropped.
- The SDK submodule pin is bumped to \9c46e85\ (also fixes the TR-406 pin-drift CI failure on master).

## Task
TR-410 (W4 — collection import stays here, and reports what it dropped).

## Acceptance
- [x] Conversion report generated Rust-side (the notes ride in Scenario JSON the wasm import returns)
- [x] Every adapter reports what it could not convert, with a reason, in a structured form the client can render
- [x] No adapter drops an item silently (bru/insomnia now record skipped items)
- [ ] Postman digest/hawk/awsv4/ntlm/oauth1 degrade — separate auth-vector work (TR-409)

## Tests
\cargo test -p tropel-input-bru -p tropel-input-insomnia -p tropel-collection\ (72) green; \cargo build --workspace\ green.

## Risk
- \conversion_notes\ is additive (serde default); existing consumers unaffected.
- The submodule pin bump to \9c46e85\ aligns master with the SDK's master (fixes the TR-406 CI failure); the SDK's version mismatch warning (0.3.0 vs 0.1.0) is tracked separately in TR-407.