### PR TITLE
docs(W1): verify 0 open, W1-A/B empty covered by W6 gate [W1]

### DIFF
--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -4,6 +4,8 @@
 
 Two asymmetric failure classes, and the duplicate implementations that keep regenerating both. Source: `TROPEL_MASTER_TODO.md` §W1-A/B/C, §W2, §W-R4.
 
+> **Verification 2026-08-28 — 0 open (58/58 checked) — green after `bb77c0e` (`d55dd96`).** Re-counted all checkboxes in this file: 58 × `[x]`, 0 × `[ ]`. No hidden unchecked items. `TROPEL_MASTER_TODO.md` §W1-A/B/C and §Release gate both ticked; `W6-release.md` gate is green and explicitly covers **W1-A empty** and **W1-B empty** via `bb77c0e` (`W6-merge-all` #457). No additional W1 fix required — this PR is verification-only and documents the W6 coverage.
+
 ---
 
 # Track A — Always-green: a broken thing reports success


### PR DESCRIPTION
## What
Verification-only PR for 	ropel_plan/tasks/W1-honest-numbers.md. Re-counted all checkboxes: 58 x [x], 0 x [ ]. No hidden unchecked items. TROPEL_MASTER_TODO.md §W1-A/B/C and §Release gate (§W1-A empty, §W1-B empty) are already green via b77c0e (W6-merge-all #457, commit d55dd96). This PR documents that **W1-A/B empty is now covered by the W6 release gate** and adds a verification banner to the task file. No code change beyond the doc banner.

## Task
W1

## Acceptance
- [x] 	ropel_plan/tasks/W1-honest-numbers.md has 0 open items — 58/58 checked, 0 unchecked (Select-String count)
- [x] No hidden open: grepped for \\- \[ \]\ in W1 file and in TROPEL_MASTER_TODO.md §W1 — zero in W1, remaining 199 unchecked are outside W1 (P1-P3 backlog)
- [x] W1-A empty and W1-B empty verified via W6 gate: TROPEL_MASTER_TODO.md:91-92 and 	ropel_plan/tasks/W6-release.md:9-10 both [x] with note \erified via TR-603/604, W6-release.md all checked in bb77c0e\
- [x] If any hidden open, fix them — none found, no fix required
- [x] Documentation of W6 coverage added to W1-honest-numbers.md header

## Tests
No new tests — verification-only. Existing suite used as regression guard:
- cargo test -p tropel-sdk --target-dir C:/tropel-native-target --lib — 28 passed
- cargo clippy -p tropel-sdk --target-dir C:/tropel-native-target -- -D warnings — pass (0 warnings)
Existing W1 regression tests remain green (e.g., 	est_cardinality_cap_http_req_failed_rate_covers_dropped_series, headline_http_req_failed_matches_summary_not_worst_series, ailing_abort_on_fail_threshold_stops_run_at_the_failing_request, anner_and_exit_code_agree_across_pass_fail_and_no_data, 	est_tag_scoped_avg_pools_across_series_not_worst_of, headline_http_req_duration_reinjected_into_handle_summary).

## Twin check
W1 twin is the duplicate-implementation shape (Track D). Checked sibling sites grepped for this verification:
- grep -r \	hresholds.rs\ totals/headline — thresholds read totals-repaired headline (TR-101)
- driver.rs vs 	rp.rs reserved-name guard — both now reject user emission into builtins (TR-102)
- pm.js/chai-shim.js hasOwnProperty guards (TR-103)
- No new sibling to check for doc-only change.

## Evidence
READ + EXEC
- File count: \Get-Content W1-honest-numbers.md | Select-String \[x\] | Measure\ = 58, unchecked = 0
- Master gate: \TROPEL_MASTER_TODO.md:91\ \No path where a broken thing reports success (W1-A empty) — verified via TR-603/604, W6-release.md all checked in bb77c0e\ [x]
- W6 gate: \W6-release.md:9-10\ both [x] covering W1-A/B
- Commands executed with \--target-dir C:/tropel-native-target\ per instructions: \cargo test -p tropel-sdk --lib\ (28 passed), \cargo clippy -p tropel-sdk -- -D warnings\ (pass)
- Commit \62e59f5\ on \	r/W1-honest-numbers\ documents verification in file header.

## Risk
Docs-only. No metric, threshold, or execution path touched. Risk is stale docs — mitigated by re-counting in PR and citing bb77c0e/d55dd96.