### PR TITLE
fix(clippy): context shared Runtime doc and unused vars [CI]

### DIFF
--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -346,7 +346,7 @@ pub(crate) async fn create_vu_js_context(
         let _ = globals.set(
             "__tropel_native_sleep",
             rquickjs::function::Func::from(rquickjs::function::Async(
-                move |ctx: rquickjs::Ctx<'_>, ms: f64| {
+                move |_ctx: rquickjs::Ctx<'_>, ms: f64| {
                     let deadline_sleep = deadline_sleep.clone();
                     let force_stop_sleep = force_stop_sleep.clone();
                     async move {

--- a/crates/tropel-js/src/context.rs
+++ b/crates/tropel-js/src/context.rs
@@ -12,11 +12,12 @@ use std::time::Duration;
 
 static NEXT_CTX_ID: AtomicU64 = AtomicU64::new(1);
 
-/// TR-503 proper fix: per-thread shared Runtime for 92% heap win.
-/// Each worker thread reuses one Runtime (heap + atom table) across its VUs,
-/// and template Context globals are aliased into per-VU Contexts (57k vs 843k).
 thread_local! {
-    static SHARED_RT: RefCell<Option<Runtime>> = RefCell::new(None);
+    /// TR-503 proper fix: per-thread shared Runtime for 92% heap win.
+    /// Each worker thread reuses one Runtime (heap + atom table) across its VUs,
+    /// and template Context globals are aliased into per-VU Contexts (57k vs 843k).
+    #[allow(clippy::missing_const_for_thread_local)]
+    static SHARED_RT: RefCell<Option<Runtime>> = const { RefCell::new(None) };
 }
 
 /// A compiled script function persisted across `ctx.with()` calls.
@@ -277,7 +278,7 @@ impl JsContext {
         // per-VU heap significantly. Fall back to per-VU Runtime if thread-local
         // is unavailable (e.g., outside tokio).
         let rt = SHARED_RT.with(|cell| {
-            if let Some(rt) = cell.borrow().as_ref() {
+            if let Some(_rt) = cell.borrow().as_ref() {
                 // Clone the Runtime handle? Runtime is !Clone, so we can't clone.
                 // Instead, we return None to signal we need to create a new one
                 // but we can still share the heap via not dropping the old one.


### PR DESCRIPTION
## What
Fixes clippy -D warnings on master after both-ceilings PR:

- 	ropel-js/src/context.rs:15 unused doc comment on 	hread_local! macro invocation — moved doc inside macro, added #[allow(clippy::missing_const_for_thread_local)] on static inside.
- 	ropel-js/src/context.rs:280 unused variable t — prefixed _rt.
- 	ropel-engine/src/js_bootstrap.rs:349 unused variable ctx in async sleep — prefixed _ctx.

All with CARGO_TARGET_DIR=C:/tropel-native-target.

## Task
CI clippy green

## Tests
- cargo clippy -p tropel-js -- -D warnings passes
- cargo clippy -p tropel-engine -- -D warnings passes

## Twin check
Checked other 	hread_local and Func usages.

## Evidence
Local clippy passes.

## Risk
None.