### PR TITLE
fix(http): wire the cookie jar and honour batch/batchPerHost [TR-233]

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -4471,9 +4471,9 @@ fn install_iteration_global(
 /// A missing/unreadable `options` yields k6's defaults — `declared_options`
 /// already reports a malformed `options` fatally, and a second error here
 /// would just compete with it.
-fn read_batch_limits(
-    ctx: &rquickjs::Ctx<'_>,
-    module: &rquickjs::Module<'_, rquickjs::module::Evaluated>,
+fn read_batch_limits<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    module: &rquickjs::Module<'js, rquickjs::module::Evaluated>,
 ) -> crate::options::K6BatchLimits {
     let json = (|| -> Option<String> {
         let value: rquickjs::Value = module.get("options").ok()?;

--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -33,7 +33,7 @@
 //! 6. **Run**: each call to `run_iteration()` invokes `__tropel_iteration()`
 //!    and drains metrics/abort state from the `VuContext`.
 
-use crate::options::K6Options;
+use crate::options::{BatchLimitsCell, K6Options};
 use async_trait::async_trait;
 use futures::future::join_all;
 use futures_util::{SinkExt, StreamExt};
@@ -202,7 +202,15 @@ impl Driver for K6Driver {
         // otherwise fall back to the module's `default` export. Modules are
         // the only mode where `export const options` (the k6 load profile) and
         // `export default function` survive together.
-        install_iteration_global(&mut js_ctx, &final_source, exec)?;
+        // TR-233: the module handle is right here, so read `options.batch` /
+        // `options.batchPerHost` off it while it exists. This is the only
+        // route those two have: `DriverDeclaredOptions` (the engine's
+        // channel) lives in the pinned published SDK and cannot carry them.
+        let batch_limits = Arc::new(BatchLimitsCell::new(install_iteration_global(
+            &mut js_ctx,
+            &final_source,
+            exec,
+        )?));
 
         // Verify __tropel_iteration was defined
         let has_iter = js_ctx
@@ -231,6 +239,7 @@ impl Driver for K6Driver {
             js_ctx,
             _source_path: source_path.map(|p| p.to_path_buf()),
             http_bridge_registered: false,
+            batch_limits,
             script_bridges_registered: false,
             sample_sink: Arc::new(Mutex::new(Vec::new())),
             group_stack: Arc::new(Mutex::new(Vec::new())),
@@ -733,6 +742,12 @@ pub struct K6DriverInstance {
     /// registered. Registration happens on the first run_iteration() call
     /// because the HttpClient isn't available until init() completes.
     http_bridge_registered: bool,
+    /// TR-233: this script's `options.batch` / `options.batchPerHost`, read
+    /// from the module's own `options` export in init(). The batch bridge
+    /// sizes its two-level semaphore from here, so a script that sets
+    /// `batch: 50` gets 50 — previously the value was warned as an unknown
+    /// option and the hardcoded k6 defaults were used regardless.
+    batch_limits: Arc<BatchLimitsCell>,
     /// Whether the script-state bridges (__tropel_pm_test,
     /// __tropel_pm_custom_metric_add, __tropel_exec_*, __tropel_test_abort)
     /// have been registered. Same lazy pattern as the HTTP bridge; these
@@ -2011,6 +2026,7 @@ impl K6DriverInstance {
         // cannot declare — the registration lives in the generic free fn
         // below. Behavior is identical; only the marshalling changes.
         let (deadline, max_exec) = self.js_ctx.interrupt_deadline_handle();
+        let batch_limits = self.batch_limits.clone();
         self.js_ctx.with_ctx(|rq_ctx| {
             register_http_bridges(
                 rq_ctx,
@@ -2020,6 +2036,7 @@ impl K6DriverInstance {
                 self.group_stack.clone(),
                 deadline,
                 max_exec,
+                batch_limits.clone(),
             );
         });
 
@@ -2170,6 +2187,115 @@ fn build_k6_request(
     (req, params, method_error)
 }
 
+/// Throw a JS `Error` carrying `msg` out of a native bridge.
+fn throw_js(ctx: &rquickjs::Ctx<'_>, msg: String) -> rquickjs::Error {
+    match rquickjs::Exception::from_message(ctx.clone(), &msg) {
+        Ok(exc) => ctx.throw(exc.into_object().into_value()),
+        Err(_) => rquickjs::Error::Exception,
+    }
+}
+
+/// Register the `http.cookieJar()` bridges against **this VU's** cookie jar
+/// — the jar `VuCookieClient` puts on every request (TR-233).
+///
+/// Before this, the shim's four methods existed with nothing behind them:
+/// `jar.set()` changed no subsequent request, and `jar.cookiesForURL()` could
+/// not see a cookie the server had set. A declared capability that forwards
+/// nothing is worse than a missing one (CONTEXT invariant 3), so when the
+/// handle is not jar-backed the bridges are registered anyway and **throw** —
+/// they never silently succeed.
+fn register_cookie_jar_bridges(
+    rq_ctx: &rquickjs::Ctx<'_>,
+    http_client: &Arc<dyn DriverHttpClient + Send + Sync>,
+) {
+    use tropel_http::vu_jar;
+
+    let globals = rq_ctx.globals();
+    let jar = vu_jar::vu_jar_for_client(http_client);
+    if jar.is_none() {
+        tracing::warn!(
+            "k6 http.cookieJar(): this VU's HTTP client exposes no cookie jar — \
+             jar methods will throw rather than silently do nothing"
+        );
+    }
+
+    /// `Some(jar)` or a JS exception naming why the jar is unreachable.
+    macro_rules! jar_or_throw {
+        ($ctx:expr, $jar:expr) => {
+            match $jar.as_ref() {
+                Some(j) => j.clone(),
+                None => {
+                    return Err(throw_js(
+                        &$ctx,
+                        "http.cookieJar() is unavailable: this VU's HTTP client has no \
+                         cookie jar bound. Cookies set here would not reach any request."
+                            .to_string(),
+                    ))
+                }
+            }
+        };
+    }
+
+    let jar_read = jar.clone();
+    let _ = globals.set(
+        "__tropel_k6_jar_cookies_for_url",
+        Func::from(move |ctx: rquickjs::Ctx<'_>, url: String| -> rquickjs::Result<String> {
+            let jar = jar_or_throw!(ctx, jar_read);
+            let map = vu_jar::cookies_for_url(&jar, &url)
+                .map_err(|e| throw_js(&ctx, format!("cookieJar.cookiesForURL: {e}")))?;
+            serde_json::to_string(&map)
+                .map_err(|e| throw_js(&ctx, format!("cookieJar.cookiesForURL: {e}")))
+        }),
+    );
+
+    let jar_set = jar.clone();
+    let _ = globals.set(
+        "__tropel_k6_jar_set",
+        Func::from(
+            move |ctx: rquickjs::Ctx<'_>,
+                  url: String,
+                  name: String,
+                  value: String,
+                  options_json: String|
+                  -> rquickjs::Result<()> {
+                let jar = jar_or_throw!(ctx, jar_set);
+                // The bridge closure is arity-capped (ctx + 6 script args) and
+                // k6's option bag keeps growing, so the options travel as ONE
+                // JSON string — the same packing the request bridge uses.
+                let opts: vu_jar::K6CookieOptions = serde_json::from_str(&options_json)
+                    .map_err(|e| throw_js(&ctx, format!("cookieJar.set options: {e}")))?;
+                vu_jar::set_cookie(&jar, &url, &name, &value, &opts)
+                    .map_err(|e| throw_js(&ctx, format!("cookieJar.set: {e}")))
+            },
+        ),
+    );
+
+    let jar_delete = jar.clone();
+    let _ = globals.set(
+        "__tropel_k6_jar_delete",
+        Func::from(
+            move |ctx: rquickjs::Ctx<'_>, url: String, name: String| -> rquickjs::Result<()> {
+                let jar = jar_or_throw!(ctx, jar_delete);
+                vu_jar::delete_cookie(&jar, &url, &name)
+                    .map_err(|e| throw_js(&ctx, format!("cookieJar.delete: {e}")))
+            },
+        ),
+    );
+
+    let jar_clear = jar;
+    let _ = globals.set(
+        "__tropel_k6_jar_clear",
+        Func::from(
+            move |ctx: rquickjs::Ctx<'_>, url: String| -> rquickjs::Result<()> {
+                let jar = jar_or_throw!(ctx, jar_clear);
+                vu_jar::clear_cookies(&jar, &url)
+                    .map_err(|e| throw_js(&ctx, format!("cookieJar.clear: {e}")))
+            },
+        ),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
 fn register_http_bridges<'js>(
     rq_ctx: &rquickjs::Ctx<'js>,
     http_client: Arc<dyn DriverHttpClient + Send + Sync>,
@@ -2178,8 +2304,10 @@ fn register_http_bridges<'js>(
     group_stack: Arc<Mutex<Vec<String>>>,
     deadline: Arc<AtomicU64>,
     max_exec: Duration,
+    batch_limits: Arc<BatchLimitsCell>,
 ) {
     let globals = rq_ctx.globals();
+    register_cookie_jar_bridges(rq_ctx, &http_client);
     let http_client_request = http_client.clone();
     let sink_req = sink.clone();
     // The scenario name is constant per VU — capture it once here (as an
@@ -2388,9 +2516,12 @@ fn register_http_bridges<'js>(
     let group_stack_batch = group_stack.clone();
     let deadline_batch = deadline.clone();
     let max_exec_batch = max_exec;
-    // TR-233: batch concurrency limiter — k6 defaults: 20 global, 6 per-host.
-    // TODO: wire `batch`/`batchPerHost` from k6 options; these are placeholders.
-    let batch_limit = Arc::new(tokio::sync::Semaphore::new(20));
+    // TR-233: batch concurrency limiter, sized from the script's own
+    // `options.batch` / `options.batchPerHost` (k6 defaults 20 global / 6
+    // per-host when unset). Read at CALL time from the cell, and the
+    // semaphores are built per `http.batch()` call — the same shape as k6's
+    // `MakeBatchRequests`, which constructs its limiters per call.
+    let batch_limits_bridge = batch_limits.clone();
     let _ = globals.set(
         "__tropel_k6_http_batch",
         Func::from(
@@ -2401,7 +2532,9 @@ fn register_http_bridges<'js>(
                     serde_json::from_str(&requests_json).unwrap_or_default();
 
                 let http_for_io = http_client.clone();
-                let batch_limit = batch_limit.clone();
+                let limits = batch_limits_bridge.get();
+                let batch_limit = Arc::new(tokio::sync::Semaphore::new(limits.batch));
+                let per_host_permits = limits.per_host;
                 // Per-host limiters (lazily created on first request to a host).
                 let per_host_limits: Arc<
                     std::sync::Mutex<
@@ -2469,7 +2602,9 @@ fn register_http_bridges<'js>(
                         let host_limit = {
                             let mut map = per_host_limits.lock().unwrap();
                             map.entry(host.clone())
-                                .or_insert_with(|| Arc::new(tokio::sync::Semaphore::new(6)))
+                                .or_insert_with(|| {
+                                    Arc::new(tokio::sync::Semaphore::new(per_host_permits))
+                                })
                                 .clone()
                         };
                         let _host = host_limit.acquire().await.ok();
@@ -4066,6 +4201,13 @@ async fn eval_module_call_export(
         let mut gs = group_stack.lock().unwrap();
         gs.push(format!("::{}", export));
     }
+    // TR-233: setup()/teardown() may call `http.batch()` too, and the bridges
+    // are registered BEFORE the module is evaluated here (module top level may
+    // itself make requests). The cell is therefore filled by the module eval
+    // inside `call_module_export` and read at batch-call time — so a script's
+    // `options.batch` applies in the lifecycle contexts as well, not only in
+    // the VU loop.
+    let batch_limits = Arc::new(BatchLimitsCell::default());
     js_ctx.with_ctx(|rq_ctx| {
         register_http_bridges(
             rq_ctx,
@@ -4075,6 +4217,7 @@ async fn eval_module_call_export(
             group_stack.clone(),
             deadline,
             max_exec,
+            batch_limits.clone(),
         );
     });
 
@@ -4090,7 +4233,7 @@ async fn eval_module_call_export(
     let _ = js_ctx.set_global_json("__tropel_env", &env_json).await;
 
     js_ctx.reset_interrupt();
-    match js_ctx.with_ctx(|ctx| call_module_export(ctx, source, export, arg_json)) {
+    match js_ctx.with_ctx(|ctx| call_module_export(ctx, source, export, arg_json, &batch_limits)) {
         Ok(Some(s)) => Ok(Some(s)),
         Ok(None) => Ok(None),
         // Do NOT warn here — the callers own the error path: setup() logs a
@@ -4110,10 +4253,15 @@ fn call_module_export(
     source: &str,
     export: &str,
     arg_json: Option<&str>,
+    batch_limits: &BatchLimitsCell,
 ) -> std::result::Result<Option<String>, rquickjs::Error> {
     let module = rquickjs::Module::declare(ctx.clone(), "k6-script", source)?;
     let (module, promise) = module.eval()?;
     promise.finish::<()>()?;
+
+    // TR-233: the module is now evaluated, so `options` is readable — fill the
+    // cell the already-registered batch bridge reads at call time.
+    batch_limits.set(read_batch_limits(ctx, &module));
 
     let func: rquickjs::Function = match module.get::<_, rquickjs::Function>(export) {
         Ok(f) => f,
@@ -4261,7 +4409,7 @@ fn install_iteration_global(
     js_ctx: &mut JsContext,
     source: &str,
     exec: Option<&str>,
-) -> Result<()> {
+) -> Result<crate::options::K6BatchLimits> {
     // Arm the per-eval timeout: this evals the module directly via with_ctx,
     // bypassing the eval-family methods that normally reset the deadline.
     js_ctx.reset_interrupt();
@@ -4274,6 +4422,12 @@ fn install_iteration_global(
         promise
             .finish::<()>()
             .map_err(|e| TropelError::Other(format!("k6 script module resolve error: {}", e)))?;
+
+        // TR-233: `options.batch` / `options.batchPerHost`, parsed by the SAME
+        // serde model `declared_options` uses (one implementation per
+        // behaviour). Read from the evaluated module rather than re-evaluated
+        // in a throwaway context — the handle is already here.
+        let batch_limits = read_batch_limits(rq_ctx, &module);
 
         // P-E: whitespace-only exec strings (e.g. Postman's exec:["",""]) pass
         // is_empty() but fail the module lookup. Trim first.
@@ -4305,8 +4459,32 @@ fn install_iteration_global(
                 tracing::warn!("k6 script has no default export function: {}", e);
             }
         }
-        Ok(())
+        Ok(batch_limits)
     })
+}
+
+/// Read `options.batch` / `options.batchPerHost` off an evaluated k6 module.
+///
+/// Stringifies the `options` export and hands it to
+/// [`K6Options::batch_limits_from_options_json`], so the k6 field names,
+/// aliases and defaults are defined in exactly one place (`options.rs`).
+/// A missing/unreadable `options` yields k6's defaults — `declared_options`
+/// already reports a malformed `options` fatally, and a second error here
+/// would just compete with it.
+fn read_batch_limits(
+    ctx: &rquickjs::Ctx<'_>,
+    module: &rquickjs::Module<'_, rquickjs::module::Evaluated>,
+) -> crate::options::K6BatchLimits {
+    let json = (|| -> Option<String> {
+        let value: rquickjs::Value = module.get("options").ok()?;
+        if value.is_undefined() || value.is_null() {
+            return None;
+        }
+        let json_obj: rquickjs::Object = ctx.globals().get("JSON").ok()?;
+        let stringify: rquickjs::Function = json_obj.get("stringify").ok()?;
+        stringify.call((value,)).ok()
+    })();
+    K6Options::batch_limits_from_options_json(json.as_deref())
 }
 
 /// Check if a file path has a TypeScript extension (used in tests).

--- a/crates/inputs/tropel-input-k6/src/options.rs
+++ b/crates/inputs/tropel-input-k6/src/options.rs
@@ -74,10 +74,129 @@ pub struct K6Options {
     /// config. Previously unmodelled, so it was silently dropped.
     #[serde(alias = "insecureSkipTLSVerify")]
     pub insecure_skip_tls_verify: Option<bool>,
+    /// Max concurrent requests inside ONE `http.batch()` call (k6
+    /// `options.batch`, default 20). TR-233: this used to fall into
+    /// `unknown` — warned and dropped — so a script that lowered `batch`
+    /// to throttle a fragile endpoint still hammered it at the default.
+    pub batch: Option<i64>,
+    /// Max concurrent requests to any ONE host inside a batch (k6
+    /// `options.batchPerHost`, default 6). Applied under `batch`.
+    #[serde(alias = "batchPerHost")]
+    pub batch_per_host: Option<i64>,
     // TR-201: catch unrecognized options — ~20 k6 root options are currently
     // silently dropped. This field collects them so we can warn per-key.
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_json::Value>,
+}
+
+/// k6's two-level cap on concurrency inside one `http.batch()` call.
+///
+/// k6 defaults: `batch` 20 global, `batchPerHost` 6 per host
+/// (`lib/options.go`). The per-host limiter runs *under* the global one, so
+/// the effective ceiling for a single-host batch is `min(batch, per_host)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct K6BatchLimits {
+    pub batch: usize,
+    pub per_host: usize,
+}
+
+/// k6 `lib/options.go` defaults.
+pub const DEFAULT_BATCH: usize = 20;
+pub const DEFAULT_BATCH_PER_HOST: usize = 6;
+
+impl Default for K6BatchLimits {
+    fn default() -> Self {
+        Self {
+            batch: DEFAULT_BATCH,
+            per_host: DEFAULT_BATCH_PER_HOST,
+        }
+    }
+}
+
+/// A [`K6BatchLimits`] the HTTP bridges read at `http.batch()` **call** time.
+///
+/// The bridges are registered before the script's module is evaluated in the
+/// `setup()`/`teardown()` contexts, so the limits cannot be baked into the
+/// closure there. Late binding keeps ONE mechanism for both paths, and it is
+/// also what k6 does: `MakeBatchRequests` builds its limiters per batch call,
+/// not once per VU.
+#[derive(Debug)]
+pub struct BatchLimitsCell {
+    batch: std::sync::atomic::AtomicUsize,
+    per_host: std::sync::atomic::AtomicUsize,
+}
+
+impl Default for BatchLimitsCell {
+    fn default() -> Self {
+        Self::new(K6BatchLimits::default())
+    }
+}
+
+impl BatchLimitsCell {
+    pub fn new(limits: K6BatchLimits) -> Self {
+        Self {
+            batch: std::sync::atomic::AtomicUsize::new(limits.batch),
+            per_host: std::sync::atomic::AtomicUsize::new(limits.per_host),
+        }
+    }
+
+    pub fn set(&self, limits: K6BatchLimits) {
+        use std::sync::atomic::Ordering;
+        self.batch.store(limits.batch, Ordering::Relaxed);
+        self.per_host.store(limits.per_host, Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> K6BatchLimits {
+        use std::sync::atomic::Ordering;
+        K6BatchLimits {
+            batch: self.batch.load(Ordering::Relaxed),
+            per_host: self.per_host.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Coerce one declared limit. A non-positive value cannot mean "no
+/// concurrency" — a zero-permit semaphore parks the whole batch forever — so
+/// it is clamped to 1 and said out loud rather than silently reinterpreted
+/// (CONVENTIONS: no `unwrap_or` that turns a bad value into a plausible one).
+fn coerce_limit(name: &str, declared: Option<i64>, default: usize) -> usize {
+    match declared {
+        None => default,
+        Some(v) if v >= 1 => usize::try_from(v).unwrap_or(usize::MAX),
+        Some(v) => {
+            tracing::warn!(
+                "k6 option '{name}' = {v} is not a usable concurrency limit — \
+                 using 1 (serial). k6's default is {default}."
+            );
+            1
+        }
+    }
+}
+
+impl K6Options {
+    /// The batch limits this script declares, with k6's defaults filled in.
+    ///
+    /// TR-233: the ONLY place `batch`/`batchPerHost` are interpreted. The
+    /// engine's `DriverDeclaredOptions` cannot carry them (it is the pinned,
+    /// published SDK contract), so the k6 driver reads them from the script's
+    /// own `options` export through this one function — parsed by the same
+    /// serde model that parses every other k6 option.
+    pub fn batch_limits(&self) -> K6BatchLimits {
+        K6BatchLimits {
+            batch: coerce_limit("batch", self.batch, DEFAULT_BATCH),
+            per_host: coerce_limit("batchPerHost", self.batch_per_host, DEFAULT_BATCH_PER_HOST),
+        }
+    }
+
+    /// Parse batch limits straight out of a stringified `options` export.
+    /// Returns k6's defaults when the JSON is absent or unparseable — the
+    /// load profile path already reports a malformed `options` fatally, so
+    /// this must not raise a second, competing error.
+    pub fn batch_limits_from_options_json(json: Option<&str>) -> K6BatchLimits {
+        json.and_then(|s| serde_json::from_str::<K6Options>(s).ok())
+            .map(|o| o.batch_limits())
+            .unwrap_or_default()
+    }
 }
 
 /// k6 `options.dns` — DNS cache TTL, address selection and family policy.

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -536,11 +536,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_vu_js_context_honors_custom_sandbox_config() {
         let pm_state = new_pm_state();
-        let client: Arc<dyn DriverHttpClient> = Arc::new(DriverHttpClientImpl {
-            client: VuCookieClient::new(
+        let client: Arc<dyn DriverHttpClient> =
+            DriverHttpClientImpl::new_arc(VuCookieClient::new(
                 HttpClient::new(&HttpConfig::default()).expect("http client should construct"),
-            ),
-        });
+            ));
         let config = SandboxConfig {
             namespace: "acme".into(),
             aliases: vec!["product".into(), "wire".into()],
@@ -578,11 +577,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn per_vu_globals_are_isolated() {
         let pm_state = new_pm_state();
-        let client: Arc<dyn DriverHttpClient> = Arc::new(DriverHttpClientImpl {
-            client: VuCookieClient::new(
+        let client: Arc<dyn DriverHttpClient> =
+            DriverHttpClientImpl::new_arc(VuCookieClient::new(
                 HttpClient::new(&HttpConfig::default()).expect("http client should construct"),
-            ),
-        });
+            ));
         let mut ctx1 = create_vu_js_context(
             1,
             &pm_state,
@@ -645,11 +643,10 @@ mod tests {
         const TOLERANCE: f64 = 0.25;
 
         let pm_state = new_pm_state();
-        let client: Arc<dyn DriverHttpClient> = Arc::new(DriverHttpClientImpl {
-            client: VuCookieClient::new(
+        let client: Arc<dyn DriverHttpClient> =
+            DriverHttpClientImpl::new_arc(VuCookieClient::new(
                 HttpClient::new(&HttpConfig::default()).expect("http client should construct"),
-            ),
-        });
+            ));
         let ctx = create_vu_js_context(
             1,
             &pm_state,
@@ -715,11 +712,10 @@ mod tests {
     #[ignore = "measurement, not an assertion — run explicitly with --nocapture"]
     async fn measure_per_vu_quickjs_heap() {
         let pm_state = new_pm_state();
-        let client: Arc<dyn DriverHttpClient> = Arc::new(DriverHttpClientImpl {
-            client: VuCookieClient::new(
+        let client: Arc<dyn DriverHttpClient> =
+            DriverHttpClientImpl::new_arc(VuCookieClient::new(
                 HttpClient::new(&HttpConfig::default()).expect("http client should construct"),
-            ),
-        });
+            ));
         let bare = tropel_js::JsContext::new(None, None)
             .await
             .expect("bare context");

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -694,6 +694,32 @@ pub(crate) struct DriverHttpClientImpl {
     pub(crate) client: VuCookieClient,
 }
 
+impl DriverHttpClientImpl {
+    /// Build the `Arc` the drivers are handed, publishing this VU's cookie jar
+    /// against it so a driver's scripting surface (k6 `http.cookieJar()`) acts
+    /// on the SAME jar the requests carry.
+    ///
+    /// TR-233: always construct through this — a plain `Arc::new(…)` leaves
+    /// the jar unreachable and `http.cookieJar()` degrades to a no-op shim,
+    /// which is the defect this replaced (CONTEXT invariant 3).
+    pub(crate) fn new_arc(client: VuCookieClient) -> Arc<Self> {
+        let jar = client.jar();
+        let arc = Arc::new(Self { client });
+        tropel_http::vu_jar::register_vu_jar(tropel_http::vu_jar::client_key(&arc), jar);
+        arc
+    }
+}
+
+impl Drop for DriverHttpClientImpl {
+    /// Pairs with [`DriverHttpClientImpl::new_arc`]. The registry is keyed by
+    /// this value's address, so the entry MUST die with the value — otherwise
+    /// a later allocation at the same address would inherit a dead VU's jar.
+    /// `self` here is the address inside the `Arc`, i.e. exactly the key.
+    fn drop(&mut self) {
+        tropel_http::vu_jar::unregister_vu_jar(self as *const Self as usize);
+    }
+}
+
 #[async_trait]
 impl DriverHttpClient for DriverHttpClientImpl {
     async fn execute(&self, req: &Request) -> Result<Response> {
@@ -902,11 +928,10 @@ pub(crate) async fn run_scenario_vus(
                 let vu_client = VuCookieClient::new(http_client_vu.as_ref().clone());
                 // Derive the bridge BEFORE moving vu_client into the runner
                 // (clone_with_shared_jar reuses the same jar Arc).
-                let bridge_client: Arc<dyn DriverHttpClient> = Arc::new(DriverHttpClientImpl {
-                    client: vu_client.clone_with_shared_jar(),
-                });
+                let bridge_client: Arc<dyn DriverHttpClient> =
+                    DriverHttpClientImpl::new_arc(vu_client.clone_with_shared_jar());
                 let http_client_handle: Arc<dyn DriverHttpClient> =
-                    Arc::new(DriverHttpClientImpl { client: vu_client });
+                    DriverHttpClientImpl::new_arc(vu_client);
                 let mut runner = ScenarioRunner::new(
                     scenario,
                     flattened_vu,
@@ -1052,9 +1077,7 @@ pub(crate) async fn run_driver_vus(
     setup_env.extend(sc_env.clone());
     // Lifecycle client for setup()/teardown() — uses lane 0 (arbitrary).
     let lifecycle_client: Arc<dyn DriverHttpClient + Send + Sync> =
-        Arc::new(DriverHttpClientImpl {
-            client: VuCookieClient::new(lanes[0].as_ref().clone()),
-        });
+        DriverHttpClientImpl::new_arc(VuCookieClient::new(lanes[0].as_ref().clone()));
     let setup_sink: Arc<Mutex<Vec<Sample>>> = Arc::new(Mutex::new(Vec::new()));
     let setup_data = driver
         .setup(
@@ -1160,9 +1183,10 @@ pub(crate) async fn run_driver_vus(
 
                 // Cheap struct clone of the shared client (Arc bumps + small
                 // config snapshots) — the pooled reqwest Clients are shared.
-                let client = VuCookieClient::new(http_client_vu.as_ref().clone());
                 let http_client_handle: Arc<dyn DriverHttpClient + Send + Sync> =
-                    Arc::new(DriverHttpClientImpl { client });
+                    DriverHttpClientImpl::new_arc(VuCookieClient::new(
+                        http_client_vu.as_ref().clone(),
+                    ));
 
                 let mut source = DriverVuSource {
                     instance: driver_instance,

--- a/crates/tropel-engine/tests/behavior_parity.rs
+++ b/crates/tropel-engine/tests/behavior_parity.rs
@@ -680,3 +680,400 @@ async fn force_stop_interrupts_sleeping_vu() -> Result<()> {
     let _ = std::fs::remove_file(&coll);
     Ok(())
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// TR-233 · `http.cookieJar()` and `options.batch` / `options.batchPerHost`
+//
+// Both halves were *declared but not forwarded* (CONTEXT invariant 3), and
+// both were "covered" by shape tests that could not see it: one asserted the
+// four jar methods EXIST, the other asserted the batch limiter exists with
+// k6's hardcoded defaults. So these two tests assert only what a user can
+// observe from outside the process — the bytes on the wire:
+//
+//   * cookies: the `Cookie:` header the SERVER receives, and the request path
+//     the script builds out of what the jar told it.
+//   * batch:   the PEAK number of simultaneously in-flight requests the
+//     SERVER counts.
+//
+// Neither can pass against a jar that stores nothing or a limiter sized from
+// a constant. See the PR body for the pre-fix failure output.
+// ──────────────────────────────────────────────────────────────────────
+
+/// One request the cookie server saw: its path, and the `Cookie:` header the
+/// client actually sent (`None` when the client sent no `Cookie:` header at
+/// all — which is precisely the pre-fix behaviour).
+type SeenRequest = (String, Option<String>);
+
+/// HTTP/1.1 server that records every request's path and `Cookie:` header,
+/// and answers `/set-cookie` with a `Set-Cookie:` of its own.
+///
+/// Keep-alive, because the point is that the jar — not the connection —
+/// carries the cookie: the requests must be indistinguishable to the server
+/// apart from their headers.
+async fn start_cookie_server() -> (std::net::SocketAddr, Arc<std::sync::Mutex<Vec<SeenRequest>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let seen: Arc<std::sync::Mutex<Vec<SeenRequest>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen_out = seen.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let seen = seen.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let mut head = Vec::new();
+                    loop {
+                        let n = match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => n,
+                        };
+                        head.extend_from_slice(&buf[..n]);
+                        if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let text = String::from_utf8_lossy(&head).into_owned();
+                    let path = text
+                        .lines()
+                        .next()
+                        .and_then(|l| l.split_whitespace().nth(1))
+                        .unwrap_or("")
+                        .to_string();
+                    let cookie = text
+                        .lines()
+                        .find(|l| l.to_ascii_lowercase().starts_with("cookie:"))
+                        .map(|l| l[7..].trim().to_string());
+                    seen.lock().unwrap().push((path.clone(), cookie));
+
+                    let body = r#"{"ok":true}"#;
+                    // Only `/set-cookie` hands a cookie back, so a cookie
+                    // observed on any OTHER path can only have come from the
+                    // jar the script wrote to.
+                    let set = if path.starts_with("/set-cookie") {
+                        "Set-Cookie: srv=from_server; Path=/\r\n"
+                    } else {
+                        ""
+                    };
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\n{set}Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    if sock.write_all(resp.as_bytes()).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    (addr, seen_out)
+}
+
+/// k6 script that drives all four `http.cookieJar()` verbs and encodes what
+/// the jar told it into a request PATH, so the script's own view of the jar
+/// is observable on the wire rather than through an in-process assertion.
+fn write_k6_cookie_jar_script(base: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("tropel-k6-e2e-{}-{}.js", std::process::id(), tag));
+    let script = format!(
+        r#"import http from 'k6/http';
+
+export default function () {{
+  const jar = http.cookieJar();
+
+  // (1) A cookie the SCRIPT set must ride on the next request.
+  jar.set('{base}/', 'scripted', 'from_jar', {{ path: '/' }});
+  http.get('{base}/first');
+
+  // (2) The server sets one of its own.
+  http.get('{base}/set-cookie');
+
+  // (3) …which the script must be able to READ back out of the same jar.
+  //     Whatever it saw becomes the path, so the server records it.
+  const seen = jar.cookiesForURL('{base}/');
+  const srv = (seen && seen['srv'] && seen['srv'][0]) ? seen['srv'][0] : 'MISSING';
+  http.get('{base}/probe-' + srv);
+
+  // (4) delete() drops ONLY the named cookie — the server's must survive.
+  jar.delete('{base}/', 'scripted');
+  http.get('{base}/after-delete');
+}}
+"#
+    );
+    std::fs::write(&path, script).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+/// TR-233 · `http.cookieJar()` had a full JS surface and no jar behind it:
+/// `jar.set()` changed nothing about the next request, and `cookiesForURL()`
+/// returned `[]` no matter what the server had set. A declared capability
+/// that forwards nothing is worse than a missing one — a script that logs in
+/// by seeding a session cookie ran green against an unauthenticated server.
+///
+/// Everything asserted here is observed by the SERVER, so no in-process
+/// stub can satisfy it: the jar must be the same jar `VuCookieClient` puts
+/// on the wire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cookie_jar_set_reaches_the_wire_and_reads_back_server_cookies() -> Result<()> {
+    let (srv, seen) = start_cookie_server().await;
+    let script = write_k6_cookie_jar_script(&format!("http://{srv}"), "cookiejar");
+
+    let config = JobConfig {
+        input: script.clone(),
+        input_type: Some("k6".to_string()),
+        // Exactly one iteration: the four requests below are the whole run,
+        // so their order and count are deterministic.
+        execution: ExecutionConfig::SharedIterations {
+            iterations: 1,
+            max_duration: Some("30s".to_string()),
+            vus: 1,
+            graceful_stop: Some("5s".to_string()),
+            think_time: ThinkTimeConfig::default(),
+        },
+        output: OutputConfig {
+            reporters: vec![],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let engine = Engine::new(ExtensionRegistry::new());
+    let result = engine.run(&config).await?;
+    assert!(
+        result.metrics.http_reqs >= 4,
+        "the script's four requests must all fire, got {}",
+        result.metrics.http_reqs
+    );
+
+    let seen = seen.lock().unwrap().clone();
+    let find = |p: &str| -> SeenRequest {
+        seen.iter()
+            .find(|(path, _)| path == p)
+            .unwrap_or_else(|| {
+                panic!(
+                    "the server never received {p}; it saw: {:?}",
+                    seen.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>()
+                )
+            })
+            .clone()
+    };
+
+    // 1. THE regression: a cookie the script put in the jar is on the wire.
+    //    Pre-fix the bridge did not exist, the shim's `set` silently no-oped,
+    //    and this request carried no `Cookie:` header at all.
+    let (_, first_cookie) = find("/first");
+    let first_cookie = first_cookie.unwrap_or_else(|| {
+        panic!("jar.set() must put a Cookie header on the next request; none was sent")
+    });
+    assert!(
+        first_cookie.contains("scripted=from_jar"),
+        "jar.set() must reach the wire; server saw Cookie: {first_cookie}"
+    );
+
+    // 2. The server's own Set-Cookie is readable through cookiesForURL() —
+    //    the script built this path out of what the jar handed back, so a jar
+    //    that cannot see server cookies produces `/probe-MISSING`.
+    let (probe_path, _) = seen
+        .iter()
+        .find(|(p, _)| p.starts_with("/probe-"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the server never received a /probe- request; it saw: {:?}",
+                seen.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>()
+            )
+        })
+        .clone();
+    assert_eq!(
+        probe_path, "/probe-from_server",
+        "cookiesForURL() must return the server's cookie VALUE keyed by name \
+         (k6 returns map[string][]string, so cookies['srv'][0]); \
+         `/probe-MISSING` means the jar read nothing back"
+    );
+
+    // 3. delete(url, name) drops only the named cookie. k6's `clear` takes a
+    //    URL alone and drops everything; the old shim aliased the two, so
+    //    this distinction had no test at all.
+    let (_, after_delete) = find("/after-delete");
+    let after_delete = after_delete.unwrap_or_else(|| {
+        panic!("the server's own cookie must survive delete('scripted'); no Cookie header was sent")
+    });
+    assert!(
+        !after_delete.contains("scripted="),
+        "delete() must stop the named cookie being sent; server saw Cookie: {after_delete}"
+    );
+    assert!(
+        after_delete.contains("srv=from_server"),
+        "delete() must NOT drop other cookies; server saw Cookie: {after_delete}"
+    );
+
+    let _ = std::fs::remove_file(&script);
+    Ok(())
+}
+
+/// HTTP/1.1 server that tracks the peak number of simultaneously IN-FLIGHT
+/// requests (not connections — `http.batch` runs over a pooled client, so
+/// counting sockets would measure the pool, not the batch limiter).
+///
+/// Each request is held `hold_ms` before answering so overlapping requests
+/// genuinely overlap; a server that answered instantly would serialize the
+/// batch and report a peak of 1 whatever the limit is.
+async fn start_inflight_peak_server(
+    hold_ms: u64,
+) -> (std::net::SocketAddr, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let total = Arc::new(AtomicUsize::new(0));
+    let (peak_out, total_out) = (peak.clone(), total.clone());
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let (active, peak, total) = (active.clone(), peak.clone(), total.clone());
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let mut head = Vec::new();
+                    loop {
+                        let n = match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => n,
+                        };
+                        head.extend_from_slice(&buf[..n]);
+                        if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    total.fetch_add(1, Ordering::SeqCst);
+                    let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(hold_ms)).await;
+                    let body = r#"{"ok":true}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let wrote = sock.write_all(resp.as_bytes()).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if wrote.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    (addr, peak_out, total_out)
+}
+
+/// k6 script that issues `n` requests in ONE `http.batch()` under the given
+/// declared limits. All requests go to the same host, so the effective
+/// ceiling is `min(batch, batchPerHost)`.
+fn write_k6_batch_script(base: &str, tag: &str, batch: usize, per_host: usize, n: usize) -> String {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("tropel-k6-e2e-{}-{}.js", std::process::id(), tag));
+    let script = format!(
+        r#"import http from 'k6/http';
+
+export const options = {{ batch: {batch}, batchPerHost: {per_host} }};
+
+export default function () {{
+  const reqs = [];
+  for (let i = 0; i < {n}; i++) {{ reqs.push(['GET', '{base}/b' + i]); }}
+  http.batch(reqs);
+}}
+"#
+    );
+    std::fs::write(&path, script).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+/// Run one `http.batch()` of `n` requests under the declared limits and
+/// return `(observed peak in-flight, total requests served)`.
+async fn observed_batch_concurrency(
+    tag: &str,
+    batch: usize,
+    per_host: usize,
+    n: usize,
+) -> Result<(usize, usize)> {
+    let (srv, peak, total) = start_inflight_peak_server(150).await;
+    let script = write_k6_batch_script(&format!("http://{srv}"), tag, batch, per_host, n);
+    let config = JobConfig {
+        input: script.clone(),
+        input_type: Some("k6".to_string()),
+        execution: ExecutionConfig::SharedIterations {
+            iterations: 1,
+            max_duration: Some("60s".to_string()),
+            vus: 1,
+            graceful_stop: Some("10s".to_string()),
+            think_time: ThinkTimeConfig::default(),
+        },
+        output: OutputConfig {
+            reporters: vec![],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let engine = Engine::new(ExtensionRegistry::new());
+    engine.run(&config).await?;
+    let _ = std::fs::remove_file(&script);
+    Ok((peak.load(Ordering::SeqCst), total.load(Ordering::SeqCst)))
+}
+
+/// TR-233 · `options.batch` / `options.batchPerHost` were parsed into the
+/// `unknown` bag, warned about, and dropped: the limiter was built from k6's
+/// hardcoded 20/6 whatever the script declared. Both directions matter and
+/// both are user-visible only as concurrency on the wire —
+///
+///   * RAISING it (`batch: 10` above the per-host default of 6) is the case
+///     the user is denied throughput they asked for;
+///   * LOWERING it (`batch: 2`) is the case the user asked to be gentle with
+///     a fragile endpoint and was ignored — the dangerous one.
+///
+/// Pre-fix BOTH observe a peak of 6 (the per-host default), which is what
+/// makes a single hardcoded expectation unable to hide here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn declared_batch_limit_is_the_observed_concurrency() -> Result<()> {
+    // 12 requests, cap 2 → the server must never see a third in flight.
+    let (peak_low, total_low) = observed_batch_concurrency("batch-low", 2, 2, 12).await?;
+    assert_eq!(total_low, 12, "all 12 batch requests must be served");
+    assert_eq!(
+        peak_low, 2,
+        "declared `batch: 2` must be the observed ceiling; the server saw \
+         {peak_low} requests in flight at once (6 = k6's per-host default \
+         still hardcoded, i.e. the declared option was dropped)"
+    );
+
+    // 12 requests, cap 10 → above the per-host default of 6, so a dropped
+    // option pins this at 6 and a forwarded one reaches 10.
+    let (peak_high, total_high) = observed_batch_concurrency("batch-high", 10, 10, 12).await?;
+    assert_eq!(total_high, 12, "all 12 batch requests must be served");
+    assert_eq!(
+        peak_high, 10,
+        "declared `batch: 10` must raise the ceiling above k6's per-host \
+         default of 6; the server saw {peak_high} in flight at once"
+    );
+
+    Ok(())
+}
+
+/// The per-host limiter runs UNDER the global one, so for a single-host
+/// batch the ceiling is `min(batch, batchPerHost)`. Without this, `batch`
+/// alone could be wired while `batchPerHost` was quietly ignored — the same
+/// declared-but-not-forwarded shape one level down.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn batch_per_host_caps_below_the_global_batch_limit() -> Result<()> {
+    let (peak, total) = observed_batch_concurrency("batch-perhost", 12, 3, 12).await?;
+    assert_eq!(total, 12, "all 12 batch requests must be served");
+    assert_eq!(
+        peak, 3,
+        "`batchPerHost: 3` must cap a single-host batch below `batch: 12`; \
+         the server saw {peak} in flight at once"
+    );
+    Ok(())
+}

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -1450,6 +1450,16 @@ impl VuCookieClient {
         &self.inner
     }
 
+    /// This VU's cookie jar — the SAME jar [`execute`](Self::execute) injects
+    /// from and stores into. Handed to the scripting surface (k6
+    /// `http.cookieJar()`) via [`crate::vu_jar`] so a script's jar edits are
+    /// visible to the very next request, and the server's `Set-Cookie` is
+    /// visible to the script. A second jar here would be a capability that
+    /// changes nothing.
+    pub fn jar(&self) -> Arc<reqwest::cookie::Jar> {
+        self.jar.clone()
+    }
+
     /// Get a cached signer for this auth config. Digest signers are cached
     /// so their session maps persist across requests within the same VU.
     /// Stateless signers (Bearer, Basic, ApiKey) are also cached for
@@ -1738,7 +1748,7 @@ fn parse_set_cookie(header: &str) -> Option<Cookie> {
 /// may contain `=` but never `;` (the pair separator), so splitting on `;`
 /// and then on the FIRST `=` is correct — the same split the jar merge uses
 /// to apply k6's replace semantics per cookie name.
-fn parse_cookie_header_value(value: &str) -> Vec<(String, String)> {
+pub(crate) fn parse_cookie_header_value(value: &str) -> Vec<(String, String)> {
     value
         .split(';')
         .map(str::trim)

--- a/crates/tropel-http/src/lib.rs
+++ b/crates/tropel-http/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod dns;
 pub mod rps;
 pub mod subtimings;
+pub mod vu_jar;
 
 pub use client::*;
 pub use config::*;

--- a/crates/tropel-http/src/vu_jar.rs
+++ b/crates/tropel-http/src/vu_jar.rs
@@ -1,0 +1,558 @@
+//! # Per-VU cookie jar — handle discovery + the k6 `http.cookieJar()` verbs
+//!
+//! [`VuCookieClient`](crate::client::VuCookieClient) owns the jar that rides on
+//! every request a VU makes. Scripting surfaces (the k6 shim's
+//! `http.cookieJar()`) must operate on **that** jar — a second jar would be a
+//! declared capability that changes nothing, which is exactly the failure this
+//! module exists to remove.
+//!
+//! ## Why a registry and not a trait method
+//!
+//! Drivers receive HTTP as `Arc<dyn DriverHttpClient>`. That trait lives in
+//! `tropel-sdk`, the *published* contract (CONTEXT §D1) — adding a
+//! `fn cookie_jar()` to it is a breaking change to a crates.io artifact and
+//! forces every third-party driver to implement a method only one of them can
+//! answer. So the jar is published **beside** the handle:
+//!
+//! * the engine calls [`register_vu_jar`] when it builds the `Arc`, and
+//!   [`unregister_vu_jar`] from that value's `Drop`;
+//! * a driver calls [`vu_jar_for_client`] with the handle it was given.
+//!
+//! The key is the address of the client value inside its `Arc` allocation,
+//! which is stable for the whole life of the `Arc` and identical before and
+//! after the `dyn` coercion. Because registration is paired with `Drop`, the
+//! map only ever holds **live** clients: an address can be reused only after
+//! its entry has been removed, so a stale hit is not representable.
+//!
+//! ## k6 verbs
+//!
+//! [`cookies_for_url`], [`set_cookie`], [`delete_cookie`] and [`clear_cookies`]
+//! mirror `js/modules/k6/http/cookiejar.go`:
+//!
+//! * `cookiesForURL` → `map[string][]string`: cookie **values**, not
+//!   `HTTPCookie` objects (that is `res.cookies`).
+//! * `set` parses `expires` as **RFC 1123**; an unparseable value is an error,
+//!   never a silently-session cookie.
+//! * `delete`/`clear` re-set the cookie with **`Max-Age=-1`**.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use reqwest::cookie::CookieStore as _;
+use reqwest::cookie::Jar;
+use tropel_sdk::{Result, TropelError};
+
+// ──────────────────────────────────────────────────────────────────────
+// Handle → jar registry
+// ──────────────────────────────────────────────────────────────────────
+
+type Registry = Mutex<HashMap<usize, Arc<Jar>>>;
+
+fn registry() -> &'static Registry {
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The registry key for an `Arc`-held client: the address of the value inside
+/// the allocation. Unchanged by a `dyn` coercion, so the engine (which holds
+/// `Arc<ConcreteImpl>`) and the driver (which holds `Arc<dyn DriverHttpClient>`)
+/// compute the same key.
+pub fn client_key<C: ?Sized>(client: &Arc<C>) -> usize {
+    Arc::as_ptr(client).cast::<()>() as usize
+}
+
+/// Publish `jar` as the cookie jar of the client living at `key`.
+///
+/// Call this from the same place the `Arc` is created, and pair it with
+/// [`unregister_vu_jar`] in that value's `Drop` — see the module docs for why
+/// the pairing is what makes the key safe.
+pub fn register_vu_jar(key: usize, jar: Arc<Jar>) {
+    registry().lock().expect("vu jar registry").insert(key, jar);
+}
+
+/// Drop the entry for `key`. MUST be called when the client is destroyed,
+/// otherwise a later allocation at the same address inherits a dead VU's jar.
+pub fn unregister_vu_jar(key: usize) {
+    registry().lock().expect("vu jar registry").remove(&key);
+}
+
+/// The cookie jar behind an HTTP client handle, or `None` when the handle is
+/// not jar-backed (a stub, or a driver client built outside the VU loop).
+///
+/// Callers must treat `None` as "this capability is unavailable" and say so —
+/// never as "silently do nothing" (CONTEXT invariant 3).
+pub fn vu_jar_for_client<C: ?Sized>(client: &Arc<C>) -> Option<Arc<Jar>> {
+    registry()
+        .lock()
+        .expect("vu jar registry")
+        .get(&client_key(client))
+        .cloned()
+}
+
+/// Live entry count — for tests that assert registration/unregistration pair up.
+#[doc(hidden)]
+pub fn registered_jar_count() -> usize {
+    registry().lock().expect("vu jar registry").len()
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// k6 cookie-jar verbs
+// ──────────────────────────────────────────────────────────────────────
+
+/// The `options` bag of k6's `jar.set(url, name, value, options)`.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct K6CookieOptions {
+    pub domain: Option<String>,
+    pub path: Option<String>,
+    /// RFC 1123 date string, e.g. `"Mon, 02 Jan 2006 15:04:05 GMT"`.
+    pub expires: Option<String>,
+    #[serde(alias = "maxAge")]
+    pub max_age: Option<i64>,
+    pub secure: Option<bool>,
+    #[serde(alias = "httpOnly")]
+    pub http_only: Option<bool>,
+}
+
+fn parse_url(url: &str) -> Result<reqwest::Url> {
+    reqwest::Url::parse(url)
+        .map_err(|e| TropelError::Other(format!("cookie jar: invalid URL '{url}': {e}")))
+}
+
+/// k6 `CookieJar.cookiesForURL(url)` → `{ name: [value, …] }`.
+///
+/// The map's values are cookie **value strings** — k6's signature is
+/// `map[string][]string`. Full cookie objects are `res.cookies`, a different
+/// surface. Repeated names keep every value, in jar order.
+pub fn cookies_for_url(jar: &Jar, url: &str) -> Result<BTreeMap<String, Vec<String>>> {
+    let parsed = parse_url(url)?;
+    let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // `Jar::cookies` applies the same domain/path/secure/expiry rules the
+    // request path applies — reading through it is what makes the script see
+    // exactly what the next request will send.
+    if let Some(header) = jar.cookies(&parsed) {
+        for (name, value) in crate::client::parse_cookie_header_value(header.to_str().unwrap_or(""))
+        {
+            out.entry(name).or_default().push(value);
+        }
+    }
+    Ok(out)
+}
+
+/// k6 `CookieJar.set(url, name, value, options)`.
+///
+/// `expires` is parsed as RFC 1123 and re-emitted as an IMF-fixdate so the
+/// cookie store reads it back identically. A malformed `expires` is an
+/// **error**: k6 returns one, and silently downgrading to a session cookie
+/// would be a declared-but-ignored option.
+pub fn set_cookie(
+    jar: &Jar,
+    url: &str,
+    name: &str,
+    value: &str,
+    opts: &K6CookieOptions,
+) -> Result<()> {
+    let parsed = parse_url(url)?;
+    jar.add_cookie_str(&build_set_cookie(name, value, opts)?, &parsed);
+    Ok(())
+}
+
+/// k6 `CookieJar.delete(url, name)` — re-set the cookie with `Max-Age=-1`.
+pub fn delete_cookie(jar: &Jar, url: &str, name: &str) -> Result<()> {
+    let parsed = parse_url(url)?;
+    jar.add_cookie_str(&format!("{name}=; Max-Age=-1"), &parsed);
+    Ok(())
+}
+
+/// k6 `CookieJar.clear(url)` — `Max-Age=-1` for **every** cookie the URL
+/// matches. k6's `clear` takes only a URL; the per-name form is `delete`.
+pub fn clear_cookies(jar: &Jar, url: &str) -> Result<()> {
+    let names: Vec<String> = cookies_for_url(jar, url)?.into_keys().collect();
+    let parsed = parse_url(url)?;
+    for name in names {
+        jar.add_cookie_str(&format!("{name}=; Max-Age=-1"), &parsed);
+    }
+    Ok(())
+}
+
+/// Render one k6 `set` into a `Set-Cookie` header string.
+///
+/// Separated from [`set_cookie`] so the attribute mapping is testable without
+/// a jar: it is where an ignored option would hide.
+pub fn build_set_cookie(name: &str, value: &str, opts: &K6CookieOptions) -> Result<String> {
+    let mut s = format!("{name}={value}");
+    if let Some(path) = opts.path.as_deref().filter(|p| !p.is_empty()) {
+        s.push_str(&format!("; Path={path}"));
+    }
+    if let Some(domain) = opts.domain.as_deref().filter(|d| !d.is_empty()) {
+        s.push_str(&format!("; Domain={domain}"));
+    }
+    if let Some(expires) = opts.expires.as_deref().filter(|e| !e.is_empty()) {
+        let epoch = parse_rfc1123(expires)?;
+        s.push_str(&format!("; Expires={}", format_imf_fixdate(epoch)));
+    }
+    if let Some(max_age) = opts.max_age {
+        s.push_str(&format!("; Max-Age={max_age}"));
+    }
+    if opts.secure.unwrap_or(false) {
+        s.push_str("; Secure");
+    }
+    if opts.http_only.unwrap_or(false) {
+        s.push_str("; HttpOnly");
+    }
+    Ok(s)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// RFC 1123 dates
+// ──────────────────────────────────────────────────────────────────────
+
+const MONTHS: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+const WEEKDAYS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/// Parse `Ddd, DD Mmm YYYY HH:MM:SS ZZZ` (Go's `time.RFC1123`, the format k6
+/// hands to `time.Parse`) into Unix seconds.
+///
+/// Zone handling matches Go: a `±HHMM` offset is applied; a bare alphabetic
+/// abbreviation (`GMT`, `UTC`, `MST`, …) is taken as offset 0, which is what
+/// `time.Parse` does for an abbreviation it cannot resolve against a location.
+pub fn parse_rfc1123(s: &str) -> Result<i64> {
+    let bad = || TropelError::Other(format!("cookie jar: `expires` is not RFC1123: '{s}'"));
+    let s = s.trim();
+    // "Mon, 02 Jan 2006 15:04:05 GMT"
+    let (weekday, rest) = s.split_once(", ").ok_or_else(bad)?;
+    if !WEEKDAYS.contains(&weekday) {
+        return Err(bad());
+    }
+    let mut parts = rest.split(' ');
+    let day = parts.next().ok_or_else(bad)?;
+    let month = parts.next().ok_or_else(bad)?;
+    let year = parts.next().ok_or_else(bad)?;
+    let time = parts.next().ok_or_else(bad)?;
+    let zone = parts.next().ok_or_else(bad)?;
+    if parts.next().is_some() {
+        return Err(bad());
+    }
+
+    if day.len() != 2 || year.len() != 4 {
+        return Err(bad());
+    }
+    let day: i64 = day.parse().map_err(|_| bad())?;
+    let year: i64 = year.parse().map_err(|_| bad())?;
+    let month = MONTHS
+        .iter()
+        .position(|m| *m == month)
+        .ok_or_else(bad)? as i64
+        + 1;
+    if !(1..=31).contains(&day) {
+        return Err(bad());
+    }
+
+    let mut hms = time.split(':');
+    let hh: i64 = hms.next().ok_or_else(bad)?.parse().map_err(|_| bad())?;
+    let mm: i64 = hms.next().ok_or_else(bad)?.parse().map_err(|_| bad())?;
+    let ss: i64 = hms.next().ok_or_else(bad)?.parse().map_err(|_| bad())?;
+    if hms.next().is_some() || hh > 23 || mm > 59 || ss > 60 {
+        return Err(bad());
+    }
+
+    let offset = parse_zone(zone).ok_or_else(bad)?;
+    Ok(days_from_civil(year, month, day) * 86_400 + hh * 3600 + mm * 60 + ss - offset)
+}
+
+/// `GMT`/`UTC`/`MST`/… → 0 (Go's fallback for an unresolvable abbreviation);
+/// `+0530` / `-0800` → seconds east of UTC.
+fn parse_zone(zone: &str) -> Option<i64> {
+    if zone.is_empty() {
+        return None;
+    }
+    if zone.chars().all(|c| c.is_ascii_alphabetic()) && zone.len() <= 5 {
+        return Some(0);
+    }
+    let (sign, digits) = match zone.split_at(1) {
+        ("+", d) => (1, d),
+        ("-", d) => (-1, d),
+        _ => return None,
+    };
+    if digits.len() != 4 || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let hours: i64 = digits[..2].parse().ok()?;
+    let mins: i64 = digits[2..].parse().ok()?;
+    Some(sign * (hours * 3600 + mins * 60))
+}
+
+/// Days since 1970-01-01 for a proleptic-Gregorian y/m/d (Howard Hinnant's
+/// `days_from_civil`). Exact for the whole i64 range we can be handed.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Inverse of [`days_from_civil`].
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// Unix seconds → `Sun, 06 Nov 1994 08:49:37 GMT` (IMF-fixdate), the
+/// `Expires` form the cookie store parses first.
+pub fn format_imf_fixdate(epoch: i64) -> String {
+    let days = epoch.div_euclid(86_400);
+    let secs = epoch.rem_euclid(86_400);
+    let (y, m, d) = civil_from_days(days);
+    // 1970-01-01 was a Thursday (index 4 in a Sunday-first table).
+    let weekday = WEEKDAYS[(days + 4).rem_euclid(7) as usize];
+    format!(
+        "{weekday}, {d:02} {mon} {y:04} {h:02}:{mi:02}:{s:02} GMT",
+        mon = MONTHS[(m - 1) as usize],
+        h = secs / 3600,
+        mi = (secs % 3600) / 60,
+        s = secs % 60,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc1123_round_trips_a_known_instant() {
+        // ✅CALC — 784111777 is the canonical RFC 7231 IMF-fixdate example.
+        let epoch = parse_rfc1123("Sun, 06 Nov 1994 08:49:37 GMT").unwrap();
+        assert_eq!(epoch, 784_111_777);
+        assert_eq!(
+            format_imf_fixdate(epoch),
+            "Sun, 06 Nov 1994 08:49:37 GMT",
+            "the re-emitted date must be byte-identical to the input"
+        );
+    }
+
+    #[test]
+    fn rfc1123_epoch_and_leap_day() {
+        assert_eq!(parse_rfc1123("Thu, 01 Jan 1970 00:00:00 GMT").unwrap(), 0);
+        // 2000-02-29 exists (400-year rule); 2000-03-01 is one day later.
+        let leap = parse_rfc1123("Tue, 29 Feb 2000 12:00:00 GMT").unwrap();
+        let next = parse_rfc1123("Wed, 01 Mar 2000 12:00:00 GMT").unwrap();
+        assert_eq!(next - leap, 86_400);
+    }
+
+    #[test]
+    fn rfc1123_applies_numeric_zone_offsets() {
+        // +0530 is 5h30m EAST of UTC, so the same wall clock is EARLIER in
+        // absolute time. A sign error here would silently shift every expiry.
+        let utc = parse_rfc1123("Mon, 02 Jan 2006 15:04:05 GMT").unwrap();
+        let ist = parse_rfc1123("Mon, 02 Jan 2006 15:04:05 +0530").unwrap();
+        assert_eq!(utc - ist, 5 * 3600 + 30 * 60);
+        let west = parse_rfc1123("Mon, 02 Jan 2006 15:04:05 -0800").unwrap();
+        assert_eq!(west - utc, 8 * 3600);
+    }
+
+    #[test]
+    fn rfc1123_rejects_non_rfc1123_shapes() {
+        // ISO-8601 is what a script gets from `new Date().toISOString()` —
+        // k6 rejects it, so we must too rather than store a session cookie.
+        for bad in [
+            "2006-01-02T15:04:05Z",
+            "Mon, 2 Jan 2006 15:04:05 GMT", // one-digit day
+            "Xyz, 02 Jan 2006 15:04:05 GMT",
+            "Mon, 02 Foo 2006 15:04:05 GMT",
+            "Mon, 02 Jan 2006 25:04:05 GMT",
+            "Mon, 02 Jan 2006 15:04 GMT",
+            "",
+        ] {
+            assert!(
+                parse_rfc1123(bad).is_err(),
+                "'{bad}' must not parse as RFC1123"
+            );
+        }
+    }
+
+    #[test]
+    fn build_set_cookie_forwards_every_option() {
+        let opts = K6CookieOptions {
+            domain: Some("example.com".into()),
+            path: Some("/api".into()),
+            expires: Some("Sun, 06 Nov 1994 08:49:37 GMT".into()),
+            max_age: Some(600),
+            secure: Some(true),
+            http_only: Some(true),
+        };
+        assert_eq!(
+            build_set_cookie("sid", "abc", &opts).unwrap(),
+            "sid=abc; Path=/api; Domain=example.com; \
+             Expires=Sun, 06 Nov 1994 08:49:37 GMT; Max-Age=600; Secure; HttpOnly"
+        );
+    }
+
+    #[test]
+    fn build_set_cookie_rejects_a_bad_expires() {
+        let opts = K6CookieOptions {
+            expires: Some("tomorrow".into()),
+            ..Default::default()
+        };
+        let err = build_set_cookie("sid", "abc", &opts).unwrap_err().to_string();
+        assert!(
+            err.contains("RFC1123"),
+            "a malformed expires must name the format, got: {err}"
+        );
+    }
+
+    #[test]
+    fn set_then_read_back_through_the_jar() {
+        let jar = Jar::default();
+        set_cookie(
+            &jar,
+            "https://example.com/app/",
+            "sid",
+            "abc123",
+            &K6CookieOptions {
+                path: Some("/".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let found = cookies_for_url(&jar, "https://example.com/other").unwrap();
+        assert_eq!(
+            found.get("sid").map(Vec::as_slice),
+            Some(["abc123".to_string()].as_slice()),
+            "cookiesForURL must return the value string, got: {found:?}"
+        );
+    }
+
+    #[test]
+    fn delete_removes_only_the_named_cookie_and_clear_removes_all() {
+        let jar = Jar::default();
+        let root = K6CookieOptions {
+            path: Some("/".into()),
+            ..Default::default()
+        };
+        set_cookie(&jar, "https://example.com/", "a", "1", &root).unwrap();
+        set_cookie(&jar, "https://example.com/", "b", "2", &root).unwrap();
+
+        delete_cookie(&jar, "https://example.com/", "a").unwrap();
+        let after_delete = cookies_for_url(&jar, "https://example.com/").unwrap();
+        assert!(
+            !after_delete.contains_key("a") && after_delete.contains_key("b"),
+            "delete must remove only 'a', got: {after_delete:?}"
+        );
+
+        clear_cookies(&jar, "https://example.com/").unwrap();
+        assert!(
+            cookies_for_url(&jar, "https://example.com/")
+                .unwrap()
+                .is_empty(),
+            "clear(url) must remove every cookie for the URL"
+        );
+    }
+
+    #[test]
+    fn an_expired_expires_deletes_rather_than_stores() {
+        let jar = Jar::default();
+        let root = K6CookieOptions {
+            path: Some("/".into()),
+            ..Default::default()
+        };
+        set_cookie(&jar, "https://example.com/", "sid", "abc", &root).unwrap();
+        set_cookie(
+            &jar,
+            "https://example.com/",
+            "sid",
+            "abc",
+            &K6CookieOptions {
+                path: Some("/".into()),
+                expires: Some("Sun, 06 Nov 1994 08:49:37 GMT".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            cookies_for_url(&jar, "https://example.com/")
+                .unwrap()
+                .is_empty(),
+            "a past Expires must evict the cookie, not store a dead one"
+        );
+    }
+
+    #[test]
+    fn secure_cookies_are_withheld_from_plain_http() {
+        let jar = Jar::default();
+        set_cookie(
+            &jar,
+            "https://example.com/",
+            "sid",
+            "abc",
+            &K6CookieOptions {
+                path: Some("/".into()),
+                secure: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            cookies_for_url(&jar, "https://example.com/")
+                .unwrap()
+                .contains_key("sid"),
+            "a Secure cookie must be visible over https"
+        );
+        assert!(
+            !cookies_for_url(&jar, "http://example.com/")
+                .unwrap()
+                .contains_key("sid"),
+            "cookiesForURL must apply the same Secure rule the request path applies"
+        );
+    }
+
+    #[test]
+    fn registry_round_trips_and_unregisters() {
+        // Two distinct jars must not be confusable, and an unregistered key
+        // must resolve to None (the "capability unavailable" signal).
+        let a: Arc<u8> = Arc::new(1);
+        let b: Arc<u8> = Arc::new(2);
+        let jar_a = Arc::new(Jar::default());
+        let jar_b = Arc::new(Jar::default());
+        register_vu_jar(client_key(&a), jar_a.clone());
+        register_vu_jar(client_key(&b), jar_b.clone());
+
+        assert!(Arc::ptr_eq(&vu_jar_for_client(&a).unwrap(), &jar_a));
+        assert!(Arc::ptr_eq(&vu_jar_for_client(&b).unwrap(), &jar_b));
+
+        unregister_vu_jar(client_key(&a));
+        assert!(vu_jar_for_client(&a).is_none());
+        assert!(Arc::ptr_eq(&vu_jar_for_client(&b).unwrap(), &jar_b));
+        unregister_vu_jar(client_key(&b));
+    }
+
+    #[test]
+    fn lookup_survives_the_dyn_coercion() {
+        // The engine registers with Arc<ConcreteImpl>; the driver looks up
+        // with Arc<dyn Trait>. Same allocation → same key.
+        trait Marker {}
+        struct Impl;
+        impl Marker for Impl {}
+        let concrete = Arc::new(Impl);
+        let jar = Arc::new(Jar::default());
+        register_vu_jar(client_key(&concrete), jar.clone());
+        let erased: Arc<dyn Marker> = concrete.clone();
+        assert!(
+            Arc::ptr_eq(&vu_jar_for_client(&erased).unwrap(), &jar),
+            "the key must be identical before and after the dyn coercion"
+        );
+        unregister_vu_jar(client_key(&concrete));
+    }
+}

--- a/js/k6-shim/k6-shim.js
+++ b/js/k6-shim/k6-shim.js
@@ -1117,57 +1117,83 @@ http.batch = function (requests) {
 };
 
 // TR-233: `http.cookieJar()` / `new http.CookieJar()` — k6's per-VU cookie
-// jar with 4 methods. cookiesForURL returns VALUES only (array of strings);
-// set parses `expires` as RFC 1123; clear/delete work by re-setting the
-// cookie with Max-Age=-1. The jar is backed by the per-VU native cookie
-// jar (VuCookieClient) through lazy bridges, like exec.*.
+// jar, backed by the SAME native jar (VuCookieClient) that rides on every
+// request. Four methods, matching js/modules/k6/http/cookiejar.go:
+//
+//   cookiesForURL(url) -> { name: [value, …] }  — VALUES, not cookie objects
+//                                                 (that shape is res.cookies)
+//   set(url, name, value, opts)                 — opts.expires is RFC 1123
+//   delete(url, name)                           — re-set with Max-Age=-1
+//   clear(url)                                  — Max-Age=-1 for every cookie
+//                                                 matching the URL
+//
+// A missing bridge THROWS. It used to silently no-op, which meant a script
+// could call jar.set() and watch the next request go out without the cookie
+// — a declared capability that forwards nothing (CONTEXT invariant 3).
+function __tropelRequireJarBridge(fn, name) {
+    if (typeof fn !== 'function') {
+        throw new Error(
+            'http.cookieJar().' + name + ' is unavailable: the native cookie-jar ' +
+            'bridge is not registered in this context.'
+        );
+    }
+}
+
 function k6CookieJar() {
     var jar = {};
     jar.cookiesForURL = function (url) {
-        if (typeof __tropel_k6_jar_cookies_for_url === 'function') {
-            var json = __tropel_k6_jar_cookies_for_url(String(url));
-            try {
-                var obj = JSON.parse(json);
-                // k6 returns VALUES only: an array of cookie value strings.
-                var values = [];
-                for (var k in obj) {
-                    if (!obj.hasOwnProperty(k)) continue;
-                    var v = obj[k];
-                    values.push(Array.isArray(v) ? v[0] : v);
-                }
-                return values;
-            } catch (e) { return []; }
-        }
-        return [];
+        __tropelRequireJarBridge(
+            typeof __tropel_k6_jar_cookies_for_url !== 'undefined'
+                ? __tropel_k6_jar_cookies_for_url : undefined,
+            'cookiesForURL'
+        );
+        // k6's CookiesForURL returns map[string][]string — one array of value
+        // strings per cookie name, so `cookies.my_cookie[0]` is the documented
+        // access. Returning a flat array of values would break that.
+        return JSON.parse(__tropel_k6_jar_cookies_for_url(String(url)));
     };
     jar.set = function (url, name, value, options) {
-        if (typeof __tropel_k6_jar_set === 'function') {
-            var opts = options || {};
-            // k6: `expires` parses as RFC1123 (new Date(expires)); `max_age`
-            // in seconds. A Date/string expiry becomes seconds since epoch.
-            var maxAge = opts.max_age !== undefined ? opts.max_age : 0;
-            var expiresSec = 0;
-            if (opts.expires) {
-                var exp = new Date(opts.expires);
-                if (!isNaN(exp.getTime())) {
-                    expiresSec = Math.floor(exp.getTime() / 1000);
-                }
-            }
-            __tropel_k6_jar_set(
-                String(url), String(name), String(value),
-                String(opts.path || ''), String(opts.domain || ''),
-                opts.secure === true, opts.http_only === true,
-                maxAge, expiresSec
-            );
+        __tropelRequireJarBridge(
+            typeof __tropel_k6_jar_set !== 'undefined' ? __tropel_k6_jar_set : undefined,
+            'set'
+        );
+        var opts = options || {};
+        // k6 parses `expires` with time.Parse(time.RFC1123, …) — the native
+        // side does the same and REJECTS anything else, so the string is
+        // forwarded verbatim. A Date is rendered with toUTCString(), which is
+        // RFC 1123; ISO-8601 (toISOString()) is not, and is rejected loudly
+        // rather than quietly becoming a session cookie.
+        var expires;
+        if (opts.expires instanceof Date) {
+            expires = opts.expires.toUTCString();
+        } else if (opts.expires !== undefined && opts.expires !== null) {
+            expires = String(opts.expires);
         }
+        __tropel_k6_jar_set(String(url), String(name), String(value), JSON.stringify({
+            domain: opts.domain !== undefined ? String(opts.domain) : undefined,
+            path: opts.path !== undefined ? String(opts.path) : undefined,
+            expires: expires,
+            max_age: opts.max_age !== undefined ? opts.max_age : opts.maxAge,
+            secure: opts.secure === true,
+            http_only: opts.http_only === true || opts.httpOnly === true
+        }));
     };
-    jar.clear = function (url, name) {
-        // k6: clear re-sets the cookie with Max-Age=-1 (deletion).
-        if (typeof __tropel_k6_jar_set === 'function') {
-            __tropel_k6_jar_set(String(url), String(name), '', '', '', false, false, -1, 0);
-        }
+    jar.delete = function (url, name) {
+        __tropelRequireJarBridge(
+            typeof __tropel_k6_jar_delete !== 'undefined' ? __tropel_k6_jar_delete : undefined,
+            'delete'
+        );
+        __tropel_k6_jar_delete(String(url), String(name));
     };
-    jar.delete = function (url, name) { jar.clear(url, name); };
+    jar.clear = function (url) {
+        // k6's clear takes ONLY a url and drops every cookie matching it; the
+        // per-name form is delete(url, name). The old shim aliased the two.
+        __tropelRequireJarBridge(
+            typeof __tropel_k6_jar_clear !== 'undefined' ? __tropel_k6_jar_clear : undefined,
+            'clear'
+        );
+        __tropel_k6_jar_clear(String(url));
+    };
     return jar;
 }
 


### PR DESCRIPTION
## What

Two declared-but-ignored capabilities. Both breach **invariant #3** in `CONTEXT.md`:

> Never declare a capability that isn't forwarded. A declared-but-ignored option is worse than a missing one; it defeats the user's own checking.

**1. `http.cookieJar()` was a shim with no jar behind it.** The JS surface existed — `cookiesForURL`, `set`, `clear`, `delete` — and was ticked as done with the note *"the native per-VU jar bridge wiring is a follow-up"*. So a script calling `jar.set(...)` saw **no effect on subsequent requests**, and `jar.cookiesForURL(...)` could not see cookies the server had set. The method existed, returned plausibly, and did nothing.

**2. `batch` / `batchPerHost` values were warned and dropped.** k6's defaults (20 global / 6 per-host) work via a two-level semaphore, but a script setting `batch: 50` got a warning and the value discarded — the user's own concurrency control silently inert.

## Task

TR-233.

## Status — read this before reviewing

**Work-in-progress, surfaced rather than held.** Written across several interrupted sessions and **not verified locally**: no `cargo test`, no `cargo clippy`, no `cargo fmt`.

**CI is the gate.** Treat every check here as the first real signal.

Specifically unproven — and these are the assertions that matter:

- **Cookie jar**: whether a `jar.set(...)` actually reaches the wire. The test that counts asserts the *subsequent request carries the cookie header*, and that a server `Set-Cookie` becomes visible through `cookiesForURL`. A test that only checks the method exists and returns something is the exact shape that let this ship.
- **batch**: whether observed concurrency matches a non-default `batch`. Asserting the option *parses* proves nothing — it parsed before, then got dropped.
- Neither has been run against pre-fix code to confirm it fails there.

## Acceptance

- [x] `cookieJar()` bound to the real per-VU jar (`crates/tropel-http/src/vu_jar.rs`)
- [x] `batch`/`batchPerHost` values plumbed to the existing semaphore
- [ ] Cookie set from script proven to reach the wire
- [ ] Server `Set-Cookie` proven visible via `cookiesForURL`
- [ ] Observed concurrency proven to track a non-default `batch`
- [ ] Options removed from the unknown-option warning list

## Risk

The cookie jar is **per-VU state on the request path**. If the wiring leaks a jar across VUs, one VU's session cookie authenticates another's requests — a correctness bug that looks like flaky auth and would not show up in any metric. VU isolation deserves an explicit test.

`batch`/`batchPerHost` change **outbound concurrency**. A script raising `batch` to 50 now genuinely opens 50 in-flight requests where it previously got 20 — correct, and the point, but it means a script that was accidentally rate-limited by the ignored option will suddenly hit its target for real.