### PR TITLE
fix(ci): TR-407 guard sample implements the real Driver trait [TR-407]

### DIFF
--- a/scripts/sdk-guard.sh
+++ b/scripts/sdk-guard.sh
@@ -41,14 +41,22 @@ edition = "2021"
 tropel-sdk = { path = "$(realpath "$SDK_DIR")" }
 EOF
 cat > "$TMPDIR/src/lib.rs" <<EOF
-use tropel_sdk::traits::{Driver, DriverDeclaredOptions};
+use tropel_sdk::traits::{Driver, DriverInstance, DriverDeclaredOptions, VuContext};
 use tropel_sdk::types::{Request, Method, AuthConfig};
 use tropel_sdk::Result;
 
 pub struct MyDriver;
 impl Driver for MyDriver {
-    fn name(&self) -> &str { "test" }
+    fn id(&self) -> &str { "test" }
     fn detect(&self, _bytes: &[u8]) -> bool { false }
+    async fn init(
+        &self,
+        _bytes: &[u8],
+        _path: Option<&std::path::Path>,
+        _exec: Option<&str>,
+    ) -> Result<Box<dyn DriverInstance>> {
+        Ok(Box::new(MyInstance))
+    }
     async fn declared_options(
         &self,
         _bytes: &[u8],
@@ -56,6 +64,13 @@ impl Driver for MyDriver {
         _env: &std::collections::HashMap<String, String>,
     ) -> Result<Option<DriverDeclaredOptions>> {
         Ok(None)
+    }
+}
+
+pub struct MyInstance;
+impl DriverInstance for MyInstance {
+    async fn run_iteration(&mut self, _ctx: &mut VuContext) -> Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## What

The TR-407 SDK guard's sample extension (added in PR #413) was written against a WRONG Driver trait shape — it used a non-existent \
ame()\ method and skipped the required \id()\/\init()\/\un_iteration()\. The CI wasm-slice step caught it: 'method \
ame\ is not a member of trait \Driver\'.

The sample now implements the real \Driver\ (\id\/\detect\/\init\/\declared_options\) and \DriverInstance\ (\un_iteration\), and touches \Request\/\Method\/\AuthConfig\ — proving the contract resolves from the SDK alone.

## Task
CI fix (TR-407 guard).

## Tests
\cargo build --locked -p tropel-sdk\ green (the sample uses only SDK exports). The CI wasm-slice step runs \sdk-guard.sh\ and will verify the sample builds.

## Risk
None — script fix only.