### PR TITLE
test(w4): TR-409 RFC 7616 A.2 published digest vectors [TR-409]

### DIFF
--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -2304,4 +2304,60 @@ mod tests {
         assert!(h3.contains("nonce=\"nonce-b\""));
         assert!(h3.contains("nc=00000001"), "rotated nonce resets nc: {h3}");
     }
+
+    #[test]
+    fn rfc_7616_a2_sha256_published_vector() {
+        // TR-409: RFC 7616 Appendix A.2 — the SHA-256 example with known
+        // inputs and a published response. This test verifies that the digest
+        // signer's response computation matches the RFC's published value.
+        //
+        // The cnonce is random in the signer, but `digest_response_value`
+        // accepts it as a parameter — inject the RFC's cnonce to reproduce
+        // the exact published response.
+        let base_ha1 = digest_with(
+            "Mufasa:http-auth@example.org:Circle of Life",
+            "SHA-256",
+        );
+        assert!(!base_ha1.is_empty(), "HA1 must compute");
+
+        let ha2 = digest_with("GET:/dir/index.html", "SHA-256");
+        assert!(!ha2.is_empty(), "HA2 must compute");
+
+        let response = digest_response_value(
+            &base_ha1,
+            false, // not -sess
+            "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",  // nonce
+            "00000001",                                          // nc
+            "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ",    // cnonce (RFC's value)
+            Some("auth"),                                        // qop
+            &ha2,
+            "SHA-256",
+        );
+
+        // RFC 7616 A.2 published response value (SHA-256, qop=auth).
+        let expected = "753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1";
+        assert_eq!(
+            response, expected,
+            "RFC 7616 A.2 SHA-256 vector mismatch"
+        );
+
+        // RFC 7616 A.2 also lists the MD5 response for the SAME inputs
+        // (the server offered both SHA-256 and MD5 challenges).
+        let md5_ha1 = digest_with("Mufasa:http-auth@example.org:Circle of Life", "MD5");
+        let md5_ha2 = digest_with("GET:/dir/index.html", "MD5");
+        let md5_response = digest_response_value(
+            &md5_ha1,
+            false,
+            "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+            "00000001",
+            "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ",
+            Some("auth"),
+            &md5_ha2,
+            "MD5",
+        );
+        assert_eq!(
+            md5_response, "8ca523f5e9506fed4657c9700eebdbec",
+            "RFC 7616 A.2 MD5 vector mismatch"
+        );
+    }
 }


### PR DESCRIPTION
## What

TR-409: every signing scheme must round-trip with a PUBLISHED vector, not just against its own implementation (a symmetric bug round-trips fine).

Adds the RFC 7616 Appendix A.2 digest vectors — the canonical SHA-256 AND MD5 examples with known inputs and published response values:
- username \Mufasa\ / password \Circle of Life\ / realm \http-auth@example.org\, GET \/dir/index.html\
- RFC's fixed nonce/nc/cnonce/qop=auth injected into \digest_response_value\ (the cnonce is random in the signer, but the function accepts it as a parameter)
- SHA-256 response asserted = \753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\
- MD5 response asserted = \8ca523f5e9506fed4657c9700eebdbec\

## Task
TR-409 (W4 — signing correctness contract).

## Acceptance
- [x] Digest round-trips with a published RFC vector (SHA-256 + MD5)
- [ ] SigV4 / OAuth1 / Hawk vectors — follow-up (each needs the AWS/RFC/OAuth test-suite values; same pattern)

## Tests
\cargo test -p tropel-auth rfc_7616_a2_sha256_published_vector\ passes — the signer reproduces the RFC's published response values exactly.

## Risk
None — a new test; it asserts the current (correct) behavior.