### PR TITLE
fix(ci): rustfmt + clippy mut in native_vs_wasm corpus test [ci]

### DIFF
--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -686,7 +686,7 @@ fn native_and_wasm_agree_over_request_corpus() {
         response_type: ResponseType::Text,
     };
 
-    let mut corpus: Vec<Request> = vec![
+    let corpus: Vec<Request> = vec![
         base("https://fixture.test/get"),
         {
             let mut r = base("https://fixture.test/post");
@@ -702,7 +702,9 @@ fn native_and_wasm_agree_over_request_corpus() {
         },
         {
             let mut r = base("https://fixture.test/bearer");
-            r.auth = Some(AuthConfig::Bearer { token: "tok".into() });
+            r.auth = Some(AuthConfig::Bearer {
+                token: "tok".into(),
+            });
             r
         },
         {


### PR DESCRIPTION
## What

The TR-408 corpus harness (PR #422) was formatted with an older rustfmt and the test's \let mut corpus\ Vec doesn't need mutability (newer clippy flags it as an error under \-D warnings\). This applies the CI's exact formatting (multi-line \AuthConfig\ literals) and drops the \mut\.

## Task
CI fix (rustfmt + clippy + wasm slice all failing on the same test).

## Tests
\cargo clippy -p tropel-web --all-targets -- -D warnings\ green; the rustfmt changes match the CI's \cargo fmt --all --check\ diff exactly.

## Risk
None — formatting + \mut\ removal only.