### PR TITLE
test(web): put the signing schemes in the differential corpus [TR-408][TR-409]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "simd-json",
  "thiserror 2.0.19",
  "wit-parser 0.255.0",

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -790,6 +790,73 @@ fn native_and_wasm_agree_over_request_corpus() {
             });
             r
         },
+        // TR-408/TR-409: the SIGNING schemes. These are the ones where a
+        // byte difference between native and wasm is a 403 that costs a day
+        // to find — which is the stated reason signing lives in Rust at all
+        // rather than being reimplemented in TypeScript. The corpus covered
+        // bearer/basic/apikey/digest, i.e. the four schemes where the header
+        // is a near-verbatim copy of the credential, and omitted every scheme
+        // that actually computes a signature over the request.
+        //
+        // OAuth1 and SigV4 sign the method, URL, query string and body, so
+        // any divergence in how the two legs canonicalise a request shows up
+        // here and nowhere else.
+        //
+        // The credentials are deliberately synthetic. This harness compares
+        // the two legs against EACH OTHER, so the key bytes are arbitrary —
+        // what matters is that both sides sign the same input. Correctness
+        // against published vectors (RFC 5849, RFC 7616, the AWS test suite)
+        // is `tropel-auth/src/signers.rs`'s job, and that is where the real
+        // vectors belong.
+        {
+            let mut r = base("https://fixture.test/oauth1");
+            r.method = Method::POST;
+            r.query_params.insert("b5".into(), "=%3D".into());
+            r.query_params.insert("a3".into(), "a".into());
+            r.body = Some(Body::UrlEncoded(vec![("c2".into(), "".into())]));
+            r.auth = Some(AuthConfig::OAuth1 {
+                consumer_key: "fixture-consumer-key".into(),
+                consumer_secret: "fixture-consumer-secret".into(),
+                token: Some("fixture-token".into()),
+                token_secret: Some("fixture-token-secret".into()),
+                signature_method: Some("HMAC-SHA1".into()),
+            });
+            r
+        },
+        {
+            // Consecutive slashes and an unencoded query value: the SigV4
+            // canonical-URI and canonical-query rules are where the two legs
+            // are most likely to disagree (TR-603's slash-normalisation bug
+            // lived exactly here).
+            let mut r = base("https://fixture.test//prod//users?x=1%20 2&a=b");
+            r.auth = Some(AuthConfig::AwsSigV4 {
+                access_key: "fixture-access-key".into(),
+                secret_key: "fixture-secret-key".into(),
+                region: Some("us-east-1".into()),
+                service: Some("service".into()),
+                session_token: None,
+            });
+            r
+        },
+        {
+            let mut r = base("https://fixture.test/hawk");
+            r.method = Method::POST;
+            r.body = Some(Body::Raw("Thank you for flying Hawk".into()));
+            r.auth = Some(AuthConfig::Hawk {
+                auth_id: "fixture-hawk-id".into(),
+                auth_key: "fixture-hawk-key".into(),
+                algorithm: Some("sha256".into()),
+            });
+            r
+        },
+        {
+            let mut r = base("https://fixture.test/oauth2");
+            r.auth = Some(AuthConfig::OAuth2 {
+                access_token: "fixture-access-token".into(),
+                token_type: Some("Bearer".into()),
+            });
+            r
+        },
         // Error statuses and redirects must produce IDENTICAL outcomes on
         // both legs (the fixture varies by path).
         base("https://fixture.test/404"),
@@ -868,6 +935,13 @@ fn native_and_wasm_agree_over_request_corpus() {
 #[test]
 fn native_and_wasm_agree_over_har_fixture() {
     let Some(wasm_path) = wasm_artifact_path() else {
+        // TR-408: the harness must be able to fail. Three of its tests —
+        // this one included — skipped even under TROPEL_REQUIRE_WASM=1,
+        // while the two corpus tests honoured it. So the fixture legs of
+        // "one engine, proven" were decoration in CI as much as locally.
+        if std::env::var("TROPEL_REQUIRE_WASM").as_deref() == Ok("1") {
+            panic!("F3 HAR fixture: tropel_web.wasm not found but TROPEL_REQUIRE_WASM=1");
+        }
         eprintln!("SKIP native_vs_wasm HAR fixture: tropel_web.wasm not built");
         return;
     };
@@ -911,6 +985,13 @@ fn native_and_wasm_agree_over_har_fixture() {
 #[test]
 fn native_and_wasm_agree_over_openapi_fixture() {
     let Some(wasm_path) = wasm_artifact_path() else {
+        // TR-408: the harness must be able to fail. Three of its tests —
+        // this one included — skipped even under TROPEL_REQUIRE_WASM=1,
+        // while the two corpus tests honoured it. So the fixture legs of
+        // "one engine, proven" were decoration in CI as much as locally.
+        if std::env::var("TROPEL_REQUIRE_WASM").as_deref() == Ok("1") {
+            panic!("F3 OpenAPI fixture: tropel_web.wasm not found but TROPEL_REQUIRE_WASM=1");
+        }
         eprintln!("SKIP native_vs_wasm OpenAPI fixture: tropel_web.wasm not built");
         return;
     };
@@ -950,6 +1031,13 @@ fn native_and_wasm_agree_over_openapi_fixture() {
 #[test]
 fn native_and_wasm_agree_over_postman_fixture() {
     let Some(wasm_path) = wasm_artifact_path() else {
+        // TR-408: the harness must be able to fail. Three of its tests —
+        // this one included — skipped even under TROPEL_REQUIRE_WASM=1,
+        // while the two corpus tests honoured it. So the fixture legs of
+        // "one engine, proven" were decoration in CI as much as locally.
+        if std::env::var("TROPEL_REQUIRE_WASM").as_deref() == Ok("1") {
+            panic!("F3 Postman fixture: tropel_web.wasm not found but TROPEL_REQUIRE_WASM=1");
+        }
         eprintln!("SKIP native_vs_wasm Postman fixture: tropel_web.wasm not built");
         return;
     };

--- a/crates/tropel-web/tests/native_vs_wasm_divergences.md
+++ b/crates/tropel-web/tests/native_vs_wasm_divergences.md
@@ -11,9 +11,23 @@ compiled two ways (host vs wasm32-wasip1) with a shared deterministic fixture,
 and asserts the normalized outcomes are byte-identical across:
 
 - methods (GET/POST), JSON/query/form bodies
-- auth schemes (bearer, basic, api-key, digest) — the wire signing is shared
+- **credential-copy** auth (bearer, basic, api-key, digest, oauth2) — the
+  header is a near-verbatim copy of the credential
+- **computed-signature** auth (OAuth1 HMAC-SHA1, AWS SigV4, Hawk) — these sign
+  over the method, URL, query string and body, so a canonicalisation
+  difference between the legs shows up here and nowhere else. They are the
+  schemes where a byte difference is a 403 that costs a day to find, which is
+  the stated reason signing lives in Rust rather than being reimplemented in
+  TypeScript (TR-409). The SigV4 case deliberately uses a URL with consecutive
+  slashes and an encoded query value — TR-603's slash-normalisation bug lived
+  exactly there
 - error statuses (404, 500), redirects (301), text/empty bodies
 - a throwing test script (both legs report the same `script_failures`)
+
+**Still uncovered:** NTLM, WSSE, JWT and Akamai EdgeGrid. Those are reported as
+`unsupported` by `build_auth_signer` rather than implemented (TR-409), so there
+is no signature for the two legs to disagree about yet. Add them here when they
+land.
 
 If a future divergence appears, add it here with the reason it is unavoidable
 (e.g. a host-only feature like `std::time` precision, or a platform-specific

--- a/tropel_plan/tasks/W4-knockport-interface.md
+++ b/tropel_plan/tasks/W4-knockport-interface.md
@@ -151,8 +151,8 @@ The thesis is *"one engine, with a differential harness proving they agree."* Wi
 
 ### Acceptance criteria
 - [x] `native_vs_wasm` over a request corpus: identical wire bytes, identical signing, identical script results
-- [x] The corpus includes every fixture collection, and every auth scheme
-- [x] Runs in CI on every PR and **blocks merge** on divergence
+- [x] The corpus includes every fixture collection, and every auth scheme — **expanded**: it covered bearer/basic/api-key/digest, i.e. only the schemes where the header is a near-verbatim copy of the credential, and omitted every scheme that computes a signature. OAuth1 (HMAC-SHA1), AWS SigV4 and Hawk are now in the corpus, plus OAuth2. Those are the schemes where a byte difference is a 403, which is the stated reason signing is Rust-side at all. NTLM/WSSE/JWT/Akamai remain uncovered because they are reported `unsupported` rather than implemented — recorded in `native_vs_wasm_divergences.md`
+- [x] Runs in CI on every PR and **blocks merge** on divergence — **fixed**: three of the harness's five tests (the HAR, OpenAPI and Postman fixture legs) skipped even under `TROPEL_REQUIRE_WASM=1`, so they blocked nothing. Only the two corpus tests honoured the flag. All five now fail closed
 - [x] Divergences that are genuinely unavoidable are enumerated in a checked-in file; the suite fails on any divergence **not** on that list
 - [x] Extends the conformance suite rather than forking it — a second harness is the bug this harness exists to catch — **verified**: `crates/tropel-web/tests/native_vs_wasm.rs:1-26` now documents `TR-408: this harness extends the conformance suite (tropel_engine/tests/conformance_k6.rs TR-202 + native_vs_wasm_divergences.md) — corpus and divergences file are shared; both harnesses run in CI and block merge; the corpus reuses the same examples/ collections and fixture axes (status/headers/variable state/assertion/setNextRequest)`
 - [x] Published as a badge


### PR DESCRIPTION
## What

TR-408's criterion: *"The corpus includes every fixture collection, and **every auth scheme**."*

The corpus covered **bearer, basic, api-key, digest** — the four schemes where the `Authorization` header is a near-verbatim copy of the credential — and omitted every scheme that *computes a signature over the request*.

That is backwards relative to the stated risk. TR-409 opens with:

> A signing byte-difference is a 403 that takes a day to find — this is precisely why signing is Rust-side and must not be reimplemented in TypeScript.

The schemes that motivate the entire arrangement were the ones not being compared. A bearer token cannot meaningfully diverge between native and wasm; a SigV4 canonical URI absolutely can.

Adds **OAuth1 (HMAC-SHA1)**, **AWS SigV4**, **Hawk** and **OAuth2**. These sign over the method, URL, query string and body, so a canonicalisation difference between the legs surfaces here and nowhere else.

The SigV4 case uses `https://fixture.test//prod//users?x=1%20 2&a=b` deliberately — consecutive slashes plus an encoded query value. **TR-603's slash-normalisation bug lived exactly there** (`path.replace("//","/")` was a single pass, so runs of ≥3 survived) and produced a real 403 on the classic base-URL-ends-in-`/` join.

NTLM, WSSE, JWT and Akamai EdgeGrid stay out: `build_auth_signer` reports them `unsupported` rather than implementing them (TR-409), so there is no signature for the legs to disagree about yet. Recorded in `native_vs_wasm_divergences.md` so the gap is visible rather than implied.

## Second defect: three of the five harness tests could not fail

`TROPEL_REQUIRE_WASM=1` turns a missing wasm artifact into a CI failure. Only two of the five tests honoured it. The **HAR**, **OpenAPI** and **Postman** fixture legs did:

```rust
let Some(wasm_path) = wasm_artifact_path() else {
    eprintln!("SKIP native_vs_wasm HAR fixture: tropel_web.wasm not built");
    return;
};
```

— unconditionally. Three fifths of "one engine, proven" blocked nothing. All five now fail closed.

## Acceptance

- [x] Computed-signature schemes are in the corpus
- [x] Uncovered schemes enumerated with the reason, not silently absent
- [x] Every harness test fails closed under `TROPEL_REQUIRE_WASM=1`

## Tests

**Fail-closed, verified both ways:**

```
$ cargo test -p tropel-web --test native_vs_wasm
test result: ok. 7 passed

$ TROPEL_REQUIRE_WASM=1 cargo test -p tropel-web --test native_vs_wasm
F3 Postman fixture: tropel_web.wasm not found but TROPEL_REQUIRE_WASM=1
F3 HAR fixture: ...
F3 OpenAPI fixture: ...
test result: FAILED. 2 passed; 5 failed
```

On pre-fix code that second run reported **5 passed** — the three fixture legs skipped silently.

## What I could not verify locally, stated plainly

The corpus test **skips entirely without the wasm artifact**, and building `tropel-web` for `wasm32-wasip1` needs the WASI SDK, which I do not have here. So the new signing entries have **not** been executed through both legs on my machine — the native side compiles and the harness skips.

CI's `wasm` job builds the artifact and sets `TROPEL_REQUIRE_WASM=1`, so this PR's own CI run is the first real execution. **If it fails, that is not a broken test — it is the finding this harness exists to produce.** It should be read as a genuine native/wasm signing divergence and investigated, not papered over by deleting the corpus entry.

I would rather say that than imply a verification I did not perform.

## A note on the credentials

They are deliberately synthetic (`fixture-access-key`, `fixture-hawk-key`, …) rather than the published AWS/RFC vectors. This harness compares the two legs **against each other**, so the key bytes are arbitrary — what matters is that both sides sign identical input. Correctness against published vectors (RFC 5849, RFC 7616, the AWS `aws4_testsuite`) is `tropel-auth/src/signers.rs`'s job and already covered there; that is where real vectors belong. It also keeps secret-scanning tooling from tripping on an `AKIA`-shaped literal.

## Twin check

Swept the harness for other fail-open shapes, since that was half the defect:

- `native_and_wasm_runtime_produce_identical_outcomes` (`:592`) and `native_and_wasm_agree_over_request_corpus` (`:719`) — both already honoured the flag. Unchanged.
- The three fixture legs — fixed here.
- `conformance_k6` had the same shape with no flag at all — that is #471.

After this and #471, every conformance surface either runs or fails in CI.

## Evidence

READ + EXEC. Native leg compiles, suite passes (7 tests), fail-closed verified in both directions (output above). `cargo clippy -p tropel-web --all-targets -- -D warnings` clean; `cargo fmt --all` applied.

## Risk

Four more corpus entries mean four more wasm round-trips per CI run — negligible.

The real risk is the one stated above: this may turn CI red by finding something. That would be the harness working.