### PR TITLE
fix(w4): TR-408 corpus failing-script semantics + robust assertion [TR-408]

### DIFF
--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -748,7 +748,7 @@ fn native_and_wasm_agree_over_request_corpus() {
                 name: "fail-item".into(),
                 request: Some(base("https://fixture.test/fail")),
                 prerequest: vec![],
-                test: vec!["pm.test('boom', () => { throw new Error('boom'); });".into()],
+                test: vec!["throw new Error('boom');".into()],
                 assertions: vec![],
                 items: vec![],
             }],
@@ -769,9 +769,13 @@ fn native_and_wasm_agree_over_request_corpus() {
         let n = normalize(&native);
         let w = normalize(&wasm);
         assert_eq!(n, w, "failing-script outcome diverged");
-        assert_eq!(
-            n[0].script_failures, 1,
+        assert!(
+            n[0].script_failures >= 1,
             "the throwing script must fail on the native leg"
+        );
+        assert!(
+            w[0].script_failures >= 1,
+            "the throwing script must fail on the wasm leg"
         );
     }
 

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -686,7 +686,7 @@ fn native_and_wasm_agree_over_request_corpus() {
         response_type: ResponseType::Text,
     };
 
-    let mut corpus: Vec<Request> = vec![
+    let corpus: Vec<Request> = vec![
         base("https://fixture.test/get"),
         {
             let mut r = base("https://fixture.test/post");
@@ -702,7 +702,9 @@ fn native_and_wasm_agree_over_request_corpus() {
         },
         {
             let mut r = base("https://fixture.test/bearer");
-            r.auth = Some(AuthConfig::Bearer { token: "tok".into() });
+            r.auth = Some(AuthConfig::Bearer {
+                token: "tok".into(),
+            });
             r
         },
         {


### PR DESCRIPTION
## What

The TR-408 corpus test's failing-script item used \pm.test('boom', () => { throw ... })\ — but \pm.test\ CATCHES a throw and reports it as a failed CHECK, not a script failure. The harness correctly caught the divergence (native reported 0 script_failures while the test expected 1).

Fixed:
- The failing-script item now uses a DIRECT top-level \	hrow new Error('boom');\ (which propagates to \ecord_script_failure\ → script_failures >= 1 on both legs).
- The assertion is robust: both legs must report \script_failures >= 1\ (not an exact \== 1\, so it doesn't over-pin the failure mechanics).

## Task
TR-408 CI fix (the harness caught a real test defect, not a runtime divergence).

## Tests
\cargo check -p tropel-web --tests\ green. The wasm-slice CI job runs the test with \TROPEL_REQUIRE_WASM=1\ and blocks on divergence.

## Risk
None — test-only fix.