### PR TITLE
fix(w4): TR-409 OAuth1 form-urlencoded + decodes to space [TR-409]

### DIFF
--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -771,12 +771,23 @@ fn parse_form(bytes: &[u8]) -> Vec<(String, String)> {
         .filter(|p| !p.is_empty())
         .filter_map(|pair| {
             let (k, v) = pair.split_once('=')?;
+            // RFC 5849 §3.4.1.1: form-urlencoded bodies use `+` for space
+            // (the same decoding as `application/x-www-form-urlencoded`).
+            // The decoded value is then percent-encoded by `enc()` when the
+            // base string is built — so `+` must become space here, not
+            // survive as a literal `+` (which would re-encode as `%2B`).
             Some((
-                percent_decode(k).unwrap_or_else(|| k.to_string()),
-                percent_decode(v).unwrap_or_else(|| v.to_string()),
+                decode_form_value(k),
+                decode_form_value(v),
             ))
         })
         .collect()
+}
+
+/// Decode a form-urlencoded value: `+` → space, then percent-decode `%XX`.
+fn decode_form_value(s: &str) -> String {
+    let plus_to_space = s.replace('+', " ");
+    percent_decode(&plus_to_space).unwrap_or(plus_to_space)
 }
 
 fn percent_decode(s: &str) -> Option<String> {


### PR DESCRIPTION
## What

TR-409: RFC 5849 §3.4.1.3.1 REQUIRES that \pplication/x-www-form-urlencoded\ values have \+\ decoded to space before the signature base string is built. The old \parse_form\ only percent-decoded \%XX\, leaving \+\ as a literal (which then re-encoded as \%2B\ — an incorrect signature).

\decode_form_value\ now converts \+\ → space before percent-decoding, so \3=2+q\ signs as \3=2%20q\ per the RFC.

The RFC 5849 vector test is \#[ignore]\ — it documents a REMAINING divergence (the vector's exact published signature depends on \oauth_version\ inclusion and subtle base-string details that the signer's standard construction doesn't reproduce exactly). The \+\→space fix is a genuine improvement regardless.

## Task
TR-409 (W4 — OAuth1 signing correctness).

## Acceptance
- [x] \+\ in form bodies decodes to space (RFC 5849 requirement)
- [ ] Full RFC 5849 vector match — remaining divergence documented in the \#[ignore]\ test

## Tests
\cargo test -p tropel-auth\ (56) green, 1 ignored.

## Risk
Low — the fix only affects form-urlencoded body decoding (moves signatures toward the RFC's form); no other path uses \parse_form\.