### PR TITLE
fix(gitignore): scope the *.json rule instead of negating it eight times [TR-008]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,32 @@ jobs:
             }
             console.log("ok: all packages/* have committed manifests and are workspace members");
           '
+      # TR-008: the rule that ate the manifests must not come back. A blanket
+      # `*.json` / `*.csv` ignore is what consumed three package.json files
+      # across three incidents, and every fix added another `!` negation
+      # instead of scoping the rule — so the next manifest, and every .json
+      # test fixture, was ignored by default. Assert the shape, not just the
+      # symptom: checking that today's manifests exist (below) passes right up
+      # until someone adds a new package.
+      - name: .gitignore must not blanket-ignore source extensions (TR-008)
+        run: |
+          set -euo pipefail
+          if grep -nE '^\*\.(json|csv|toml|yaml|yml|rs|js|ts)$' .gitignore; then
+            echo "FAIL: .gitignore blanket-ignores a source extension (above)." >&2
+            echo "      Scope it to where output lands (/results/, /output/, named files)." >&2
+            echo "      This rule ate packages/input-wasm/package.json and broke" >&2
+            echo "      knockport's install from a clean clone." >&2
+            exit 1
+          fi
+          echo "ok: no blanket source-extension ignores"
+          # And nothing currently tracked may be ignored — a belt-and-braces
+          # check that a future negation-based patch cannot mask.
+          if git ls-files | git check-ignore --stdin --no-index | grep .; then
+            echo "FAIL: the files above are tracked AND ignored — the ignore rules disagree with the index" >&2
+            exit 1
+          fi
+          echo "ok: no tracked file is ignored"
+
       # TR-008: a clean clone must run `npm install` at the root with no
       # missing-manifest error (the workspace resolves every packages/* dir).
       # Deliberately after the manifest assert, so a failure here names the

--- a/.gitignore
+++ b/.gitignore
@@ -28,27 +28,33 @@ Desktop.ini
 ehthumbs.db
 $RECYCLE.BIN/
 
-# ── Tropel output / reports ───────────────────────────────────
-*.csv
-*.json
-# graphify knowledge-graph output (generated, not source)
+# ── Tropel run output / reports ───────────────────────────────
+#
+# SCOPED, not a blanket `*.json` (TR-008).
+#
+# The blanket rule ate three `package.json` files across three separate
+# incidents — `packages/input-wasm/package.json` was the third, and it broke
+# knockport's `pnpm install` from a clean clone. Each incident was patched by
+# adding another `!` negation rather than fixing the rule, so it accumulated
+# eight of them and still could not be trusted: the next manifest, and every
+# `.json` test fixture, was ignored by default. `crates/inputs/tropel-input-bru`
+# and `-insomnia` have no fixture files at all, which is why TR-005/TR-006
+# still test against hand-written inline JSON — the gap that let them ship
+# broken.
+#
+# A stray output file left untracked shows up in `git status`. A silently
+# ignored source file does not. Ignore the places output actually lands, and
+# nothing else.
+/results/
+/output/
 /graphify-out/
-# The e2e smoke fixture is committed despite the *.json rule above.
-!.github/ci/www/ok.json
-!examples/collections/
-# npm package manifests must be TRACKED despite the *.json rule.
-# TR-401: exec-wasm was renamed to runtime-wasm; dead lines removed.
-!packages/runtime-wasm/package.json
-!packages/runtime-wasm/tsconfig.json
-!packages/shims/package.json
-!packages/core-wasm/package.json
-!packages/input-wasm/package.json
-# W2 #186: the ROOT npm workspace manifest must be tracked — CI's npm install
-# resolves @tropel/shims to the local packages/ sibling only via this file.
-!/package.json
-!examples/openapi/working_api.json
-results/
-output/
+# `--summary-export` / `-o` / `-r csv` written into the working tree. Runs in
+# CI use /tmp; these cover local runs without hiding sources.
+/*.csv
+/summary-export.json
+/tropel-summary.json
+/tropel-report*.json
+/k6-summary.json
 
 # ── Environment & secrets ─────────────────────────────────────
 .env

--- a/crates/inputs/tropel-input-bru/tests/fixtures/README.md
+++ b/crates/inputs/tropel-input-bru/tests/fixtures/README.md
@@ -1,0 +1,15 @@
+# Bruno fixtures
+
+**These must be files produced by Bruno's own exporter, not hand-written JSON.**
+
+TR-005's acceptance criterion says so explicitly, and names the reason: the
+adapter matched only `type: "http-request"`, while Bruno's exporter rewrites
+that to `"http"` (`transformItem` in `bruno-app/src/utils/collections/export.js`).
+Every test used inline JSON that spelled it the internal way, so **no real
+export would have parsed** and the whole suite was green.
+
+Adding a fixture here was also blocked until TR-008: the root `.gitignore`
+carried a blanket `*.json`, so any fixture dropped in this directory was
+silently untracked.
+
+When adding one: export from Bruno, commit it verbatim, do not tidy it.

--- a/crates/inputs/tropel-input-insomnia/tests/fixtures/README.md
+++ b/crates/inputs/tropel-input-insomnia/tests/fixtures/README.md
@@ -1,0 +1,16 @@
+# Insomnia fixtures
+
+**These must be workspaces exported by Insomnia, and at least one must be
+exported AFTER dragging items to reorder them.**
+
+TR-006's acceptance criterion says so, and names the reason: `metaSortKey` was
+typed `Option<i64>`, while Insomnia assigns sort keys by **midpoint averaging**
+— they go fractional the first time a user drags anything, and the whole
+export then fails to deserialize. A hand-written fixture with integer sort
+keys can never catch that; only a genuinely reordered export can.
+
+Adding a fixture here was also blocked until TR-008: the root `.gitignore`
+carried a blanket `*.json`, so any fixture dropped in this directory was
+silently untracked.
+
+When adding one: export from Insomnia, commit it verbatim, do not tidy it.

--- a/tropel_plan/tasks/W0-stop-the-bleeding.md
+++ b/tropel_plan/tasks/W0-stop-the-bleeding.md
@@ -91,7 +91,7 @@ These are one story: the newest adapters do not work, and the npm side does not 
 **Effort:** M · **Blocked by:** none
 
 - [x] `lib.rs:302` matches `Some("http-request")`; Bruno's exporter rewrites the type, so no real export matches
-- [x] Test fixtures are **exports produced by Bruno**, not hand-written JSON — this is exactly the gap that let it ship
+- [ ] Test fixtures are **exports produced by Bruno**, not hand-written JSON — this is exactly the gap that let it ship — **NOT DONE.** `crates/inputs/tropel-input-bru/` contains only `Cargo.toml` and `src/lib.rs`; every test uses inline JSON. Two things were in the way and one is now cleared: the root `.gitignore` carried a blanket `*.json`, so a fixture dropped in the crate was silently untracked (fixed in TR-008). `tests/fixtures/` now exists with the requirement recorded — **someone with Bruno installed still has to export one and commit it verbatim**
 - [x] Bruno path params are preserved (`:345` currently keeps only `param_type == "query"`)
 - [x] Duplicate query keys survive — `merge_pairs` joins with `", "`, collapsing `[{ids,1},{ids,2}]` into one
 - [x] A request that fails to convert is **reported**, not skipped: `if let Ok(child)` currently drops bad requests silently, contradicting the adapter's own docs
@@ -100,7 +100,7 @@ These are one story: the newest adapters do not work, and the npm side does not 
 **Effort:** S · **Blocked by:** none
 
 - [x] `lib.rs:71` types `metaSortKey` as `Option<i64>`; Insomnia assigns sort keys by **midpoint averaging**, so they go fractional the first time a user drags anything. Type it as a float
-- [x] Fixture: a workspace exported *after* reordering
+- [ ] Fixture: a workspace exported *after* reordering — **NOT DONE**, same story as TR-005. A hand-written fixture with integer `metaSortKey`s cannot catch this: the bug only appears once Insomnia's midpoint averaging makes them fractional, which only a genuinely drag-reordered export produces. `tests/fixtures/` now exists and is no longer gitignored
 - [x] Same silent-drop and duplicate-query-key fixes as `TR-005`
 
 ## TR-007 · Bruno and Insomnia are compiled out of the CLI entirely
@@ -118,9 +118,9 @@ These are one story: the newest adapters do not work, and the npm side does not 
 Root `.gitignore:33` is a blanket `*.json`. This is its **third** victim — the file's own comments record the prior two. Four reproduced consequences: the directory is not a workspace member (npm silently skips manifest-less dirs); its own `scripts/build.sh:50` fails `npm pack --dry-run` with `ENOENT` *after* producing `pkg/`; the README's `npm run build` reports `Missing script`; and **knockport's `file:` dep cannot resolve**, so `pnpm install` fails there.
 
 ### Acceptance criteria
-- [x] **Scope the ignore rule** — do not add a fifth exception
+- [x] **Scope the ignore rule** — do not add a fifth exception — **now actually done.** The blanket `*.json` survived the original fix and the exception count had grown to **eight**; the criterion said not to add a fifth. The rule is now scoped to where run output lands (`/results/`, `/output/`, named report files) and every negation is gone
 - [x] Delete the two dead `!packages/exec-wasm/*` lines left from the rename to `runtime-wasm`
-- [x] A CI check asserts every `packages/*` directory has a committed manifest and is a workspace member
+- [x] A CI check asserts every `packages/*` directory has a committed manifest and is a workspace member — plus a check that `.gitignore` carries no blanket source-extension rule, since the manifest check passes right up until someone adds a new package
 - [x] A clean clone runs `npm install` at the root with no missing-manifest error
 
 ## TR-009 · `@tropel/core-wasm` cannot be imported without a prior Rust build

--- a/tropel_plan/tasks/W1-honest-numbers.md
+++ b/tropel_plan/tasks/W1-honest-numbers.md
@@ -150,7 +150,7 @@ Every item here is a wrong number **caused by** having two implementations. Fixi
 ## TR-134 · The npm workspace resolves `@tropel/shims` locally
 **Effort:** S · **Blocked by:** TR-008
 
-- [x] With no root `package.json` workspace entry and no `file:` dep, `@tropel/shims` resolves **from npmjs.org** — the published copy, not the tree you are editing — **fixed**: root `package.json` declares `"workspaces": ["packages/*"]`; `package-lock.json` links `@tropel/shims` to `packages/shims`
+- [x] With no root `package.json` workspace entry and no `file:` dep, `@tropel/shims` resolves **from npmjs.org** — the published copy, not the tree you are editing — **fixed**: root `package.json` declares `"workspaces": ["packages/*"]`, which is what makes `npm install` resolve the local sibling. Note the `package-lock.json` half of this claim was never true: the lockfile is **not tracked** (the blanket `*.json` ate it too), so a clean clone has none. The workspaces field is doing the work on its own
 - [x] Every package in `packages/` is a workspace member (asserted by the `TR-008` check)
 
 ## TR-135 · Sweep the seven lying comments and the four bug-pinning tests


### PR DESCRIPTION
## What

TR-008's first acceptance criterion:

> - [x] **Scope the ignore rule** — do not add a fifth exception

It is ticked. The blanket `*.json` was never removed, and the exception count had grown to **eight**:

```
*.json
!.github/ci/www/ok.json
!examples/collections/
!packages/runtime-wasm/package.json
!packages/runtime-wasm/tsconfig.json
!packages/shims/package.json
!packages/core-wasm/package.json
!packages/input-wasm/package.json
!/package.json
!examples/openapi/working_api.json
```

That rule ate three `package.json` files across three separate incidents — the third, `packages/input-wasm/package.json`, broke knockport's `pnpm install` from a clean clone. Each incident was patched by adding another negation rather than scoping the rule, so the next manifest, and every `.json` test fixture, remained ignored by default.

## This is still causing damage today

Two live consequences, both traceable to the rule rather than to the code:

1. **`crates/inputs/tropel-input-bru/` and `-insomnia/` contain no fixture files at all** — just `Cargo.toml` and `src/lib.rs`. Every test uses hand-written inline JSON. TR-005's criterion says *"Test fixtures are exports produced by Bruno, not hand-written JSON — **this is exactly the gap that let it ship**"*, and it is ticked while being unmet. A fixture dropped into either crate was silently untracked.

2. **`package-lock.json` is not tracked**, so TR-134's *"`package-lock.json` links `@tropel/shims` to `packages/shims`"* is false from a clean clone. The `"workspaces"` field is doing that work on its own — which is fine, but the claim as written is wrong.

## Acceptance

- [x] Rule scoped to where output lands (`/results/`, `/output/`, named report files)
- [x] Negations: **8 → 0**
- [x] No tracked file becomes ignored
- [x] A stray `summary-export.json` is still ignored
- [x] A new `packages/*/package.json` is **not** ignored
- [x] `crates/inputs/*/tests/fixtures/` can now hold a committed fixture

## Verification

```
$ git ls-files | git check-ignore --stdin --no-index      # nothing tracked is ignored
(empty)

$ git check-ignore -v summary-export.json                  # output still ignored
.gitignore:54:/summary-export.json	summary-export.json

$ git check-ignore -v packages/zzz-probe/package.json      # the actual bug
NOT IGNORED — correct
```

On the pre-fix rule that last probe was ignored, which is the defect in one line.

## Tests

CI gains a check on the **shape**, not the symptom. The existing check asserts today's `packages/*` all have committed manifests — which passes right up until someone adds a new package, so it cannot catch the recurrence. The new one rejects any blanket source-extension ignore, and separately asserts no tracked file is ignored (which a future negation-based patch cannot mask).

Both fail on the pre-fix `.gitignore`: `grep -E '^\*\.(json|csv|...)$'` matches `*.json` and `*.csv`.

## What this does NOT fix

The fixtures themselves. I created `tests/fixtures/` in both crates with the requirement and rationale recorded, and **un-ticked** TR-005's and TR-006's fixture criteria rather than leaving them falsely closed. I cannot produce an authentic Bruno export or a drag-reordered Insomnia workspace — and a hand-written file would not satisfy the criterion anyway, which is the whole point:

- Bruno's exporter rewrites `type: "http-request"` → `"http"`, so a fixture written by hand in the internal spelling proves nothing.
- Insomnia's `metaSortKey` only goes fractional after a real drag-reorder; integer sort keys can never reproduce the bug.

Someone with those tools installed needs to export one and commit it verbatim. The blocker is now gone.

## Twin check

The register calls the blanket ignore a repeat offender, so I checked for siblings:

- `*.csv` sat directly above `*.json` with the same failure mode and no negations yet — scoped to `/*.csv` here before it claims its first victim.
- `packages/*/.gitignore` (four files) — checked all four; they ignore `pkg/`, `node_modules/`, build output. Correctly scoped, no blanket extension rules.
- `deny.toml`, `rust-toolchain.toml`, `Cargo.lock` — all tracked and unaffected.

## Evidence

READ + EXEC on a clean clone at `66b22cb`. `git check-ignore` probes above run both before and after. `git status --ignored` shows no `.json` currently hidden, so nothing new becomes tracked by this change.

## Risk

Files matching the removed blanket rule but not the new scoped rules will now show as untracked in `git status` — a local `out.json` from an ad-hoc run, say. That is the intended trade: a visible untracked file is recoverable, a silently ignored source file is not, and this rule has cost three manifests and two test-fixture directories so far.

CI writes all its summary exports to `/tmp`, so no job is affected.