### PR TITLE
fix(ci): add Default fallback for MetricsResult in reporters test [TR-505]

### DIFF
--- a/crates/tropel-report/tests/reporters.rs
+++ b/crates/tropel-report/tests/reporters.rs
@@ -140,6 +140,7 @@ fn fixture() -> MetricsResult {
         run_duration: std::time::Duration::from_secs(30),
         vu_init_failures: 0,
         script_failures: 0,
+        ..Default::default()
     };
     result.metrics.extend(result.per_url.clone());
     result


### PR DESCRIPTION
## What
CI failure on master after TR-505 added requested_vus/effective_vus to MetricsResult. The exhaustive initializer in crates/tropel-report/tests/reporters.rs:40 was missing the two new fields, causing error[E0063] on all platforms. Fix by adding ..Default::default().

## Task
CI fix for TR-505

## Acceptance
CI green.

## Tests
cargo check -p tropel-report --tests passes with CARGO_TARGET_DIR=C:/tropel-native-target

## Twin check
Checked other MetricsResult initializers: collector.rs:1281 fixed, stdout.rs and summary.rs already use ..Default::default() so no break.

## Evidence
cargo check passes.

## Risk
None. Test fixture now uses defaults for new fields (0).