### PR TITLE
fix(ci): SnapshotMsg.done + runner.rs/tropel-web Scenario.conversion_notes [TR-410]

### DIFF
--- a/crates/tropel-distributed/src/protocol.rs
+++ b/crates/tropel-distributed/src/protocol.rs
@@ -170,6 +170,7 @@ mod tests {
 
         let msg = SnapshotMsg {
             snapshot: MetricsSnapshot::default(),
+            done: true,
         };
         let send = tokio::spawn(async move {
             write_frame(&mut tx, &msg).await.unwrap();

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1504,8 +1504,9 @@ mod tests {
                 description: None,
                 schema: None,
             },
-            variables: HashMap::new(),
+variables: HashMap::new(),
             auth: None,
+            conversion_notes: Vec::new(),
             items: vec![ScenarioItem {
                 name: "resolved-item".into(),
                 id: None,
@@ -1573,6 +1574,7 @@ mod tests {
             },
             variables: HashMap::new(),
             auth: None,
+            conversion_notes: Vec::new(),
             items: vec![
                 ScenarioItem {
                     name: "item-a".into(),
@@ -2302,6 +2304,7 @@ mod tests {
             },
             variables: HashMap::new(),
             auth: None,
+            conversion_notes: Vec::new(),
             items: vec![leaf("ok-item"), leaf("dead-item")],
         });
         let execution_items: Arc<Vec<ScenarioItem>> =

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -273,6 +273,7 @@ mod tests {
             }],
             variables: HashMap::new(),
             auth: None,
+            conversion_notes: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What

Fixes the remaining CI failures from the TR-410/TR-309 merges:

1. \	ropel-distributed/src/protocol.rs\: test SnapshotMsg literal missing \done: true\ (TR-309).
2. \	ropel-runtime/src/runner.rs\: 3 test Scenario literals missing \conversion_notes\.
3. \	ropel-web/src/lib.rs\: test Scenario literal missing \conversion_notes\.

## Task
CI fix.

## Tests
\cargo check --workspace --tests\ green; \cargo build --workspace\ green.