### PR TITLE
fix(scheduler): wire GetStripedOffsets into the arrival-rate executor [TR-221]

### DIFF
--- a/crates/tropel-core/src/segment.rs
+++ b/crates/tropel-core/src/segment.rs
@@ -299,7 +299,34 @@ impl ExecutionSegment {
     /// that runs only this node's share of the workload. All scaling is
     /// deterministic — each node derives the same result from the same
     /// segment spec, so N nodes partition the workload with no coordination.
+    ///
+    /// Arrival rates are scaled by the segment fraction
+    /// ([`RateSegmentation::ScaleRate`]) — the fallback for when no full
+    /// `executionSegmentSequence` is available to stripe against. Use
+    /// [`apply_with`](Self::apply_with) with
+    /// [`RateSegmentation::GlobalRate`] on the striped path.
     pub fn apply(&self, exec: &ExecutionConfig) -> ExecutionConfig {
+        self.apply_with(exec, RateSegmentation::ScaleRate)
+    }
+
+    /// [`apply`](Self::apply), choosing how the segment's share of an
+    /// **arrival-rate** workload is expressed (TR-221). VU counts and
+    /// iteration budgets are always telescoped; only the rate handling
+    /// differs — see [`RateSegmentation`].
+    pub fn apply_with(
+        &self,
+        exec: &ExecutionConfig,
+        rate_mode: RateSegmentation,
+    ) -> ExecutionConfig {
+        // TR-221: on the striped path the rate stays GLOBAL — k6 builds
+        // `constant_arrival_rate.go`'s ticker period from the UNSCALED rate
+        // and expresses segmentation purely by skipping the global ticks this
+        // segment doesn't own. Scaling the rate *as well* would divide the
+        // load twice.
+        let rate_share = |r: f64| match rate_mode {
+            RateSegmentation::ScaleRate => self.scale_rate(r),
+            RateSegmentation::GlobalRate => r,
+        };
         match exec {
             ExecutionConfig::ConstantVus {
                 vus,
@@ -340,7 +367,7 @@ impl ExecutionSegment {
                 graceful_stop,
                 think_time,
             } => ExecutionConfig::ConstantArrivalRate {
-                rate: self.scale_rate(*rate),
+                rate: rate_share(*rate),
                 time_unit: time_unit.clone(),
                 duration: duration.clone(),
                 pre_alloc_vus: self.scale_vus(*pre_alloc_vus),
@@ -370,12 +397,12 @@ impl ExecutionSegment {
                 graceful_stop,
                 think_time,
             } => ExecutionConfig::RampingArrivalRate {
-                start_rate: self.scale_rate(*start_rate),
+                start_rate: rate_share(*start_rate),
                 stages: stages
                     .iter()
                     .map(|s| ArrivalRateStage {
                         duration: s.duration.clone(),
-                        target: self.scale_rate(s.target),
+                        target: rate_share(s.target),
                     })
                     .collect(),
                 time_unit: time_unit.clone(),
@@ -412,6 +439,36 @@ impl ExecutionSegment {
             },
         }
     }
+}
+
+/// How a segment expresses its share of an **arrival-rate** workload
+/// (TR-221).
+///
+/// VU counts and iteration budgets are always telescoped
+/// (`floor(n·to) − floor(n·from)`); arrival rates have two possible models
+/// and picking the wrong one is a silent 1/N or N× load error, so the caller
+/// states it explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateSegmentation {
+    /// Multiply the configured rate by the segment's fraction. Each node then
+    /// runs its own **independent** rate from its own `t = 0`, so N nodes'
+    /// arrivals **bunch** instead of interleaving (three nodes at 50/25/25
+    /// all fire together at every 200 ms instead of filling a 50 ms cadence).
+    /// This is the fallback for when no full `executionSegmentSequence` is
+    /// available to stripe against — it delivers the right *total* rate but
+    /// the wrong *shape*.
+    ScaleRate,
+    /// Leave the rate **global** and let striped offsets pick this node's
+    /// ticks out of the global sequence — k6's model
+    /// (`constant_arrival_rate.go` builds its ticker period from the
+    /// *unscaled* rate and skips the ticks the segment doesn't own).
+    ///
+    /// The caller MUST install the matching [`ArrivalStripe`] on the
+    /// executor. Without it, every node runs the full global rate — an N×
+    /// overload. [`ArrivalStripe::full`] is the identity stripe, so a
+    /// scheduler that was never given a stripe is safe only when the rate
+    /// was *not* left global.
+    GlobalRate,
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -476,6 +533,19 @@ impl ExecutionSegmentSequence {
             prev = cur;
         }
         Ok(Self(segments))
+    }
+
+    /// Position of the segment whose bounds match `seg`.
+    ///
+    /// Uses the same `1e-9` tolerance [`ExecutionSegment::parse`] uses when
+    /// validating a segment against a sequence: the controller can spell a
+    /// boundary as a decimal (`"0:0.3333333333333333"`) while the sequence
+    /// spells it as a fraction (`"0,1/3,2/3,1"`), and both must resolve to
+    /// the same index or the node would stripe against the wrong slot.
+    pub fn index_of(&self, seg: &ExecutionSegment) -> Option<usize> {
+        self.0
+            .iter()
+            .position(|s| (s.from() - seg.from()).abs() < 1e-9 && (s.to() - seg.to()).abs() < 1e-9)
     }
 }
 
@@ -584,11 +654,19 @@ impl ExecutionSegmentSequenceWrapper {
             unscaled: 0,
         }
     }
+
+    /// The [`ArrivalStripe`] for `segment_index` — the cursor the
+    /// arrival-rate executor walks so this node fires only the global ticks
+    /// it owns.
+    pub fn arrival_stripe(&self, segment_index: usize) -> ArrivalStripe {
+        ArrivalStripe::from_index(self.segmented_index(segment_index))
+    }
 }
 
 /// k6's `SegmentedIndex` — the non-thread-safe striped iterator over the
 /// global tick space. See `ExecutionSegmentSequenceWrapper::segmented_index`.
 #[allow(dead_code)]
+#[derive(Debug, Clone)]
 pub struct SegmentedIndex {
     start: i64,
     lcd: i64,
@@ -621,6 +699,78 @@ impl Iterator for SegmentedIndex {
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.advance())
+    }
+}
+
+/// One node's cursor over the **global** arrival sequence — the piece that
+/// turns [`get_striped_offsets`](ExecutionSegmentSequenceWrapper::get_striped_offsets)
+/// into something an arrival-rate executor can drive (TR-221).
+///
+/// k6's `constant_arrival_rate.go:316-330` walks a global iteration index
+/// `gi` (stepping by this segment's striped offsets) and fires iteration
+/// `gi` at `global_period × gi` measured from the executor's own start. So
+/// N instances *skip* the global ticks they don't own and interleave back
+/// into the exact original global rate.
+///
+/// Tropel's arrival-rate executors are token-bucket shaped: instead of
+/// sleeping to a per-iteration deadline they ask, once per tick, "how many
+/// arrivals do I owe by now?". [`due_by`](Self::due_by) is that question,
+/// expressed against the **global** arrival count — feed it
+/// `floor(elapsed × global_rate)` (constant) or `floor(∫global_rate)`
+/// (ramping) and it returns this node's cumulative share.
+///
+/// Global tick `g` (0-based, k6's `gi`) is the `g+1`-th global arrival, and
+/// [`SegmentedIndex`] already yields that 1-based `unscaled` number — so the
+/// node's `j`-th arrival is due exactly when the global sequence reaches its
+/// `unscaled_j`-th. For the [`full`](Self::full) stripe `unscaled` is
+/// `1, 2, 3, …` and `due_by(n) == n`, i.e. the un-segmented schedule is
+/// unchanged.
+#[derive(Debug, Clone)]
+pub struct ArrivalStripe {
+    index: SegmentedIndex,
+    /// 1-based global arrival number of the next arrival this node owns.
+    next_owned: i64,
+    /// How many arrivals this node has released so far.
+    released: u64,
+}
+
+impl ArrivalStripe {
+    fn from_index(mut index: SegmentedIndex) -> Self {
+        let (_scaled, next_owned) = index.advance();
+        Self {
+            index,
+            next_owned,
+            released: 0,
+        }
+    }
+
+    /// The identity stripe: this node owns **every** global tick, so
+    /// `due_by(n) == n`. This is the single-node (un-segmented) schedule and
+    /// the default for a scheduler that was never given a segment.
+    pub fn full() -> Self {
+        // The `[0,1)` sequence: one segment of length 1, LCD 1, start 0,
+        // offset 1 — spelled directly rather than parsed so this cannot fail.
+        Self::from_index(SegmentedIndex {
+            start: 0,
+            lcd: 1,
+            offsets: vec![1],
+            scaled: 0,
+            unscaled: 0,
+        })
+    }
+
+    /// How many arrivals this node owes once the **global** arrival sequence
+    /// has produced `global_arrivals` of them.
+    ///
+    /// Monotone non-decreasing, and the cursor only ever moves forward — the
+    /// caller must feed a monotone `global_arrivals` (both executors do:
+    /// it is a floor of a non-decreasing integral of the global rate).
+    pub fn due_by(&mut self, global_arrivals: u64) -> u64 {
+        while self.next_owned > 0 && self.next_owned as u64 <= global_arrivals {
+            self.released += 1;
+            self.next_owned = self.index.advance().1;
+        }
+        self.released
     }
 }
 
@@ -858,6 +1008,11 @@ mod tests {
             _ => panic!("wrong variant"),
         }
 
+        // TR-221: `apply()` is the ScaleRate FALLBACK — it divides the rate
+        // by the segment count, which delivers the right total but makes
+        // every node fire its own independent rate from its own t=0 (arrivals
+        // bunch). It is only reached when no full executionSegmentSequence is
+        // available to stripe against; the striped path is asserted below.
         let exec = ExecutionConfig::ConstantArrivalRate {
             rate: 9.0,
             time_unit: "1s".into(),
@@ -876,6 +1031,25 @@ mod tests {
                 ..
             } => {
                 assert!((rate - 3.0).abs() < 1e-9); // 9/3 = 3
+                assert_eq!(pre_alloc_vus, 1);
+                assert_eq!(max_vus, 3);
+            }
+            _ => panic!("wrong variant"),
+        }
+        // TR-221 striped mode: the rate stays GLOBAL (the stripe is the
+        // share), while the VU counts are still telescoped.
+        let striped = third.apply_with(&exec, RateSegmentation::GlobalRate);
+        match striped {
+            ExecutionConfig::ConstantArrivalRate {
+                rate,
+                pre_alloc_vus,
+                max_vus,
+                ..
+            } => {
+                assert!(
+                    (rate - 9.0).abs() < 1e-9,
+                    "striped mode must NOT scale the rate — got {rate}, want the global 9"
+                );
                 assert_eq!(pre_alloc_vus, 1);
                 assert_eq!(max_vus, 3);
             }
@@ -910,6 +1084,39 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+        // TR-221: the whole ramping CURVE stays global in striped mode.
+        let striped = third.apply_with(&exec, RateSegmentation::GlobalRate);
+        match striped {
+            ExecutionConfig::RampingArrivalRate {
+                start_rate,
+                stages,
+                pre_alloc_vus,
+                ..
+            } => {
+                assert!((start_rate - 3.0).abs() < 1e-9);
+                assert!((stages[0].target - 9.0).abs() < 1e-9);
+                assert_eq!(pre_alloc_vus, 1);
+            }
+            _ => panic!("wrong variant"),
+        }
+        // VU-count executors are unaffected by the rate mode (ExecutionConfig
+        // has no PartialEq — compare the scaled VU count, which is the only
+        // field either mode could touch).
+        let vus_exec = ExecutionConfig::ConstantVus {
+            vus: 9,
+            duration: "30s".into(),
+            graceful_stop: None,
+            think_time: Default::default(),
+        };
+        let vus_of = |e: ExecutionConfig| match e {
+            ExecutionConfig::ConstantVus { vus, .. } => vus,
+            _ => panic!("wrong variant"),
+        };
+        assert_eq!(
+            vus_of(third.apply(&vus_exec)),
+            vus_of(third.apply_with(&vus_exec, RateSegmentation::GlobalRate)),
+            "rate mode must not touch VU-count executors"
+        );
 
         let exec = ExecutionConfig::PerVUIterations {
             vus: 9,
@@ -1079,5 +1286,92 @@ mod tests {
         for (gi, c) in covered.iter().enumerate() {
             assert!(c, "global tick {gi} was never claimed");
         }
+    }
+    /// TR-221: the identity stripe owns every global tick, so the
+    /// un-segmented executor schedule is unchanged (`due_by(n) == n`).
+    #[test]
+    fn full_arrival_stripe_owns_every_tick() {
+        let mut stripe = ArrivalStripe::full();
+        for n in 0..50u64 {
+            assert_eq!(stripe.due_by(n), n, "full stripe must owe every arrival");
+        }
+        // Monotone under a jump (the executor's 1 ms tick can skip several
+        // global arrivals at high rates).
+        let mut stripe = ArrivalStripe::full();
+        assert_eq!(stripe.due_by(1000), 1000);
+        assert_eq!(stripe.due_by(1000), 1000, "no double-count on a re-ask");
+    }
+
+    /// TR-221: the three stripes of the k6-doc 50%/25%/25% sequence must
+    /// PARTITION the global arrival sequence — every global arrival owed by
+    /// exactly one node, none owed twice, none dropped. This is the property
+    /// the executor relies on to make N nodes indistinguishable from one.
+    #[test]
+    fn arrival_stripes_partition_the_global_sequence() {
+        let seq = ExecutionSegmentSequence::parse("0,1/2,3/4,1").unwrap();
+        let wrapper = ExecutionSegmentSequenceWrapper::new(&seq).unwrap();
+        let mut stripes: Vec<ArrivalStripe> = (0..3).map(|i| wrapper.arrival_stripe(i)).collect();
+
+        // Walk the global sequence one arrival at a time and record which
+        // node claimed it.
+        let mut owner = vec![usize::MAX; 41];
+        let mut prev = [0u64; 3];
+        for g in 1..=40u64 {
+            let mut claimed = 0;
+            for (i, stripe) in stripes.iter_mut().enumerate() {
+                let now = stripe.due_by(g);
+                if now > prev[i] {
+                    assert_eq!(
+                        now - prev[i],
+                        1,
+                        "node {i} claimed {} arrivals at global tick {g}",
+                        now - prev[i]
+                    );
+                    assert_eq!(owner[g as usize], usize::MAX, "tick {g} claimed twice");
+                    owner[g as usize] = i;
+                    claimed += 1;
+                    prev[i] = now;
+                }
+            }
+            assert_eq!(
+                claimed, 1,
+                "global arrival {g} must be claimed exactly once"
+            );
+        }
+        // 50/25/25 over 40 arrivals → 20/10/10.
+        assert_eq!(prev, [20, 10, 10], "stripe shares must match the segments");
+        // And the ownership pattern is k6's doc example: node 0 takes the odd
+        // arrivals, nodes 1 and 2 alternate on the evens.
+        assert_eq!(&owner[1..9], &[0, 1, 0, 2, 0, 1, 0, 2]);
+    }
+
+    /// TR-221: 100 equal segments — each node must owe exactly 1 of every 100
+    /// global arrivals, and the 100 stripes must cover the sequence with no
+    /// gaps. The f64-scaling bug this sequence exposed for VU counts has an
+    /// arrival-rate twin: `rate/100` per node fires 100 bunched arrivals at
+    /// each 1/rate boundary instead of one every 1/(100·rate).
+    #[test]
+    fn arrival_stripes_partition_hundred_segments() {
+        let tokens: Vec<String> = (0..=100u64).map(|i| format!("{i}/100")).collect();
+        let seq = ExecutionSegmentSequence::parse(&tokens.join(",")).unwrap();
+        let wrapper = ExecutionSegmentSequenceWrapper::new(&seq).unwrap();
+        let mut stripes: Vec<ArrivalStripe> = (0..100).map(|i| wrapper.arrival_stripe(i)).collect();
+        for (i, stripe) in stripes.iter_mut().enumerate() {
+            // Over 1000 global arrivals each node owes exactly 10, and its
+            // first is global arrival i+1.
+            assert_eq!(stripe.due_by(1000), 10, "node {i} share over 1000 arrivals");
+        }
+        let mut firsts: Vec<u64> = (0..100)
+            .map(|i| {
+                let mut s = wrapper.arrival_stripe(i);
+                (1..=100u64).find(|g| s.due_by(*g) == 1).unwrap()
+            })
+            .collect();
+        firsts.sort();
+        assert_eq!(
+            firsts,
+            (1..=100u64).collect::<Vec<_>>(),
+            "the 100 stripes must claim the first 100 global arrivals one each"
+        );
     }
 }

--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -518,11 +518,67 @@ impl Engine {
             },
             None => None,
         };
+
+        // TR-221: express this node's share of an ARRIVAL-RATE workload by
+        // striping the global iteration sequence (k6's model) instead of by
+        // scaling the rate. Scaling gives every node its own independent rate
+        // from its own t=0, so N nodes' arrivals BUNCH — three nodes at
+        // 50/25/25 all fire together every 200 ms instead of filling a 50 ms
+        // cadence. Striping skips the global ticks this segment doesn't own,
+        // so the merged sequence is indistinguishable from one node at the
+        // full rate (`constant_arrival_rate.go:316-330`).
+        //
+        // This needs the FULL sequence: a lone segment cannot be striped
+        // consistently, because each node would fill the missing pieces
+        // differently and two nodes would claim the same global ticks. k6 has
+        // the same requirement — that is what `executionSegmentSequence` is
+        // for. Without it we fall back to rate scaling and say so.
+        let mut arrival_stripe: Option<tropel_core::segment::ArrivalStripe> = None;
+        let mut rate_mode = tropel_core::segment::RateSegmentation::ScaleRate;
+        if let Some(seg) = &segment {
+            match config.execution_segment_sequence.as_deref() {
+                Some(seq_spec) => {
+                    let seq = tropel_core::segment::ExecutionSegmentSequence::parse(seq_spec)?;
+                    // `ExecutionSegment::parse` already rejected a segment
+                    // that is not a consecutive pair of this sequence, so the
+                    // lookup cannot miss — but a silent mis-index would put
+                    // the node on another node's stripe, so it errors.
+                    let idx = seq.index_of(seg).ok_or_else(|| {
+                        tropel_sdk::TropelError::Config(format!(
+                            "execution segment [{:.6}, {:.6}) is not a segment of \
+                             execution_segment_sequence '{seq_spec}'",
+                            seg.from(),
+                            seg.to()
+                        ))
+                    })?;
+                    let wrapper = tropel_core::segment::ExecutionSegmentSequenceWrapper::new(&seq)?;
+                    let (start, offsets, lcd) = wrapper.get_striped_offsets(idx);
+                    tracing::info!(
+                        "TR-221: arrival-rate striping active — segment {} of {} owns global \
+                         tick {start}, then offsets {offsets:?}, repeating every {lcd} ticks. \
+                         Arrival rates stay GLOBAL; the stripe is the segment share.",
+                        idx + 1,
+                        seq.0.len()
+                    );
+                    arrival_stripe = Some(wrapper.arrival_stripe(idx));
+                    rate_mode = tropel_core::segment::RateSegmentation::GlobalRate;
+                }
+                None => {
+                    tracing::warn!(
+                        "execution_segment was given without execution_segment_sequence — \
+                         arrival-rate scenarios fall back to per-node rate scaling, so arrivals \
+                         BUNCH instead of interleaving across nodes (TR-221). Pass the same \
+                         --execution-segment-sequence to every node to interleave."
+                    );
+                }
+            }
+        }
+
         let scenario_configs: Vec<ScenarioConfigEntry> = scenario_configs
             .into_iter()
             .map(|mut sc| {
                 if let Some(seg) = &segment {
-                    sc.execution = seg.apply(&sc.execution);
+                    sc.execution = seg.apply_with(&sc.execution, rate_mode);
                 }
                 sc
             })
@@ -635,6 +691,10 @@ impl Engine {
             // TR-313: the scenario task reuses the bytes read at startup
             // instead of re-reading the script file.
             let script_bytes_sc = script_bytes.clone();
+            // TR-221: each scenario's arrival-rate executor walks its OWN
+            // cursor over the global sequence (k6 gives every executor its
+            // own SegmentedIndex), so clone rather than share.
+            let arrival_stripe_sc = arrival_stripe.clone();
 
             let handle = tokio::spawn(async move {
                 let resolved = resolve_input_or_driver(
@@ -685,6 +745,7 @@ impl Engine {
                             control_port,
                             rps_limiter_sc,
                             &input_path,
+                            arrival_stripe_sc,
                         )
                         .await
                     }
@@ -714,6 +775,7 @@ impl Engine {
                             // declarative path (clone — the Scenario arm
                             // moves the original).
                             protocols.clone(),
+                            arrival_stripe_sc,
                         )
                         .await
                     }

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -345,6 +345,11 @@ async fn run_vus<F>(
     test_start: Instant,
     control_port: Option<u16>,
     setup_data: Option<String>,
+    // TR-221: this node's slice of the GLOBAL arrival sequence, or `None`
+    // for the un-segmented (full-workload) schedule. When it is `Some`, the
+    // arrival rates in `exec_cfg` are the GLOBAL rates — the stripe is what
+    // expresses the segment share (see `ExecutionSegment::apply_with`).
+    arrival_stripe: Option<tropel_core::segment::ArrivalStripe>,
     run_vu: F,
 ) -> (u32, u64, Option<String>)
 where
@@ -365,7 +370,10 @@ where
     let mut vu_env = base_env;
     vu_env.extend(sc_env);
 
-    let executor = VUScheduler::new(&exec_cfg);
+    let executor = match arrival_stripe {
+        Some(stripe) => VUScheduler::new(&exec_cfg).with_arrival_stripe(stripe),
+        None => VUScheduler::new(&exec_cfg),
+    };
     // A panic inside the executor's ramp/spawn path unwinds through
     // `executor.run(...)` below and skips the scheduler's own `request_stop()`
     // tail — this guard fires on that unwind path so VUs spawned so far stop
@@ -776,6 +784,7 @@ pub(crate) async fn run_scenario_vus(
     control_port: Option<u16>,
     rps_limiter: Option<Arc<tropel_http::RpsLimiter>>,
     input_path: &str,
+    arrival_stripe: Option<tropel_core::segment::ArrivalStripe>,
 ) -> (u32, u64, Option<String>) {
     // Expected statuses are read by every VU's ScenarioRunner — snapshot them once
     // and share (the closure no longer captures the whole HttpConfig, which
@@ -863,6 +872,7 @@ pub(crate) async fn run_scenario_vus(
         test_start,
         control_port,
         None, // run_scenario_vus has no driver → no setup data
+        arrival_stripe,
         move |sched, vu_id, shared| {
             let shared = shared.clone();
             let lane_idx = vu_id as usize % lanes.len();
@@ -983,6 +993,7 @@ pub(crate) async fn run_driver_vus(
     // shared map into every VU's VuContext so drivers dispatch non-HTTP
     // schemes through the same lookup the declarative runner uses.
     protocols: Arc<HashMap<String, Arc<dyn Protocol>>>,
+    arrival_stripe: Option<tropel_core::segment::ArrivalStripe>,
 ) -> (u32, u64, Option<String>) {
     let driver_id = driver.id().to_string();
     let input_bytes = match std::fs::read(input_path) {
@@ -1087,6 +1098,7 @@ pub(crate) async fn run_driver_vus(
         test_start,
         control_port,
         setup_data_c.clone(),
+        arrival_stripe,
         move |sched, vu_id, shared| {
             let shared = shared.clone();
             let driver_id = driver_id_c.clone();

--- a/crates/tropel-scheduler/src/scheduler.rs
+++ b/crates/tropel-scheduler/src/scheduler.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
 use tropel_core::config::ExecutionConfig;
+use tropel_core::segment::ArrivalStripe;
 use tropel_sdk::{Result, TropelError};
 
 /// Hard bound on the trailing VU-handle join. After `grace` expires the
@@ -124,6 +125,19 @@ pub struct VUScheduler {
     /// Backlog line 424: throttle the O(n) retain scan in `reap_and_respawn`
     /// to once per 100 ms to avoid ~50M atomic loads on a 10k ramp.
     last_reap: Arc<std::sync::Mutex<std::time::Instant>>,
+    /// TR-221: this node's slice of the GLOBAL arrival sequence.
+    ///
+    /// Defaults to [`ArrivalStripe::full`] — owns every global tick, which
+    /// reproduces the single-node schedule exactly, so nothing changes for a
+    /// non-distributed run. A distributed node installs its striped slice via
+    /// [`VUScheduler::with_arrival_stripe`] and then passes the **global**
+    /// (unscaled) rate to the arrival-rate executors, so N nodes interleave
+    /// into the exact original global rate instead of each firing its own
+    /// scaled rate from its own `t = 0`.
+    ///
+    /// Not shared/atomic like the other fields: it is a plain cursor read
+    /// only by the single executor loop, which clones it once at start.
+    arrival_stripe: ArrivalStripe,
 }
 
 /// RAII guard for the arrival-rate idle count. Marks the VU idle on
@@ -205,7 +219,26 @@ impl VUScheduler {
             control_notify: Arc::new(tokio::sync::Notify::new()),
             control_tainted: Arc::new(AtomicBool::new(false)),
             last_reap: Arc::new(std::sync::Mutex::new(std::time::Instant::now())),
+            arrival_stripe: ArrivalStripe::full(),
         }
+    }
+
+    /// Install this node's striped slice of the global arrival sequence
+    /// (TR-221).
+    ///
+    /// The rate handed to `run_arrival_rate` / `run_ramping_arrival_rate`
+    /// must then be the **global** (unscaled) rate — the stripe, not the
+    /// rate, expresses this node's share. Build the pair with
+    /// [`ExecutionSegment::apply_with`] +
+    /// [`RateSegmentation::GlobalRate`]; installing the stripe without
+    /// leaving the rate global divides the load twice, and leaving the rate
+    /// global without the stripe is an N× overload.
+    ///
+    /// [`ExecutionSegment::apply_with`]: tropel_core::segment::ExecutionSegment::apply_with
+    /// [`RateSegmentation::GlobalRate`]: tropel_core::segment::RateSegmentation::GlobalRate
+    pub fn with_arrival_stripe(mut self, stripe: ArrivalStripe) -> Self {
+        self.arrival_stripe = stripe;
+        self
     }
 
     /// Get the stop signal (Notify for waking VUs mid-iteration).
@@ -1136,6 +1169,12 @@ impl VUScheduler {
     /// Uses a time-based token bucket (no 1ms timer floor — resilient at high rates)
     /// and a dynamically growing VU pool (`pre_alloc_vus → max_vus`). VUs are
     /// spawned on demand when the current pool is saturated.
+    ///
+    /// TR-221: `rate` is the **global** arrival rate whenever an
+    /// [`ArrivalStripe`] has been installed (see
+    /// [`with_arrival_stripe`](Self::with_arrival_stripe)); the stripe picks
+    /// the global ticks this node owns. With the default full stripe the two
+    /// coincide and this is the ordinary single-node schedule.
     async fn run_arrival_rate<F>(
         &self,
         rate: f64,
@@ -1148,7 +1187,7 @@ impl VUScheduler {
         F: Fn(Arc<VUScheduler>, u32) -> tokio::task::JoinHandle<()> + Send + Sync + 'static,
     {
         tracing::info!(
-            "Starting constant arrival rate: {}/s for {:?} (pre_alloc={}, max_vus={}, grace: {:?})",
+            "Starting constant arrival rate: {}/s (global) for {:?} (pre_alloc={}, max_vus={}, grace: {:?})",
             rate,
             duration,
             pre_alloc,
@@ -1173,11 +1212,19 @@ impl VUScheduler {
         let start = time::Instant::now();
         let mut last_target: u64 = 0;
         let mut next_reap = time::Instant::now();
+        // TR-221: this node's cursor over the global arrival sequence. Cloned
+        // per run so the executor can be re-run from a fresh cursor.
+        let mut stripe = self.arrival_stripe.clone();
 
         // P1 line 139: check SIGINT stop so Ctrl-C ends the run immediately
         while start.elapsed() < duration && !self.is_stop_requested() {
             let elapsed_secs = start.elapsed().as_secs_f64();
-            let target_tokens = (elapsed_secs * rate) as u64;
+            // TR-221: count the GLOBAL arrivals due by now (k6's `gi` walked
+            // against `notScaledTickerPeriod`), then ask the stripe how many
+            // of them belong to this node. With the default full stripe this
+            // is `floor(elapsed × rate)` — the original expression.
+            let global_arrivals = (elapsed_secs * rate) as u64;
+            let target_tokens = stripe.due_by(global_arrivals);
 
             if target_tokens > last_target {
                 let to_add = target_tokens - last_target;
@@ -1260,6 +1307,10 @@ impl VUScheduler {
     /// Uses a time-based token bucket (same as `run_arrival_rate`) but the rate
     /// linearly interpolates across stages over the total stage duration.
     /// VUs are spawned on demand when the current pool is saturated, up to max_vus.
+    ///
+    /// TR-221: `start_rate` and the stage targets are the **global** rate
+    /// curve whenever an [`ArrivalStripe`] has been installed; the stripe
+    /// picks this node's ticks out of the global sequence.
     async fn run_ramping_arrival_rate<F>(
         &self,
         start_rate: f64,
@@ -1374,12 +1425,18 @@ impl VUScheduler {
         let start = time::Instant::now();
         let mut last_target: u64 = 0;
         let mut next_reap = time::Instant::now();
+        // TR-221: same striped walk as run_arrival_rate — the only difference
+        // is that the global arrival count comes from the integrated rate
+        // curve rather than `elapsed × rate` (k6 does exactly this split:
+        // `ramping_arrival_rate.go`'s `cal()` solves the curve and steps the
+        // same striped offsets).
+        let mut stripe = self.arrival_stripe.clone();
 
         // P1 line 139: check SIGINT stop so Ctrl-C ends the run immediately
         while start.elapsed() < total_duration && !self.is_stop_requested() {
             let elapsed_secs = start.elapsed().as_secs_f64();
-            let exact_tokens = tokens_at(elapsed_secs);
-            let target = exact_tokens as u64;
+            let global_arrivals = tokens_at(elapsed_secs) as u64;
+            let target = stripe.due_by(global_arrivals);
 
             if target > last_target {
                 let to_add = target - last_target;
@@ -1838,6 +1895,11 @@ impl VUScheduler {
             control_notify: self.control_notify.clone(),
             control_tainted: self.control_tainted.clone(),
             last_reap: self.last_reap.clone(),
+            // TR-221: the stripe is a cursor owned by the executor loop, not
+            // shared state — VU tasks and the control API never read it. The
+            // clone here is the pristine (un-advanced) cursor, so a shared
+            // handle can never rewind or double-advance the running one.
+            arrival_stripe: self.arrival_stripe.clone(),
         })
     }
 
@@ -3387,5 +3449,367 @@ mod tests {
         VUScheduler::await_handles_bounded(&mut handles, Duration::from_millis(10)).await;
         assert!(start.elapsed() < Duration::from_secs(1));
         assert!(handles[0].is_finished());
+    }
+
+    // ── TR-221: striped offsets in the arrival-rate executor ──────────────
+
+    /// A VU that records the wall-clock offset (from `t0`) of every arrival
+    /// token it consumes. Structurally identical to `arrival_test_vu` (same
+    /// idle guard, same pinned-`notified()` wait) but with zero simulated
+    /// latency and a timestamp log, so the recorded instants ARE the
+    /// executor's arrival schedule.
+    fn recording_arrival_vu(
+        sched: Arc<VUScheduler>,
+        t0: tokio::time::Instant,
+        log: Arc<std::sync::Mutex<Vec<Duration>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let arrival_notify = sched.arrival_notify();
+            let stop = sched.stop_signal();
+            loop {
+                if sched.is_stop_requested() || sched.is_force_stop_requested() {
+                    break;
+                }
+                let _idle_guard = sched.idle_guard();
+                let mut arrival_ready = std::pin::pin!(arrival_notify.notified());
+                let mut stop_ready = std::pin::pin!(stop.notified());
+                loop {
+                    if sched.is_stop_requested() || sched.is_force_stop_requested() {
+                        return;
+                    }
+                    if sched.try_acquire_arrival_token() {
+                        log.lock().unwrap().push(t0.elapsed());
+                        break;
+                    }
+                    tokio::select! {
+                        _ = &mut arrival_ready => {
+                            arrival_ready.set(arrival_notify.notified());
+                        }
+                        _ = &mut stop_ready => {
+                            stop_ready.set(stop.notified());
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+                    }
+                }
+            }
+        })
+    }
+
+    /// Builds one node's arrival-rate executor exactly the way `engine.rs`
+    /// does for a node running `segment_spec` of `sequence`: the segment is
+    /// applied with [`RateSegmentation::GlobalRate`] (so the rate stays
+    /// global and `pre_alloc_vus`/`max_vus` are still telescoped) and the
+    /// matching [`ArrivalStripe`] is installed on the scheduler.
+    ///
+    /// Returns the wall-clock offsets, from the shared `t0`, at which the
+    /// executor released each iteration.
+    fn node_scheduler(
+        segment_spec: &str,
+        sequence: &str,
+        global: &ExecutionConfig,
+    ) -> (VUScheduler, ExecutionConfig) {
+        let seg = tropel_core::segment::ExecutionSegment::parse(segment_spec, Some(sequence))
+            .expect("valid segment");
+        let seq = tropel_core::segment::ExecutionSegmentSequence::parse(sequence)
+            .expect("valid sequence");
+        let idx = seq.index_of(&seg).expect("segment is part of the sequence");
+        let wrapper = tropel_core::segment::ExecutionSegmentSequenceWrapper::new(&seq)
+            .expect("full sequence");
+        let node_cfg = seg.apply_with(global, tropel_core::segment::RateSegmentation::GlobalRate);
+        let sched = VUScheduler::new(&node_cfg).with_arrival_stripe(wrapper.arrival_stripe(idx));
+        (sched, node_cfg)
+    }
+
+    async fn node_arrival_times(
+        segment_spec: &str,
+        sequence: &str,
+        global_rate: f64,
+        window: Duration,
+        t0: tokio::time::Instant,
+    ) -> Vec<Duration> {
+        let global = ExecutionConfig::ConstantArrivalRate {
+            rate: global_rate,
+            time_unit: "1s".to_string(),
+            duration: format!("{}ms", window.as_millis()),
+            pre_alloc_vus: 16,
+            max_vus: 16,
+            graceful_stop: Some("0s".to_string()),
+            think_time: Default::default(),
+        };
+        let (sched, node_cfg) = node_scheduler(segment_spec, sequence, &global);
+        let (node_rate, pre_alloc, max_vus) = match &node_cfg {
+            ExecutionConfig::ConstantArrivalRate {
+                rate,
+                pre_alloc_vus,
+                max_vus,
+                ..
+            } => (*rate, *pre_alloc_vus, *max_vus),
+            _ => unreachable!(),
+        };
+        // The rate handed to the executor is the GLOBAL one on every node —
+        // that is the whole point: the stripe, not the rate, is the share.
+        assert_eq!(
+            node_rate, global_rate,
+            "striped mode must leave the arrival rate global"
+        );
+        let log: Arc<std::sync::Mutex<Vec<Duration>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log_c = log.clone();
+        let run_vu =
+            move |s: Arc<VUScheduler>, _vu: u32| recording_arrival_vu(s, t0, log_c.clone());
+        sched
+            .run_arrival_rate(
+                node_rate,
+                pre_alloc,
+                max_vus,
+                window,
+                Duration::ZERO,
+                &run_vu,
+            )
+            .await;
+        let mut v = log.lock().unwrap().clone();
+        v.sort();
+        v
+    }
+
+    /// Ramping twin of [`node_arrival_times`] — same wiring, driven through
+    /// `run_ramping_arrival_rate` with a FLAT rate curve so the expected
+    /// merged schedule is the same even cadence.
+    async fn node_ramping_arrival_times(
+        segment_spec: &str,
+        sequence: &str,
+        global_rate: f64,
+        window: Duration,
+        t0: tokio::time::Instant,
+    ) -> Vec<Duration> {
+        let stages = vec![tropel_core::config::ArrivalRateStage {
+            duration: format!("{}ms", window.as_millis()),
+            target: global_rate,
+        }];
+        let global = ExecutionConfig::RampingArrivalRate {
+            start_rate: global_rate,
+            stages,
+            time_unit: "1s".to_string(),
+            pre_alloc_vus: 16,
+            max_vus: 16,
+            graceful_stop: Some("0s".to_string()),
+            think_time: Default::default(),
+        };
+        let (sched, node_cfg) = node_scheduler(segment_spec, sequence, &global);
+        let (start_rate, stages, pre_alloc, max_vus) = match &node_cfg {
+            ExecutionConfig::RampingArrivalRate {
+                start_rate,
+                stages,
+                pre_alloc_vus,
+                max_vus,
+                ..
+            } => (*start_rate, stages.clone(), *pre_alloc_vus, *max_vus),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            start_rate, global_rate,
+            "striped mode must leave the ramping rate curve global"
+        );
+        let log: Arc<std::sync::Mutex<Vec<Duration>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log_c = log.clone();
+        let run_vu =
+            move |s: Arc<VUScheduler>, _vu: u32| recording_arrival_vu(s, t0, log_c.clone());
+        sched
+            .run_ramping_arrival_rate(
+                start_rate,
+                &stages,
+                pre_alloc,
+                max_vus,
+                Duration::ZERO,
+                &run_vu,
+            )
+            .await;
+        let mut v = log.lock().unwrap().clone();
+        v.sort();
+        v
+    }
+
+    /// TR-221 · the arrival-rate executor must INTERLEAVE across nodes.
+    ///
+    /// k6's `constant_arrival_rate.go:316-330` walks a GLOBAL iteration index
+    /// and fires only the ticks this segment owns, so N instances merge back
+    /// into the exact original global rate. Tropel ran an independent
+    /// arrival-rate executor per node, so every node fired its own scaled rate
+    /// from its own t=0 and the arrivals BUNCHED.
+    ///
+    /// 3 nodes at 50%/25%/25% (the k6 `execution_segment.go` doc example) at a
+    /// global 20/s: the merged arrival sequence must be evenly spaced at 50 ms
+    /// and must match, instant for instant, what ONE node at the full 20/s
+    /// schedules.
+    #[tokio::test(start_paused = true)]
+    async fn arrival_rate_interleaves_across_segments() {
+        const SEQUENCE: &str = "0,1/2,3/4,1";
+        const GLOBAL_RATE: f64 = 20.0;
+        let window = Duration::from_secs(2);
+        let period_ms = 1000.0 / GLOBAL_RATE; // 50 ms
+
+        let t0 = tokio::time::Instant::now();
+        let (n0, n1, n2, full) = tokio::join!(
+            node_arrival_times("0:1/2", SEQUENCE, GLOBAL_RATE, window, t0),
+            node_arrival_times("1/2:3/4", SEQUENCE, GLOBAL_RATE, window, t0),
+            node_arrival_times("3/4:1", SEQUENCE, GLOBAL_RATE, window, t0),
+            node_arrival_times("0:1", "0,1", GLOBAL_RATE, window, t0),
+        );
+
+        let mut merged: Vec<Duration> = Vec::new();
+        merged.extend_from_slice(&n0);
+        merged.extend_from_slice(&n1);
+        merged.extend_from_slice(&n2);
+        merged.sort();
+
+        let ms = |v: &[Duration]| -> Vec<u64> { v.iter().map(|d| d.as_millis() as u64).collect() };
+
+        // 1. The merged sequence must be evenly spaced at the GLOBAL period.
+        //    Bunching shows up here as gaps of 0 next to gaps of 2×period.
+        let merged_ms = ms(&merged);
+        let mut worst_gap: i64 = 0;
+        for w in merged_ms.windows(2) {
+            let gap = w[1] as i64 - w[0] as i64;
+            worst_gap = worst_gap.max((gap - period_ms as i64).abs());
+        }
+        assert!(
+            worst_gap <= 3,
+            "merged arrivals must be evenly spaced at {period_ms}ms (worst deviation {worst_gap}ms).\n  \
+             node 0:1/2   -> {:?}\n  node 1/2:3/4 -> {:?}\n  node 3/4:1   -> {:?}\n  merged       -> {:?}",
+            &ms(&n0)[..ms(&n0).len().min(10)],
+            &ms(&n1)[..ms(&n1).len().min(10)],
+            &ms(&n2)[..ms(&n2).len().min(10)],
+            &merged_ms[..merged_ms.len().min(16)],
+        );
+
+        // 2. The merged sequence must equal what a SINGLE node at the full
+        //    global rate schedules — the property that makes N nodes
+        //    indistinguishable from one, which is the whole point of striping.
+        let full_ms = ms(&full);
+        assert_eq!(
+            merged_ms.len(),
+            full_ms.len(),
+            "merged arrival count {} != single-node-at-full-rate count {}",
+            merged_ms.len(),
+            full_ms.len()
+        );
+        for (i, (m, f)) in merged_ms.iter().zip(full_ms.iter()).enumerate() {
+            assert!(
+                (*m as i64 - *f as i64).abs() <= 3,
+                "arrival {i}: striped-merged {m}ms != single-node {f}ms\n  merged -> {:?}\n  single -> {:?}",
+                &merged_ms[..merged_ms.len().min(16)],
+                &full_ms[..full_ms.len().min(16)],
+            );
+        }
+    }
+
+    /// TR-221 · the same interleaving property for `ramping-arrival-rate`.
+    ///
+    /// The ramping executor integrates the rate curve instead of multiplying
+    /// by elapsed time, but the striped walk is identical — k6 splits it the
+    /// same way (`ramping_arrival_rate.go`'s `cal()` solves the curve and
+    /// steps the same striped offsets). A FLAT curve (start == target) makes
+    /// the expected merged schedule the same even cadence, so a regression in
+    /// either executor is visible here.
+    #[tokio::test(start_paused = true)]
+    async fn ramping_arrival_rate_interleaves_across_segments() {
+        const SEQUENCE: &str = "0,1/2,3/4,1";
+        const GLOBAL_RATE: f64 = 20.0;
+        let window = Duration::from_secs(2);
+        let period_ms = 1000.0 / GLOBAL_RATE; // 50 ms
+
+        let t0 = tokio::time::Instant::now();
+        let (n0, n1, n2) = tokio::join!(
+            node_ramping_arrival_times("0:1/2", SEQUENCE, GLOBAL_RATE, window, t0),
+            node_ramping_arrival_times("1/2:3/4", SEQUENCE, GLOBAL_RATE, window, t0),
+            node_ramping_arrival_times("3/4:1", SEQUENCE, GLOBAL_RATE, window, t0),
+        );
+
+        let mut merged: Vec<u64> = Vec::new();
+        for n in [&n0, &n1, &n2] {
+            merged.extend(n.iter().map(|d| d.as_millis() as u64));
+        }
+        merged.sort();
+
+        let mut worst_gap: i64 = 0;
+        for w in merged.windows(2) {
+            let gap = w[1] as i64 - w[0] as i64;
+            worst_gap = worst_gap.max((gap - period_ms as i64).abs());
+        }
+        assert!(
+            worst_gap <= 3,
+            "merged ramping arrivals must be evenly spaced at {period_ms}ms \
+             (worst deviation {worst_gap}ms); merged -> {:?}",
+            &merged[..merged.len().min(16)],
+        );
+        // Sanity on the total: 20/s over 2s is 40 global arrivals, and the
+        // three stripes must partition them (not duplicate or drop any). The
+        // 40th is due exactly ON the 2s boundary, which the executor's
+        // half-open `elapsed < total_duration` loop has already left — so 39
+        // or 40, never 41 and never 3× anything.
+        assert!(
+            (39..=40).contains(&merged.len()),
+            "three stripes must partition the ~40 global arrivals exactly once each, got {} \
+             (per node: {} / {} / {})",
+            merged.len(),
+            n0.len(),
+            n1.len(),
+            n2.len()
+        );
+        assert_eq!(
+            n0.len() + n1.len() + n2.len(),
+            merged.len(),
+            "merged must be the union of the three stripes"
+        );
+        // 50/25/25 of ~40 arrivals.
+        assert!(
+            n0.len() >= 19 && n1.len() >= 9 && n2.len() >= 9,
+            "stripe shares must follow the segments: {} / {} / {}",
+            n0.len(),
+            n1.len(),
+            n2.len()
+        );
+    }
+
+    /// TR-221 · the un-segmented schedule must be BYTE-IDENTICAL to what it
+    /// was before striping existed: the default `ArrivalStripe::full()` owns
+    /// every global tick, so `due_by(n) == n` and the executor still fires at
+    /// `k / rate`. Guards the fallback path against the striping change.
+    #[tokio::test(start_paused = true)]
+    async fn unsegmented_arrival_schedule_is_unchanged() {
+        let window = Duration::from_secs(1);
+        let t0 = tokio::time::Instant::now();
+        let sched = VUScheduler::new(&ExecutionConfig::ConstantArrivalRate {
+            rate: 20.0,
+            time_unit: "1s".to_string(),
+            duration: "1s".to_string(),
+            pre_alloc_vus: 8,
+            max_vus: 8,
+            graceful_stop: Some("0s".to_string()),
+            think_time: Default::default(),
+        });
+        let log: Arc<std::sync::Mutex<Vec<Duration>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log_c = log.clone();
+        let run_vu =
+            move |s: Arc<VUScheduler>, _vu: u32| recording_arrival_vu(s, t0, log_c.clone());
+        sched
+            .run_arrival_rate(20.0, 8, 8, window, Duration::ZERO, &run_vu)
+            .await;
+        let mut got: Vec<u64> = log
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|d| d.as_millis() as u64)
+            .collect();
+        got.sort();
+        // 20/s for 1s: the k-th arrival lands at k × 50 ms, k = 1..=19 within
+        // the window (the 20th is due exactly at the 1s boundary, at which
+        // point the loop has already exited).
+        let expect: Vec<u64> = (1..=got.len() as u64).map(|k| k * 50).collect();
+        assert_eq!(got, expect, "un-segmented arrivals must stay at k/rate");
+        assert!(
+            (19..=20).contains(&got.len()),
+            "20/s for 1s must release ~20 arrivals, got {}",
+            got.len()
+        );
     }
 }

--- a/crates/tropel-scheduler/src/scheduler.rs
+++ b/crates/tropel-scheduler/src/scheduler.rs
@@ -3663,9 +3663,38 @@ mod tests {
 
         let ms = |v: &[Duration]| -> Vec<u64> { v.iter().map(|d| d.as_millis() as u64).collect() };
 
-        // 1. The merged sequence must be evenly spaced at the GLOBAL period.
-        //    Bunching shows up here as gaps of 0 next to gaps of 2×period.
         let merged_ms = ms(&merged);
+
+        // 0. Guard the guards: every assertion below is over `windows(2)` or a
+        //    zip, all of which are vacuously true on an empty log. 20/s over
+        //    2s is 40 global arrivals; the 40th is due exactly ON the 2s
+        //    boundary, which the half-open `elapsed < duration` loop has
+        //    already left — so 39 or 40, and never 3x anything.
+        assert!(
+            (39..=40).contains(&merged_ms.len()),
+            "three stripes must partition the ~40 global arrivals exactly once each, \
+             got {} (per node: {} / {} / {})",
+            merged_ms.len(),
+            n0.len(),
+            n1.len(),
+            n2.len()
+        );
+        assert_eq!(
+            n0.len() + n1.len() + n2.len(),
+            merged_ms.len(),
+            "merged must be the union of the three stripes"
+        );
+        // 50/25/25 of ~40 arrivals.
+        assert!(
+            n0.len() >= 19 && n1.len() >= 9 && n2.len() >= 9,
+            "stripe shares must follow the segments: {} / {} / {}",
+            n0.len(),
+            n1.len(),
+            n2.len()
+        );
+
+        // 1. The merged sequence must be evenly spaced at the GLOBAL period.
+        //    Bunching shows up here as gaps of 0 next to gaps of 2xperiod.
         let mut worst_gap: i64 = 0;
         for w in merged_ms.windows(2) {
             let gap = w[1] as i64 - w[0] as i64;


### PR DESCRIPTION
## What

TR-221's defect: tropel runs an **independent arrival-rate executor per node**, so across N distributed nodes arrivals **bunch instead of interleaving**.

`GetStripedOffsets` — `ExecutionSegmentSequence`, `ExecutionSegmentSequenceWrapper`, `SegmentedIndex` in `crates/tropel-core/src/segment.rs` — was implemented and unit-tested, matching k6's `execution_segment.go` including the k6-doc 50 %/25 %/25 % example.

**Nothing called it from the executor.** The task was marked `[x]` with the note *"The arrival-rate executor wiring is a follow-up"*, so the data structure existed while the user-visible defect — arrivals bunching in a distributed run — was completely unchanged. This wires it up.

## Task

TR-221.

## Status — read this before reviewing

**Work-in-progress, surfaced rather than held.** Written across several interrupted sessions and **not verified locally**: no `cargo test`, no `cargo clippy`, no `cargo fmt`.

**CI is the gate.** Treat every check here as the first real signal.

Specifically unproven:

- **The interleaving test may not exist, and if it does it has not been run against pre-fix code.** That is the test that matters: the existing unit tests cover the *data structure*, and a test that only re-checks the offsets computation would pass on the unfixed executor and prove nothing. What is needed is a test that drives N nodes' executors, collects scheduled iteration start times, and asserts the merged sequence is evenly spaced rather than bunched.
- Whether the segment reaches the executor through real config plumbing (`--execution-segment`) or only in the test harness.

## Acceptance

- [x] The executor consults the striped offsets rather than scheduling independently
- [ ] A test proves the merged multi-node arrival sequence interleaves
- [ ] That test demonstrated failing on pre-fix code
- [ ] Segment plumbed from CLI/config end to end

## Risk

This changes **when VUs start** in a distributed run. If the striping is applied wrongly the failure is subtle and load-shaped: arrival rate stays nominally correct while the distribution across nodes skews, which is exactly the class of bug that is invisible in a summary and obvious in a latency graph. It deserves a real multi-node check before it is trusted.

Single-node runs use one full segment and should be unaffected — that is worth confirming explicitly, since it is the common path and a regression there would be much more visible than the bug being fixed.