### PR TITLE
fix(report): summary names the engine's real VU cap, not a hardcoded 4096 [TR-505]

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -576,6 +576,12 @@ impl Engine {
                 .sum()
         };
         let effective = VUWorkerPool::effective_concurrency(peak_requested);
+        // Computed ONCE here and carried to the reporters on `MetricsResult`
+        // (`effective_vus_reason`). `tropel-report` sits below this crate and
+        // cannot read `VUWorkerPool::MAX_WORKERS`, so any cap named there is a
+        // second copy that goes stale — it already did, printing
+        // `MAX_WORKERS=4096` for the whole life of the 10 000 worker pool.
+        let mut effective_reason: Option<String> = None;
         if peak_requested > effective {
             let pids = VUWorkerPool::pids_limit();
             let reason = if pids
@@ -588,6 +594,7 @@ impl Engine {
             } else {
                 format!("MAX_WORKERS={}", VUWorkerPool::MAX_WORKERS)
             };
+            effective_reason = Some(reason.clone());
             tracing::warn!(
                 "TR-505: requested {} VUs but only {} effective ({}). Co-located VUs share a single-threaded runtime and block each other — throughput will be that of {} VUs.",
                 peak_requested, effective, reason, effective
@@ -799,6 +806,7 @@ impl Engine {
         // must not print "10 000 VUs" when it delivered 4 096.
         results.requested_vus = peak_requested;
         results.effective_vus = effective;
+        results.effective_vus_reason = effective_reason.clone();
 
         // Distributed workers (`tropel-agent`) skip ALL end-of-run output —
         // the controller owns the summary, handleSummary, and reporters —

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -725,6 +725,9 @@ impl MetricsCollector {
             out.vus_max = out.vus_max.max(r.vus_max);
             out.requested_vus = out.requested_vus.max(r.requested_vus);
             out.effective_vus = out.effective_vus.max(r.effective_vus);
+            if out.effective_vus_reason.is_none() {
+                out.effective_vus_reason = r.effective_vus_reason.clone();
+            }
         }
         // Recompute http_req_failed as weighted average if we have http_reqs
         // (each shard's http_req_failed is failed/total for that shard).
@@ -1450,6 +1453,7 @@ impl Aggregator {
             vus_max,
             requested_vus: 0,
             effective_vus: 0,
+            effective_vus_reason: None,
             // Backlog line 45 (P0): REAL mid-run elapsed — a ZERO here made
             // every rate/avg threshold compute 0.0 and abortOnFail killed
             // healthy runs (the engine stamps the final value post-run).
@@ -1903,6 +1907,17 @@ pub struct MetricsResult {
     /// pids.limit)`. When `requested > effective`, the run wrapped or was
     /// pids-capped and throughput is that of `effective`.
     pub effective_vus: u64,
+    /// Why `effective_vus < requested_vus` — e.g. `MAX_WORKERS=10000` or
+    /// `cgroup pids.max=4096`. Stamped by the engine, which is the only place
+    /// that knows the pool's real ceiling.
+    ///
+    /// Reporters MUST render this string rather than naming a cap themselves:
+    /// `tropel-report` sits below `tropel-engine` and cannot read
+    /// `VUWorkerPool::MAX_WORKERS`, so a hand-written constant there silently
+    /// goes stale the next time the ceiling moves. It already did — the
+    /// summary printed `MAX_WORKERS=4096` for the whole life of the 10 000
+    /// worker pool.
+    pub effective_vus_reason: Option<String>,
     /// Wall-clock duration of the run (stamped by the engine after the run
     /// finishes). Reporters use it for k6-style per-second rates
     /// (`http_reqs: 136 13.56/s`) and `handleSummary` state.
@@ -1964,6 +1979,7 @@ impl Default for MetricsResult {
             vus_max: 0,
             requested_vus: 0,
             effective_vus: 0,
+            effective_vus_reason: None,
             run_duration: Duration::ZERO,
             summary_trend_stats: k6_default_trend_stats(),
             effective_thresholds: std::collections::HashMap::new(),

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -1099,6 +1099,7 @@ mod tests {
             run_duration: Duration::from_secs(10),
             requested_vus: 0,
             effective_vus: 0,
+            effective_vus_reason: None,
             metrics: vec![
                 trend_series_with_hist(
                     "http_req_waiting{url=/fast}",

--- a/crates/tropel-report/src/stdout.rs
+++ b/crates/tropel-report/src/stdout.rs
@@ -91,11 +91,18 @@ impl StdoutReporter {
             ("Dropped", result.dropped_iterations.to_string()),
         ];
         if result.requested_vus > 0 && result.requested_vus != result.effective_vus {
+            // Render the engine's reason verbatim. Naming a cap here would be a
+            // SECOND copy of a constant this crate cannot see — that copy read
+            // `MAX_WORKERS=4096` for the whole life of the 10 000 worker pool.
+            let reason = result
+                .effective_vus_reason
+                .as_deref()
+                .unwrap_or("worker pool capped");
             exec_rows.push((
                 "Requested VUs",
                 format!(
-                    "{} → {} effective (MAX_WORKERS=4096, capped)",
-                    result.requested_vus, result.effective_vus
+                    "{} → {} effective ({}, capped)",
+                    result.requested_vus, result.effective_vus, reason
                 ),
             ));
         }
@@ -673,6 +680,43 @@ mod tests {
         assert!(
             out.contains("NO DATA"),
             "no-data threshold renders distinctly: {out}"
+        );
+    }
+
+    /// The cap named in the summary must be the pool's REAL ceiling, carried
+    /// from the engine — not a constant re-typed in this crate.
+    ///
+    /// Fails on the pre-fix code: `stdout.rs` hardcoded
+    /// `"MAX_WORKERS=4096, capped"`, so a run capped by the 10 000 worker pool
+    /// (or by a cgroup `pids.max`) printed a number that had not been true
+    /// since the pool was raised. This asserts the printed line, not the field.
+    #[test]
+    fn requested_vu_line_names_the_engines_cap_not_a_hardcoded_one() {
+        let mut capped = result_with();
+        capped.requested_vus = 15_000;
+        capped.effective_vus = 10_000;
+        capped.effective_vus_reason = Some("MAX_WORKERS=10000".to_string());
+        let out = StdoutReporter.render(&capped);
+        assert!(
+            out.contains("15000 → 10000 effective (MAX_WORKERS=10000, capped)"),
+            "summary must print the engine's cap verbatim, got:\n{out}"
+        );
+        assert!(
+            !out.contains("4096"),
+            "summary must not name a cap this crate cannot see:\n{out}"
+        );
+
+        // A cgroup limit is a different reason for the same gap; the reporter
+        // must render whichever the engine determined, with no cap logic here.
+        let mut pids = result_with();
+        pids.requested_vus = 8_000;
+        pids.effective_vus = 4_096;
+        pids.effective_vus_reason =
+            Some("cgroup pids.max=4096 (Docker --pids-limit / Kubernetes pids.max)".to_string());
+        let out = StdoutReporter.render(&pids);
+        assert!(
+            out.contains("cgroup pids.max=4096"),
+            "a pids-capped run must say so, not blame MAX_WORKERS:\n{out}"
         );
     }
 }


### PR DESCRIPTION
## What

`crates/tropel-report/src/stdout.rs` printed the string `MAX_WORKERS=4096, capped` as a literal. `VUWorkerPool::MAX_WORKERS` is `10_000` (`worker.rs:339`) and has been since the W5 cap change — the `worker.rs` *comment* was corrected at the time, the printed string was not. Every capped run therefore reported a ceiling that had not been true for the life of the 10 000 worker pool, and a run capped by a cgroup `pids.max` blamed `MAX_WORKERS` instead.

The root cause is structural, not a typo: `tropel-report` sits below `tropel-engine` in the graph and cannot read `VUWorkerPool::MAX_WORKERS`, so any cap named in the reporter is a second copy of a constant it cannot see. The engine already computes the correct reason (`MAX_WORKERS=10000` or `cgroup pids.max=N`) for its startup warning and then threw it away. This carries that value to the reporter on `MetricsResult::effective_vus_reason` and renders it verbatim.

## Task

TR-505 — "Exceeding the worker cap is a visible warning at startup, naming the number you will actually get." The startup warning was right; the summary was not.

## Acceptance

- [x] The summary names the pool's real ceiling
- [x] A `pids.max`-capped run says so rather than blaming `MAX_WORKERS`
- [x] The reporter contains no cap constant of its own — invariant #4, one implementation per behaviour

## Tests

`stdout::tests::requested_vu_line_names_the_engines_cap_not_a_hardcoded_one` asserts the **printed line**, not the field:

- a 15 000 → 10 000 run prints `MAX_WORKERS=10000` and the output contains no `4096` anywhere
- an 8 000 → 4 096 cgroup-capped run prints `cgroup pids.max=4096`

Both assertions fail on pre-fix code: the old renderer emitted the literal `4096` unconditionally, so the first case printed the wrong number and the second attributed the cap to the wrong subsystem.

## Twin check

Grepped every `MAX_WORKERS` occurrence in the tree:

- `worker.rs:339` — the definition, `10_000`. Correct.
- `worker.rs:24,236,400,409` — comments and the pool's own warning, all read the constant. Correct.
- `engine.rs:550,582,589,597` — the startup warning, reads the constant. Correct.
- `collector.rs:1902` — doc comment only.
- `scheduler.rs:7` — doc comment only.
- `stdout.rs:97` — **the only hardcoded copy.** Fixed here.

`summary.rs` emits `vusRequested`/`vusEffective` as numbers with no cap string, so it was never affected.

## Evidence

READ + EXEC. `cargo test -p tropel-report -p tropel-metrics -p tropel-engine` green; `cargo clippy --all-targets -- -D warnings` clean on the three touched crates; `cargo fmt --all` applied. The existing `stdout_summary_snapshot` is unchanged — the new field is `None` on the uncapped path, which is every run that does not hit the ceiling.

## Risk

`MetricsResult` gains one `Option<String>` field. It is `Serialize`/`Deserialize`, so the JSON summary grows an optional key; the shard-merge path takes the first non-`None` reason. All three construction sites (`results()`, `Default`, the thresholds test helper) are updated. No metric contract changes — this touches presentation only.