### PR TITLE
test(engine): enumerate crates/inputs for adapter reachability [TR-007]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,7 +4732,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "simd-json",
  "thiserror 2.0.19",
  "wit-parser 0.255.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "simd-json",
  "thiserror 2.0.19",
  "wit-parser 0.255.0",

--- a/crates/tropel-engine/src/builtins.rs
+++ b/crates/tropel-engine/src/builtins.rs
@@ -130,16 +130,103 @@ mod tests {
         );
     }
 
+    /// Adapters that legitimately have no static `inventory::submit!`, with the
+    /// reason. Anything not listed here MUST be reachable from the CLI.
+    ///
+    /// Data rather than an `if`, so adding an exemption is a visible diff that
+    /// has to carry a justification.
+    const REGISTRATION_EXEMPT: &[(&str, &str)] = &[(
+        "tropel-input-subprocess",
+        "factory-only: takes a runtime --subprocess-adapter <cmd> argument, so it cannot \
+         be a compile-time registration. A static placeholder would be probed on every \
+         auto-detect and spawn a bogus `echo` (see its lib.rs Registration section).",
+    )];
+
+    /// TR-007: every adapter shipped in this workspace must be reachable from
+    /// the CLI. A new adapter that is never force-linked (or never wired into
+    /// `link_builtins`) registers in `inventory` but gets dead-stripped from
+    /// the binary, so `tropel run file` reports "no input adapter recognized".
+    /// This test walks the real `collect_inventory()` path the CLI uses.
+    ///
+    /// It ENUMERATES `crates/inputs/` rather than asserting a hardcoded list.
+    /// The criterion is "otherwise the next one ships unwired too", and a
+    /// hardcoded list cannot deliver that — the next adapter is by definition
+    /// not in it, so it passes silently. bru and insomnia shipped unreachable
+    /// for exactly this reason: they were in the wasm dispatch table and not
+    /// the native one, and nothing compared the two populations.
     #[test]
-    fn every_builtin_adapter_is_reachable_from_the_cli() {
+    fn every_adapter_in_the_workspace_is_reachable_from_the_cli() {
         register_builtins();
         let registry = ExtensionRegistry::new();
         let inputs = registry.list_inputs();
-        for expected in ["postman", "har", "openapi", "k6", "http", "bru", "insomnia"] {
+
+        let inputs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root")
+            .join("crates/inputs");
+
+        let mut unreachable = Vec::new();
+        let mut checked = 0usize;
+        for entry in std::fs::read_dir(&inputs_dir)
+            .expect("crates/inputs must exist")
+            .flatten()
+        {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let crate_name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if REGISTRATION_EXEMPT.iter().any(|(n, _)| *n == crate_name) {
+                continue;
+            }
+            // The adapter id is what `list_inputs()` reports; by convention it
+            // is the crate name minus the `tropel-input-` prefix.
+            let Some(id) = crate_name.strip_prefix("tropel-input-") else {
+                continue;
+            };
+            checked += 1;
+            if !inputs.iter().any(|got| got == id) {
+                unreachable.push(id.to_string());
+            }
+        }
+
+        assert!(
+            checked >= 7,
+            "expected to enumerate at least the 7 known adapters, found {checked} — the \
+             directory layout changed and this test is no longer looking at anything \
+             (that is how a reachability test rots into a no-op)"
+        );
+        assert!(
+            unreachable.is_empty(),
+            "these adapters exist in crates/inputs but are NOT reachable from the CLI: \
+             {unreachable:?}. Add each to builtins::link_builtins(), or add an entry to \
+             REGISTRATION_EXEMPT with the reason it cannot be statically registered."
+        );
+    }
+
+    /// The exemption list must not become a way to hide a real gap: every crate
+    /// named in it has to still exist, and carry a real justification.
+    #[test]
+    fn registration_exemptions_still_exist_and_carry_a_reason() {
+        let inputs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root")
+            .join("crates/inputs");
+        for (crate_name, reason) in REGISTRATION_EXEMPT {
             assert!(
-                inputs.iter().any(|id| id == expected),
-                "adapter '{expected}' is not reachable from the CLI — it must be added to \
-                 builtins::link_builtins() or the binary dead-strips its registration"
+                inputs_dir.join(crate_name).is_dir(),
+                "REGISTRATION_EXEMPT names '{crate_name}', which no longer exists — remove \
+                 the stale exemption"
+            );
+            assert!(
+                reason.len() > 40,
+                "exemption for '{crate_name}' needs a real justification, not a stub"
             );
         }
     }


### PR DESCRIPTION
## What

TR-007's last criterion reads:

> A test asserts every adapter in the workspace is reachable from the CLI — **otherwise the next one ships unwired too**

The test written for it asserted a hardcoded list:

```rust
for expected in ["postman", "har", "openapi", "k6", "http", "bru", "insomnia"] {
```

That cannot deliver the criterion. The next adapter is, by definition, not in the list — so it passes silently. The guarantee is exactly the one the test does not provide.

This is not hypothetical: it is how bru and insomnia shipped in the first place. They were registered in the wasm dispatch table and absent from the native one, and nothing compared the two populations.

Now enumerates `crates/inputs/` and fails on any adapter missing from `link_builtins()`.

## Task

TR-007.

## Correction to my earlier review

I initially reported `tropel-input-subprocess` as a second unwired adapter. **That was wrong**, and I am not "fixing" it. It has no `inventory::submit!` at all and is deliberately factory-only — it takes a runtime `--subprocess-adapter <cmd>` argument, and its own docs explain that a static placeholder *"would be probed during content auto-detection on every run (spawning a bogus `echo`) and listed as a real format"* (`tropel-input-subprocess/src/lib.rs:23-31`).

So it belongs in the enumerating test as an **explicit, reasoned exemption**, which is what `REGISTRATION_EXEMPT` is. Kept as data rather than an `if` so that adding an exemption is a visible diff carrying a justification, rather than a quiet `continue`.

## Acceptance

- [x] The test enumerates rather than hardcodes
- [x] A new adapter that is never force-linked fails it
- [x] The one legitimate exemption is recorded with its reason
- [x] The exemption list cannot rot

## Tests

- `every_adapter_in_the_workspace_is_reachable_from_the_cli` — walks `crates/inputs/`, maps each `tropel-input-<id>` to the id `list_inputs()` reports, and asserts reachability through the real `collect_inventory()` path the CLI uses.
- `registration_exemptions_still_exist_and_carry_a_reason` — every exempted crate must still exist and carry a non-stub justification, so the exemption list cannot become a way to hide a real gap.
- A `checked >= 7` floor guards the enumeration itself. If the directory layout moves, the test fails loudly instead of silently iterating an empty directory — which is how a reachability test rots into a no-op, the same failure one level up.

**Negative control, run both ways.** Removing `Box::new(tropel_input_bru::BruInputAdapter)` from `link_builtins()`:

```
these adapters exist in crates/inputs but are NOT reachable from the CLI: ["bru"].
Add each to builtins::link_builtins(), or add an entry to REGISTRATION_EXEMPT
with the reason it cannot be statically registered.
test result: FAILED. 0 passed; 1 failed
```

The **old** test passed that same mutation, because `bru` was still in its hardcoded array. That is the defect this PR closes.

## Twin check

The register calls out the wasm/native inversion as the original shape, so I checked the sibling dispatch table: `tropel-input-wasm/src/lib.rs:15-21` deliberately exposes only the collection-import adapters (postman/insomnia/har/bru/openapi) and documents that k6/http/subprocess are impossible in a browser. That is a documented, intentional difference rather than drift, so I have not tried to make the two tables identical — an enumerating test over the wasm side would need its own exemption set for a different reason, and is worth doing separately.

`extensions/` (grpc, websocket, prometheus) are force-linked as `Protocol`s in the same `link_builtins()` and are not covered by this enumeration. Noted, not fixed here — protocols fail differently (a `grpc://` URL fails to dispatch rather than an input format being unrecognised), so they want their own assertion.

## Evidence

READ + EXEC. `cargo test -p tropel-engine --lib` 53 passed / 0 failed. `cargo clippy -p tropel-engine --all-targets -- -D warnings` clean. `cargo fmt --all` applied. Negative control above run against a modified `link_builtins()` and reverted.

## Risk

Test-only change; no production code touched. The test reads the source tree at runtime via `CARGO_MANIFEST_DIR`, so it depends on the directory layout — which is precisely what the `checked >= 7` floor guards, and it fails loudly rather than silently if `crates/inputs/` ever moves.