### PR TITLE
fix(metrics): failure duration is a genuine zero, plus a superset series [TR-203]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "simd-json",
  "thiserror 2.0.19",
  "wit-parser 0.255.0",

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -1562,10 +1562,29 @@ fn push_http_failure(
     let tags = Arc::new(tags);
 
     let mut v = sink.lock().unwrap();
-    // Time-to-failure in ms (same Trend series the success path feeds), so
-    // duration thresholds see the outage.
+    // TR-203: k6 emits a GENUINE ZERO here. `measureAndEmitMetrics` has no
+    // error branch — a DNS failure never fires GotConn/WroteRequest, so every
+    // timing records 0 and `http_req_duration` is the sum of three zeros.
+    //
+    // This used to emit the elapsed time-to-failure, which broke TR-202's
+    // formula in tropel's own data: the seven sub-timings below are 0, so
+    // `duration != sending + waiting + receiving` on exactly the samples a
+    // saturated run produces most of. It also silently shifted every ported
+    // k6 duration threshold — a 30 s timeout fed 30000 into the Trend where
+    // k6 feeds 0.
     v.push(Sample {
         metric: "http_req_duration".into(),
+        value: 0.0,
+        tags: tags.clone(),
+        timestamp: now,
+        sample_type: SampleType::Trend,
+    });
+    // The time-to-failure signal is real and worth keeping — it is how you
+    // tell a fast connection-refused from a 30 s timeout — so it moves to its
+    // own series instead of being folded into a k6-defined one. Documented as
+    // a tropel superset, not a parity claim.
+    v.push(Sample {
+        metric: "http_req_time_to_failure".into(),
         value: elapsed.as_secs_f64() * 1000.0,
         tags: tags.clone(),
         timestamp: now,
@@ -9024,7 +9043,7 @@ mod tests {
     }
 
     #[test]
-    fn test_push_http_failure_emits_duration_and_data_sent() {
+    fn test_push_http_failure_emits_zero_duration_and_data_sent() {
         // W1-B line 161: transport failures emitted ONLY http_reqs +
         // http_req_failed — no http_req_duration (time-to-failure) or
         // data_sent, so a fully-down target let p(95)<500 pass on the
@@ -9062,15 +9081,44 @@ mod tests {
         let duration = samples
             .iter()
             .find(|s| s.metric == "http_req_duration")
-            .expect("failure must emit http_req_duration (time-to-failure)");
+            .expect("failure must emit http_req_duration");
+        // INVERTED (TR-203). This asserted `1500.0` — "http_req_duration must
+        // carry the elapsed ms" — pinning a k6 divergence as correct. k6's
+        // measureAndEmitMetrics has no error branch, so a failed request
+        // records a genuine zero for every timing, and TR-202 defines
+        // duration as sending + waiting + receiving: all three are emitted as
+        // 0 below, so anything but 0 here contradicts our own formula.
         assert_eq!(
-            duration.value, 1500.0,
-            "http_req_duration must carry the elapsed ms"
+            duration.value, 0.0,
+            "http_req_duration must be a genuine zero on transport failure (k6 parity)"
         );
         assert_eq!(
             duration.sample_type,
             SampleType::Trend,
             "same Trend series as the success path"
+        );
+        // The elapsed time is preserved in its own series so the "fast
+        // refusal vs slow timeout" signal survives the parity fix.
+        let ttf = samples
+            .iter()
+            .find(|s| s.metric == "http_req_time_to_failure")
+            .expect("failure must emit http_req_time_to_failure");
+        assert_eq!(
+            ttf.value, 1500.0,
+            "http_req_time_to_failure carries the elapsed ms"
+        );
+        // The identity TR-202 defines must hold here too.
+        let phase = |m: &str| -> f64 {
+            samples
+                .iter()
+                .filter(|s| s.metric == m)
+                .map(|s| s.value)
+                .sum()
+        };
+        assert_eq!(
+            duration.value,
+            phase("http_req_sending") + phase("http_req_waiting") + phase("http_req_receiving"),
+            "http_req_duration must equal sending + waiting + receiving on the failure path"
         );
         let reqs = samples
             .iter()
@@ -9117,7 +9165,13 @@ mod tests {
                 "{sub} must be the same Trend series as the success path"
             );
         }
-        assert_eq!(samples.len(), 11, "4 base + 7 sub-timing samples");
+        // 4 base (duration, http_reqs, http_req_failed, data_sent)
+        // + 7 sub-timings + http_req_time_to_failure (TR-203).
+        assert_eq!(
+            samples.len(),
+            12,
+            "4 base + 7 sub-timings + http_req_time_to_failure"
+        );
     }
 
     #[test]

--- a/crates/tropel-metrics/src/lib.rs
+++ b/crates/tropel-metrics/src/lib.rs
@@ -128,10 +128,32 @@ pub mod time_metrics {
             || name.ends_with("_lookup")
             || name.contains("ttfb")
             || name.contains("latency")
+            // TR-203: time-to-failure on the transport-error path. Not a k6
+            // metric (k6 folds nothing here — it emits genuine zeros), so it
+            // matches none of the suffixes above and would otherwise render
+            // unitless while carrying milliseconds.
+            || name.ends_with("_time_to_failure")
         {
             return MetricUnit::Time;
         }
         MetricUnit::Default
+    }
+}
+
+#[cfg(test)]
+mod time_to_failure_unit_tests {
+    use super::{time_metrics, MetricUnit};
+
+    /// TR-203: `http_req_time_to_failure` carries milliseconds, so it must
+    /// classify as Time. It ends with `_failure`, matching none of the
+    /// duration suffixes, so without an explicit arm it would render unitless
+    /// while holding ms — the systemic µs/ms confusion TR-222 is about.
+    #[test]
+    fn time_to_failure_is_a_time_metric() {
+        assert_eq!(
+            time_metrics::unit_of("http_req_time_to_failure"),
+            MetricUnit::Time
+        );
     }
 }
 

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -808,8 +808,25 @@ impl ScenarioRunner {
                                 // where every request failed. Mirrors the k6
                                 // driver's push_http_failure (same names,
                                 // same zero values — one contract).
+                                // TR-203: a genuine ZERO, matching k6. The
+                                // seven sub-timings below are 0, so emitting
+                                // elapsed here made
+                                // `duration != sending + waiting + receiving`
+                                // in tropel's own data — on exactly the
+                                // samples a saturated run produces most of.
                                 result.samples.push(tropel_sdk::types::Sample {
                                     metric: "http_req_duration".into(),
+                                    value: 0.0,
+                                    tags: err_tags.clone(),
+                                    timestamp: now,
+                                    sample_type: SampleType::Trend,
+                                });
+                                // Time-to-failure keeps its own series (a
+                                // tropel superset, not a k6 metric) so the
+                                // "fast refusal vs 30 s timeout" signal is
+                                // not lost to the parity fix.
+                                result.samples.push(tropel_sdk::types::Sample {
+                                    metric: "http_req_time_to_failure".into(),
                                     value: duration.as_secs_f64() * 1000.0,
                                     tags: err_tags.clone(),
                                     timestamp: now,
@@ -2443,9 +2460,28 @@ mod tests {
             .filter(|s| s.metric == "http_req_duration")
             .collect();
         assert_eq!(durations.len(), 2, "two failure durations");
+        // INVERTED (TR-203). This previously asserted `value > 0.0` —
+        // "failure duration must carry the time-to-failure" — which pinned a
+        // k6 divergence as correct and contradicted TR-202's own formula:
+        // the seven sub-timings are emitted as 0, so the duration must be 0
+        // too or `duration != sending + waiting + receiving` in our own data.
+        // k6's measureAndEmitMetrics has no error branch; every timing
+        // records a genuine zero.
         assert!(
-            durations.iter().all(|s| s.value > 0.0),
-            "failure duration must carry the time-to-failure"
+            durations.iter().all(|s| s.value == 0.0),
+            "failure duration must be a genuine zero (k6 parity), got {:?}",
+            durations.iter().map(|s| s.value).collect::<Vec<_>>()
+        );
+        // The time-to-failure signal is preserved in its own series.
+        let ttf: Vec<_> = samples
+            .iter()
+            .filter(|s| s.metric == "http_req_time_to_failure")
+            .collect();
+        assert_eq!(ttf.len(), 2, "each failure emits http_req_time_to_failure");
+        assert!(
+            ttf.iter().all(|s| s.value > 0.0),
+            "time-to-failure must carry the real elapsed time, got {:?}",
+            ttf.iter().map(|s| s.value).collect::<Vec<_>>()
         );
         let failed: Vec<_> = samples
             .iter()
@@ -2471,5 +2507,27 @@ mod tests {
                 "failure path must emit {sub}"
             );
         }
+
+        // TR-202/TR-203: the identity must hold on the failure path too.
+        // `http_req_duration` is DEFINED as sending + waiting + receiving; the
+        // failure path emitted `elapsed` while those three were 0, so tropel's
+        // own data contradicted its own formula on exactly the samples a
+        // saturated run produces most of. Nothing asserted it, which is why it
+        // survived both TR-202 and TR-121.
+        let sum_of = |metric: &str| -> f64 {
+            samples
+                .iter()
+                .filter(|s| s.metric == metric)
+                .map(|s| s.value)
+                .sum()
+        };
+        let duration_total = sum_of("http_req_duration");
+        let phases_total =
+            sum_of("http_req_sending") + sum_of("http_req_waiting") + sum_of("http_req_receiving");
+        assert!(
+            (duration_total - phases_total).abs() < f64::EPSILON,
+            "http_req_duration ({duration_total}) must equal sending + waiting + receiving \
+             ({phases_total}) on the failure path — that identity is the whole of TR-202"
+        );
     }
 }

--- a/tropel_plan/CONTEXT.md
+++ b/tropel_plan/CONTEXT.md
@@ -45,6 +45,9 @@ A fix that trades one of these away is a regression even if it closes its ticket
 - **`SharedArray`** — native copy with no per-element `JSON.parse`; k6's re-parses *and* recursively freezes on every element access.
 - **`discardResponseBodies`** implemented correctly — it *drains* the body so the pooled connection survives.
 - **Executors and outputs are a k6 v2 superset** — `externally-controlled` and StatsD were both deleted in k6 v2 and tropel kept them.
+- **Transport failures keep their timing.** k6 records a genuine `0` for every phase on a transport error, which is honest per-phase but throws the signal away: a connection refused in 2 ms and a 30 s timeout are indistinguishable in k6's output. Tropel matches k6 on `http_req_duration` (a ported threshold must get k6's answer) and keeps the elapsed time in its own `http_req_time_to_failure` series, so parity costs nothing (TR-203).
+
+> **The rule these follow.** Match k6 exactly on any series a k6 script can read — that is what makes a ported threshold correct. Where k6 is simply *deficient*, add rather than diverge: a new series, a better algorithm, a cap k6 lacks. Tropel should never be worse than k6 at anything, and "parity" is never a reason to reproduce a k6 shortcoming — `CONVENTIONS.md`'s D4 says it outright: *parity means "a k6 script gets k6's answer", not "copy k6's bugs"*.
 
 ## The settled decisions
 

--- a/tropel_plan/tasks/W2-k6-parity.md
+++ b/tropel_plan/tasks/W2-k6-parity.md
@@ -50,6 +50,12 @@ k6 defines it as **`sending + waiting + receiving`**, deliberately excluding `bl
 
 **[SILENT]** k6's `measureAndEmitMetrics` has **no error branch**; `SaveSamples` is called unconditionally (`transport.go:144`). A DNS failure never fires `GotConn`/`WroteRequest`, so every timing records a genuine **`0`** — the sample exists, it is just zero. Dropping them makes `http_reqs` and `http_req_duration` counts disagree and biases every percentile.
 
+- [x] All eight emitted, sub-timings as genuine zeros, on **both** drivers
+- [x] `http_req_duration` is `0` on failure, not the elapsed time — it is defined as `sending + waiting + receiving` (TR-202) and all three are zero, so anything else contradicts tropel's own formula on exactly the samples a saturated run produces most of. Two tests pinned the old behaviour and were inverted
+- [x] **[SUPERSET]** k6 loses the time-to-failure signal completely: a connection refused in 2 ms and a 30 s timeout are indistinguishable in its output. Tropel keeps it in its own series, **`http_req_time_to_failure`** (Trend, ms), so parity costs nothing. Registered as a `Time` metric so it renders with `ms` — it matches none of the duration-suffix conventions and would otherwise print unitless while carrying milliseconds
+
+> **Note on k6's zeros.** They are honest *per phase* — those phases genuinely did not run — but feeding them into the duration Trend drags percentiles down, so a run where half the requests are refused can show a healthy `p(95)`. Tropel matches k6 on the shared series (a ported threshold must get k6's answer) and fixes the visibility gap with the extra series rather than by diverging on the shared one. `http_req_failed` remains the honest denominator.
+
 ## TR-204 · `error`, `error_code` and `expected_response` tags
 **Effort:** M · **Blocked by:** TR-203
 


### PR DESCRIPTION
## What

On a transport failure (timeout, DNS, refused) the failure path emitted the seven sub-timings as `0.0` and `http_req_duration` as the **elapsed time-to-failure**.

TR-202 defines `http_req_duration` as `sending + waiting + receiving`. All three are zero on that path. So tropel's own data contradicted tropel's own formula — on exactly the samples a saturated run produces most of.

It also silently shifted every ported k6 duration threshold: a 30 s timeout fed `30000` into the Trend where k6 feeds `0`.

Both drivers now emit `0`, matching k6's `measureAndEmitMetrics`, which has no error branch.

## k6's shortcoming is fixed, not inherited

k6's zeros are honest *per phase* — those phases genuinely did not run — but k6 then throws the signal away entirely. **A connection refused in 2 ms and a 30 s timeout are indistinguishable in k6's output.**

So the elapsed time moves to its own Trend, `http_req_time_to_failure` (ms), which k6 has no equivalent for. Parity on the shared series costs nothing, and tropel ends up strictly ahead:

| | k6 | tropel |
|---|---|---|
| `http_req_duration` on failure | `0` | `0` (parity) |
| sub-timings on failure | `0` | `0` (parity) |
| time-to-failure recoverable | **no** | **yes**, own series |

Registered as a `Time` metric — it ends `_failure`, matching none of the duration-suffix conventions in `unit_of`, so without an explicit arm it would render unitless while carrying milliseconds (the systemic µs/ms confusion TR-222 is about).

The rule is now written down in `CONTEXT.md`'s superset list: **match k6 exactly on any series a k6 script can read — that is what makes a ported threshold correct — and where k6 is simply deficient, add rather than diverge.** Parity is never a reason to reproduce a k6 shortcoming; D4 already said *"parity means 'a k6 script gets k6's answer', not 'copy k6's bugs'"*, and this makes the operational form of that explicit.

## Task

TR-203 (and TR-121, the same fix in W1's terms).

## Acceptance

- [x] `http_req_duration` is `0` on transport failure, on **both** drivers
- [x] The identity `duration == sending + waiting + receiving` holds on the failure path
- [x] The time-to-failure signal survives, in a series k6 does not have
- [x] The new metric classifies as `Time`

## Tests

**Two tests pinned the old behaviour and are inverted in the same commit**, per `CONVENTIONS.md` (*"When fixing a bug a test currently pins as correct, delete or invert that test in the same PR"*):

1. `runner.rs` — asserted `durations.iter().all(|s| s.value > 0.0)` with the message *"failure duration must carry the time-to-failure"*.
2. `driver.rs::test_push_http_failure_emits_duration_and_data_sent` — asserted `duration.value == 1500.0`, *"http_req_duration must carry the elapsed ms"*. Renamed to `..._emits_zero_duration_and_data_sent`.

Both now assert `0.0`, and both additionally assert the elapsed time appears in `http_req_time_to_failure`.

**New coverage for the actual defect** — nothing asserted the identity, which is why it survived both TR-202 and TR-121:

```rust
assert!(
    (duration_total - phases_total).abs() < f64::EPSILON,
    "http_req_duration ({duration_total}) must equal sending + waiting + receiving \
     ({phases_total}) on the failure path — that identity is the whole of TR-202"
);
```

This fails on pre-fix code (`1500 != 0`). Plus `time_to_failure_is_a_time_metric` in `tropel-metrics`.

## Twin check

TR-121's whole point is "fix once, both drivers inherit it", so I checked both and every sibling emit site:

- `tropel-input-k6/src/driver.rs:1568` `push_http_failure` — fixed.
- `tropel-runtime/src/runner.rs:812` declarative failure path — fixed.
- Success paths in both (`driver.rs:1279`, `runner.rs:668`) — already use the TR-202 formula and are untouched.
- `tropel-web` / wasm slice — routes through `ScenarioRunner`, so it inherits the runner fix. The `native_vs_wasm` harness covers it.
- Grepped every `http_req_duration` emit site in the tree: four, all accounted for above.

## Evidence

READ + EXEC. `cargo test --workspace` **1085 passed / 0 failed**. `cargo fmt --all` applied.

## Risk

**This is a metric-contract change and moves numbers users already see** — flagged under `CONVENTIONS.md` §"What needs a human", and the direction was chosen explicitly rather than by default.

Anyone whose runs contain transport failures will see `http_req_duration` percentiles **drop**, because 30 s timeouts stop being counted as 30 s durations. That is the k6-correct number and the one a ported threshold expects, but a dashboard tracking the old value will step. The compensating signal is `http_req_time_to_failure`, which is new, so nothing that exists today breaks silently — it appears rather than changes.

`http_req_time_to_failure` is a new engine-owned metric and **should be added to `RESERVED_BUILTIN_METRICS`** so a script cannot shadow it (the class of bug #468 just closed). That needs a `tropel-sdk` change plus a repin, so I have deliberately not bundled it here — filing it as an immediate follow-up rather than leaving it unsaid.