### PR TITLE
feat(w5): TR-505 report effective VUs, startup cap warning and pids limit [TR-505]

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -546,6 +546,55 @@ impl Engine {
             "Starting Tropel load test: {} scenario(s)",
             scenario_configs.len()
         );
+
+        // TR-505: effective VU reporting — warn at startup when the 4096 cap
+        // or cgroup pids limit will reduce concurrency.
+        let peak_requested: u64 = {
+            fn peak_for_exec(exec: &ExecutionConfig) -> u64 {
+                match exec {
+                    ExecutionConfig::ConstantVus { vus, .. } => *vus as u64,
+                    ExecutionConfig::RampingVus { stages, start_vus, .. } => {
+                        let max_stage = stages.iter().map(|s| s.target as u64).max().unwrap_or(0);
+                        (*start_vus as u64).max(max_stage)
+                    }
+                    ExecutionConfig::ConstantArrivalRate { max_vus, .. } => *max_vus as u64,
+                    ExecutionConfig::RampingArrivalRate { max_vus, .. } => *max_vus as u64,
+                    ExecutionConfig::SharedIterations { vus, .. } => *vus as u64,
+                    ExecutionConfig::PerVUIterations { vus, .. } => *vus as u64,
+                    ExecutionConfig::ExternallyControlled { max_vus, .. } => *max_vus as u64,
+                }
+            }
+            // Concurrent scenarios run together — worst-case is sum of peaks.
+            // Sequential scenarios (staggered start_time) would over-estimate,
+            // but a startup warning that is slightly eager is safer than one
+            // that misses a real cap.
+            scenario_configs
+                .iter()
+                .map(|sc| peak_for_exec(&sc.execution))
+                .sum()
+        };
+        let effective = VUWorkerPool::effective_concurrency(peak_requested);
+        if peak_requested > effective {
+            let pids = VUWorkerPool::pids_limit();
+            let reason = if pids.is_some_and(|lim| lim < peak_requested && lim < VUWorkerPool::MAX_WORKERS as u64) {
+                format!("cgroup pids.max={} (Docker --pids-limit / Kubernetes pids.max)", pids.unwrap())
+            } else {
+                format!("MAX_WORKERS={}", VUWorkerPool::MAX_WORKERS)
+            };
+            tracing::warn!(
+                "TR-505: requested {} VUs but only {} effective ({}). Co-located VUs share a single-threaded runtime and block each other — throughput will be that of {} VUs.",
+                peak_requested, effective, reason, effective
+            );
+        } else if peak_requested > 0 {
+            tracing::info!(
+                "TR-505: requested {} VUs, effective {} (MAX_WORKERS={}, pids={})",
+                peak_requested,
+                effective,
+                VUWorkerPool::MAX_WORKERS,
+                VUWorkerPool::pids_limit().map(|v| v.to_string()).unwrap_or_else(|| "unlimited".to_string())
+            );
+        }
+
         let mut scenario_handles = Vec::new();
 
         for sc in &scenario_configs {
@@ -735,6 +784,12 @@ impl Engine {
         // runs that exited 1).
         results.vu_init_failures = total_vu_init_failures;
         results.script_failures = total_script_failures;
+        // TR-505: stamp requested vs effective so the summary can report the gap
+        // between what was asked and what the worker pool can deliver (4096 cap /
+        // pids.max). This is the cheapest honesty win — a run requesting 10k
+        // must not print "10 000 VUs" when it delivered 4 096.
+        results.requested_vus = peak_requested;
+        results.effective_vus = effective;
 
         // Distributed workers (`tropel-agent`) skip ALL end-of-run output —
         // the controller owns the summary, handleSummary, and reporters —

--- a/crates/tropel-engine/src/summary.rs
+++ b/crates/tropel-engine/src/summary.rs
@@ -130,6 +130,8 @@ pub(crate) fn build_summary_data(
             "testRunDurationMs": test_start.elapsed().as_millis() as u64,
             "iterations": results.iterations,
             "vusMax": results.vus_max,
+            "vusRequested": results.requested_vus,
+            "vusEffective": results.effective_vus,
             "http_reqs": results.http_reqs,
             "checksTotal": results.checks_total,
             "checksPassed": results.checks_passed,

--- a/crates/tropel-engine/src/worker.rs
+++ b/crates/tropel-engine/src/worker.rs
@@ -331,7 +331,39 @@ impl VUWorkerPool {
     /// workers (isolation traded away at extreme VU counts, as documented).
     /// The vu_id passed to `run_vu` is unaffected (naming stays unique) —
     /// only the worker slot may be shared.
-    const MAX_WORKERS: usize = 4096;
+    pub const MAX_WORKERS: usize = 4096;
+
+    /// Read the cgroup `pids.max` limit if present (Kubernetes `pids.max`,
+    /// Docker `--pids-limit`). Returns `None` when unlimited or unreadable.
+    /// Checks both cgroup v1 and v2 paths.
+    pub fn pids_limit() -> Option<u64> {
+        for path in [
+            "/sys/fs/cgroup/pids.max",
+            "/sys/fs/cgroup/pids/pids.max",
+            "/sys/fs/cgroup/cpu/pids.max",
+        ] {
+            if let Ok(s) = std::fs::read_to_string(path) {
+                let t = s.trim();
+                if t == "max" || t.is_empty() {
+                    continue;
+                }
+                if let Ok(v) = t.parse::<u64>() {
+                    if v > 0 {
+                        return Some(v);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Effective concurrency actually achievable — `min(requested, MAX_WORKERS,
+    /// pids.limit)`. When `requested > effective`, wrapping or pids-capping
+    /// reduces throughput to that of `effective`.
+    pub fn effective_concurrency(requested: u64) -> u64 {
+        let pids = Self::pids_limit().unwrap_or(u64::MAX);
+        requested.min(Self::MAX_WORKERS as u64).min(pids)
+    }
 
     /// Spawn a VU on a dedicated worker thread. Reuses an idle slot (a
     /// finished VU's worker) when one exists, grows the pool only when every

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -1310,6 +1310,8 @@ impl Aggregator {
             },
             iterations,
             vus_max,
+            requested_vus: 0,
+            effective_vus: 0,
             // Backlog line 45 (P0): REAL mid-run elapsed — a ZERO here made
             // every rate/avg threshold compute 0.0 and abortOnFail killed
             // healthy runs (the engine stamps the final value post-run).
@@ -1755,6 +1757,14 @@ pub struct MetricsResult {
     pub iterations: u64,
     /// Maximum concurrent VUs observed.
     pub vus_max: u64,
+    /// Requested peak VUs (sum of configured `vus`/`maxVUs` across scenarios).
+    /// Stamped by the engine before the run so reporters can show the gap
+    /// between requested and effective when the 4096 cap bites (TR-505).
+    pub requested_vus: u64,
+    /// Effective peak VUs actually achievable — `min(requested, MAX_WORKERS,
+    /// pids.limit)`. When `requested > effective`, the run wrapped or was
+    /// pids-capped and throughput is that of `effective`.
+    pub effective_vus: u64,
     /// Wall-clock duration of the run (stamped by the engine after the run
     /// finishes). Reporters use it for k6-style per-second rates
     /// (`http_reqs: 136 13.56/s`) and `handleSummary` state.
@@ -1814,6 +1824,8 @@ impl Default for MetricsResult {
             http_req_failed: 0.0,
             iterations: 0,
             vus_max: 0,
+            requested_vus: 0,
+            effective_vus: 0,
             run_duration: Duration::ZERO,
             summary_trend_stats: k6_default_trend_stats(),
             effective_thresholds: std::collections::HashMap::new(),

--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -78,13 +78,31 @@ impl StdoutReporter {
 
         // Execution overview — aligned two-column block
         out.push_str("  ── Execution ─────────────────────────────────────────────\n");
-        let exec_rows = vec![
+        // TR-505: report effective vs requested when the 4096/pids cap bites.
+        let max_vus_label = if result.requested_vus > 0 && result.requested_vus != result.effective_vus {
+            format!("{} (effective {})", result.vus_max, result.effective_vus)
+        } else {
+            result.vus_max.to_string()
+        };
+        let mut exec_rows = vec![
             ("Iterations", result.iterations.to_string()),
-            ("Max VUs", result.vus_max.to_string()),
+            ("Max VUs", max_vus_label),
             ("Dropped", result.dropped_iterations.to_string()),
         ];
+        if result.requested_vus > 0 && result.requested_vus != result.effective_vus {
+            exec_rows.push((
+                "Requested VUs",
+                format!("{} → {} effective (MAX_WORKERS=4096, capped)", result.requested_vus, result.effective_vus),
+            ));
+        }
         for (label, value) in exec_rows {
             out.push_str(&format!("    {:<14}{}\n", label, value));
+        }
+        if result.requested_vus > result.effective_vus {
+            out.push_str(&format!(
+                "    {:<14}requested {} but only {} effective — co-located VUs share a single-threaded runtime and block each other\n",
+                "VU cap", result.requested_vus, result.effective_vus
+            ));
         }
         if result.is_unverified() {
             out.push_str("    Verification   UNVERIFIED: samples or iterations were dropped\n");


### PR DESCRIPTION
## What
Implements TR-505 honesty win: effective vs requested concurrency. Before, a run requesting 10k VUs wrapped onto 4096 workers and still printed 10k. Now the engine warns at startup when the cap bites, stamps requested/effective into MetricsResult, and the summary/stdout report both.

## Task
TR-505

## Acceptance
- [x] Summary reports effective in-flight concurrency alongside spawned VUs (MetricsResult.requested_vus/effective_vus, summary state vusRequested/vusEffective, stdout Max VUs (effective ...) and Requested VUs line)
- [x] Exceeding worker cap is visible warning at startup naming number you will actually get (engine.rs peak_requested -> VUWorkerPool::effective_concurrency, tracing::warn with reason MAX_WORKERS or pids.max)
- [x] growth_failed stops being sticky (already fixed: worker.rs reset on find_idle_slot)
- [x] make_worker failure memoized (worker.rs growth_failed)
- [x] pids.max / --pids-limit checked (VUWorkerPool::pids_limit reads /sys/fs/cgroup/pids.max, v1/v2)

## Tests
Manual: cargo check passes for tropel-metrics, tropel-engine, tropel-report. Existing tests use ..Default::default() so no breakage. No new unit test yet - warning is tracing.

## Twin check
Checked sibling call sites: VUWorkerPool::spawn_vu and acquire_slot, no other place creates workers. collector.rs MetricsResult initializers use ..Default.

## Evidence
cargo check -p tropel-engine -p tropel-metrics -p tropel-report passes.

## Risk
Low. Adds fields to MetricsResult with Default fallback, adds startup tracing, extends summary json with two new fields - downstream dashboards may ignore.