### PR TITLE
feat(w4): TR-408 corpus extended + divergence file [TR-408]

### DIFF
--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -44,14 +44,32 @@ use tropel_web::wire::{RunOutcome, RunRequest};
 
 /// Deterministic response for ANY request — shared verbatim by the native
 /// seam handler and the wasm host function, so both legs see the same bytes.
+/// The response VARIES by URL path so the corpus can exercise error
+/// statuses, redirects, and different body types through both legs.
 fn fixture_response(req: &Request) -> Result<Response> {
+    let path = req.url.split('?').next().unwrap_or("");
+    let (status, status_text, body, extra_headers) = if path.ends_with("/404") {
+        (404, "Not Found".to_string(), br#"{"error":"not found"}"#.to_vec(), HashMap::new())
+    } else if path.ends_with("/500") {
+        (500, "Internal Server Error".to_string(), br#"{"error":"boom"}"#.to_vec(), HashMap::new())
+    } else if path.ends_with("/redirect") {
+        (301, "Moved Permanently".to_string(), b"".to_vec(), HashMap::from([("location".to_string(), "https://fixture.test/200".to_string())]))
+    } else if path.ends_with("/text") {
+        (200, "OK".to_string(), b"plain text body".to_vec(), HashMap::from([("content-type".to_string(), "text/plain".to_string())]))
+    } else if path.ends_with("/empty") {
+        (204, "No Content".to_string(), b"".to_vec(), HashMap::new())
+    } else {
+        (200, "OK".to_string(), br#"{"ok":true}"#.to_vec(), HashMap::from([("content-type".to_string(), "application/json".to_string())]))
+    };
+    let mut headers = HashMap::from([("content-type".to_string(), "application/json".to_string())]);
+    headers.extend(extra_headers);
     Ok(Response {
         url: req.url.clone(),
-        status_code: 200,
-        status_text: "OK".into(),
+        status_code: status,
+        status_text,
         protocol: "HTTP/1.1".into(),
-        headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
-        body: br#"{"ok":true}"#.to_vec(),
+        headers,
+        body,
         text_cache: std::sync::OnceLock::new(),
         json_cache: std::sync::OnceLock::new(),
         response_time: std::time::Duration::from_millis(5),
@@ -732,6 +750,13 @@ fn native_and_wasm_agree_over_request_corpus() {
             });
             r
         },
+        // Error statuses and redirects must produce IDENTICAL outcomes on
+        // both legs (the fixture varies by path).
+        base("https://fixture.test/404"),
+        base("https://fixture.test/500"),
+        base("https://fixture.test/redirect"),
+        base("https://fixture.test/text"),
+        base("https://fixture.test/empty"),
     ];
 
     // A failing script must ALSO agree (script_failures on both legs).

--- a/crates/tropel-web/tests/native_vs_wasm_divergences.md
+++ b/crates/tropel-web/tests/native_vs_wasm_divergences.md
@@ -1,0 +1,22 @@
+# Native vs wasm differential divergences (TR-408)
+
+This file enumerates the divergences between the native and wasm32 runtime that
+are GENUINELY unavoidable — the `native_vs_wasm` differential harness must
+either not exercise them, or the divergence must be listed here with a reason
+before the CI merge-block is waived.
+
+Current state: **no known unavoidable divergences.** The harness (`crates/
+tropel-web/tests/native_vs_wasm.rs`) runs the identical `ScenarioRunner` code
+compiled two ways (host vs wasm32-wasip1) with a shared deterministic fixture,
+and asserts the normalized outcomes are byte-identical across:
+
+- methods (GET/POST), JSON/query/form bodies
+- auth schemes (bearer, basic, api-key, digest) — the wire signing is shared
+- error statuses (404, 500), redirects (301), text/empty bodies
+- a throwing test script (both legs report the same `script_failures`)
+
+If a future divergence appears, add it here with the reason it is unavoidable
+(e.g. a host-only feature like `std::time` precision, or a platform-specific
+timestamp) AND mark the corresponding corpus item `#[ignore]` with a link to
+this file. A divergence that is NOT listed here is a bug in the one-engine
+claim and must be fixed, not waived.


### PR DESCRIPTION
## What

TR-408: extends the differential corpus and adds the divergence-enumeration file.

- The fixture now responds DYNAMICALLY by URL path (404, 500, 301-redirect, text body, 204-empty) — so the corpus exercises error handling, redirects, and body types through BOTH legs.
- New corpus items: /404, /500, /redirect, /text, /empty — each asserted byte-identical between native and wasm32.
- \
ative_vs_wasm_divergences.md\: the checked-in divergence enumeration. Currently no known unavoidable divergences; the file documents the policy for future ones (list + \#[ignore]\ + reason, or it's a bug in the one-engine claim).

## Task
TR-408 (W4 — differential harness).

## Acceptance
- [x] Corpus covers error statuses, redirects, body types
- [x] Divergences enumerated in a checked-in file
- [ ] Fixture collections (k6/postman/har/openapi) in the corpus — follow-up
- [ ] CI badge — follow-up

## Tests
\cargo check -p tropel-web --tests\ green; the wasm-slice CI job runs the harness with \TROPEL_REQUIRE_WASM=1\.

## Risk
None — test + docs only. The fixture's path-based responses are deterministic and shared verbatim by both legs.