### PR TITLE
fix(ci): rustfmt + conversion_notes test + SDK pin 5b9f810 [TR-410]

### DIFF
--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -227,7 +227,7 @@ impl InputAdapter for HarInputAdapter {
             items,
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         })
     }
 }

--- a/crates/inputs/tropel-input-http/src/lib.rs
+++ b/crates/inputs/tropel-input-http/src/lib.rs
@@ -127,7 +127,7 @@ impl InputAdapter for HttpFileAdapter {
             items,
             variables,
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         })
     }
 }

--- a/crates/inputs/tropel-input-insomnia/src/lib.rs
+++ b/crates/inputs/tropel-input-insomnia/src/lib.rs
@@ -237,7 +237,11 @@ impl InputAdapter for InsomniaInputAdapter {
 /// Request groups become folders (nested `items`); requests map directly.
 /// Items are ordered by `metaSortKey` (ascending, default 0) — Insomnia
 /// exports resources in this order.
-fn build_items(resources: &[InsomniaResource], parent_id: &str, notes: &mut Vec<String>) -> Vec<ScenarioItem> {
+fn build_items(
+    resources: &[InsomniaResource],
+    parent_id: &str,
+    notes: &mut Vec<String>,
+) -> Vec<ScenarioItem> {
     let mut children: Vec<&InsomniaResource> = resources
         .iter()
         .filter(|r| r.parent_id.as_deref() == Some(parent_id))

--- a/crates/inputs/tropel-input-k6/src/lib.rs
+++ b/crates/inputs/tropel-input-k6/src/lib.rs
@@ -146,7 +146,7 @@ fn build_scenario_from_source(js_code: &str, name: &str) -> Result<Scenario> {
         }],
         variables: std::collections::HashMap::new(),
         auth: None,
-    conversion_notes: Vec::new(),
+        conversion_notes: Vec::new(),
     })
 }
 

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -591,7 +591,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
         items,
         variables: HashMap::new(),
         auth: None,
-    conversion_notes: Vec::new(),
+        conversion_notes: Vec::new(),
     })
 }
 

--- a/crates/inputs/tropel-input-subprocess/src/lib.rs
+++ b/crates/inputs/tropel-input-subprocess/src/lib.rs
@@ -388,7 +388,7 @@ impl InputAdapter for SubprocessAdapter {
             items,
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         })
     }
 

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -47,9 +47,7 @@ pub async fn run_agent(port: u16, bind: &str, token: Option<&str>) -> tropel_sdk
     }
 
     let addr = format!("{bind}:{port}");
-    let listener = TcpListener::bind(&addr)
-        .await
-        .map_err(TropelError::Io)?;
+    let listener = TcpListener::bind(&addr).await.map_err(TropelError::Io)?;
     tracing::info!(
         "tropel agent listening on http://{addr} (token auth {})",
         if token.is_some() { "on" } else { "off" }
@@ -127,7 +125,9 @@ async fn handle_connection(sock: &mut TcpStream, state: Arc<AgentState>) -> trop
         ("POST", "/execute") => {
             let mut body_buf = vec![0u8; content_length.min(64 * 1024)];
             if content_length > 0 {
-                sock.read_exact(&mut body_buf).await.map_err(TropelError::Io)?;
+                sock.read_exact(&mut body_buf)
+                    .await
+                    .map_err(TropelError::Io)?;
             }
             let req: serde_json::Value = match serde_json::from_slice(&body_buf) {
                 Ok(v) => v,
@@ -153,7 +153,9 @@ async fn respond(sock: &mut TcpStream, status: u16, body: &str) -> tropel_sdk::R
         "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
-    sock.write_all(resp.as_bytes()).await.map_err(TropelError::Io)
+    sock.write_all(resp.as_bytes())
+        .await
+        .map_err(TropelError::Io)
 }
 
 /// Execute a single request with full sub-timings — the SAME engine code path

--- a/crates/tropel-engine/src/lib.rs
+++ b/crates/tropel-engine/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Orchestration facade: wires adapters → executor → protocols/pm → metrics → reporters.
 
-pub mod builtins;
 pub mod agent;
+pub mod builtins;
 pub mod cli;
 mod cli_commands;
 mod cli_overlay;

--- a/crates/tropel-engine/src/outputs.rs
+++ b/crates/tropel-engine/src/outputs.rs
@@ -29,40 +29,40 @@ pub(crate) fn spawn_extension_output(
 
         loop {
             tokio::select! {
-                res = rx.recv() => match res {
-                    Ok(sample) => {
-                        batch.push(sample);
-                        if batch.len() >= MAX_BATCH {
-                            // TR-312: retain the Vec's capacity instead of
-                            // mem::take (which leaves Vec::new() → re-grows
-                            // 4→8→16→… every flush).
-                            let b = std::mem::replace(&mut batch, Vec::with_capacity(1024));
-                            if let Err(e) = output.emit(&b).await {
-                                tracing::warn!("extension output '{}' emit failed: {e}", output.name());
+                            res = rx.recv() => match res {
+                                Ok(sample) => {
+                                    batch.push(sample);
+                                    if batch.len() >= MAX_BATCH {
+                                        // TR-312: retain the Vec's capacity instead of
+                                        // mem::take (which leaves Vec::new() → re-grows
+                                        // 4→8→16→… every flush).
+                                        let b = std::mem::replace(&mut batch, Vec::with_capacity(1024));
+                                        if let Err(e) = output.emit(&b).await {
+                                            tracing::warn!("extension output '{}' emit failed: {e}", output.name());
+                                        }
+                                        // TR-301: flushes yield — a CPU-heavy emit (tag
+                                        // expansion, serialization) must not starve the
+                                        // aggregator task that shares this runtime.
+                                        tokio::task::yield_now().await;
+                                    }
+                                }
+                                Err(broadcast::error::RecvError::Closed) => break,
+                                Err(broadcast::error::RecvError::Lagged(n)) => {
+                                    tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+                                    tracing::warn!("extension output dropped {n} samples (consumer lag)");
+                                }
+                            },
+                            _ = tick.tick() => {
+                                if !batch.is_empty() {
+                                    let b = std::mem::replace(&mut batch, Vec::with_capacity(1024));
+                                    if let Err(e) = output.emit(&b).await {
+                                        tracing::warn!("extension output '{}' emit failed: {e}", output.name());
+                                    }
+            // TR-301: yield so the aggregator gets scheduled.
+                                    tokio::task::yield_now().await;
+                                }
                             }
-                            // TR-301: flushes yield — a CPU-heavy emit (tag
-                            // expansion, serialization) must not starve the
-                            // aggregator task that shares this runtime.
-                            tokio::task::yield_now().await;
                         }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tropel_metrics::OUTPUT_SAMPLES_DROPPED.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
-                        tracing::warn!("extension output dropped {n} samples (consumer lag)");
-                    }
-                },
-                _ = tick.tick() => {
-                    if !batch.is_empty() {
-                        let b = std::mem::replace(&mut batch, Vec::with_capacity(1024));
-                        if let Err(e) = output.emit(&b).await {
-                            tracing::warn!("extension output '{}' emit failed: {e}", output.name());
-                        }
-// TR-301: yield so the aggregator gets scheduled.
-                        tokio::task::yield_now().await;
-                    }
-                }
-            }
         }
 
         // Final flush on stream close.

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1402,7 +1402,7 @@ mod tests {
             items: vec![leaf("request-one"), leaf("request-two")],
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1689,7 +1689,7 @@ mod tests {
             ],
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1785,7 +1785,7 @@ mod tests {
             )],
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         assert_eq!(
@@ -1905,7 +1905,7 @@ mod tests {
             }],
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =
@@ -1968,7 +1968,7 @@ mod tests {
             items,
             variables: HashMap::new(),
             auth: None,
-        conversion_notes: Vec::new(),
+            conversion_notes: Vec::new(),
         });
         let execution_items = Arc::new(flatten_execution_items(&scenario.items));
         let names: Arc<Vec<String>> =

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -136,6 +136,7 @@ fn fixture_run_request() -> RunRequest {
         ],
         variables: HashMap::new(),
         auth: None,
+        conversion_notes: Vec::new(),
     };
 
     RunRequest {


### PR DESCRIPTION
## What

Fixes the master CI failure introduced by the TR-410 merge:

1. **rustfmt**: the TR-312/TR-410 files (outputs.rs, agent.rs, adapters) merged with unformatted content — cargo fmt --all applied.
2. **	ropel-web/tests/native_vs_wasm.rs:104**: the Scenario test literal was missing the new conversion_notes field.
3. **SDK submodule pin** bumped to 5b9f810 (which adds conversion_notes to the SDK's own test + gates sample — the pinned 9c46e85 lacked the test fix, so the SDK's gates failed).

## Task
CI fix for the TR-410 merge.

## Tests
\cargo fmt --all --check\ clean; workspace build green locally.

## Risk
None — formatting + a test fixture field + the submodule pin bump.