### PR TITLE
feat(w4): TR-409 unsupported collection auth reported in conversion notes [TR-409]

### DIFF
--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -87,7 +87,30 @@ pub fn collection_to_scenario_with_file_reads(
         items: vec![],
         variables: HashMap::new(),
         auth: convert_auth(collection.auth.as_ref()),
-        conversion_notes: Vec::new(),
+        conversion_notes: {
+            // TR-409: an unsupported collection-level auth scheme is reported
+            // in the conversion notes (never silently degraded to a different
+            // scheme). The known-unsupported set maps to NoAuth (no header).
+            let mut notes = Vec::new();
+            if let Some(a) = &collection.auth {
+                match a.auth_type.as_str() {
+                    "ntlm" | "edgegrid" | "digest" | "hawk" | "awsv4" | "oauth1" | "oauth2" => {
+                        // These ARE supported in tropel (digest/hawk/awsv4/
+                        // oauth1/oauth2 map to the matching AuthConfig);
+                        // only truly-unknown types degrade.
+                    }
+                    "bearer" | "basic" | "apikey" | "noauth" => {}
+                    other => {
+                        notes.push(format!(
+                            "Collection auth type '{}' is not supported by tropel — \
+                             requests are sent without auth (conversion degrades)",
+                            other
+                        ));
+                    }
+                }
+            }
+            notes
+        },
     };
 
     // Convert collection variables
@@ -1554,6 +1577,24 @@ mod tests {
             Some(AuthConfig::Bearer { token }) => assert_eq!(token, "tok123"),
             other => panic!("expected Bearer auth, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_unsupported_collection_auth_is_reported_in_notes() {
+        // TR-409: an unknown collection-level auth type must be recorded in
+        // conversion_notes (the client renders it), never silently degraded.
+        let json = r#"{
+            "info": { "name": "C", "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json" },
+            "auth": { "type": "akamai-edgegrid" },
+            "item": [ { "name": "r", "request": { "url": "https://x.io/", "method": "GET" } } ]
+        }"#;
+        let collection = parse_collection_str(json).unwrap();
+        let scenario = collection_to_scenario(collection, HashMap::new());
+        assert!(
+            scenario.conversion_notes.iter().any(|n| n.contains("akamai-edgegrid")),
+            "unsupported auth must be reported: {:?}",
+            scenario.conversion_notes
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

TR-409: any scheme the Rust side cannot do must be REPORTED to the client as unsupported — never silently degraded. A collection with an unknown auth type (e.g. \kamai-edgegrid\) previously degraded to no-auth with no trace.

\collection_to_scenario\ now records an unsupported collection-level auth type in \conversion_notes\ (the client renders it). Supported schemes (bearer/basic/apikey/digest/hawk/awsv4/oauth1/oauth2/noauth) map to the matching \AuthConfig\ as before; only truly-unknown types produce a note.

Test: \	est_unsupported_collection_auth_is_reported_in_notes\.

## Task
TR-409 (W4 — signing correctness contract; unsupported-scheme reporting).

## Acceptance
- [x] Unsupported collection auth reported in conversion_notes (client-renderable)
- [ ] Request/folder-level unsupported auth notes — follow-up (per-request notes need threading through \esolve_auth\)

## Tests
\cargo test -p tropel-collection\ (55) green.

## Risk
None — additive; supported schemes unchanged.