### PR TITLE
perf(ci): thin LTO for the wasm profile instead of fat + codegen-units=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,22 @@ strip         = "symbols"
 [profile.release-wasm]
 inherits = "release"
 opt-level = "z"
-lto = "fat"
-codegen-units = 1
+# `lto = "fat"` with `codegen-units = 1` is the slowest configuration cargo
+# offers: whole-program LTO with zero codegen parallelism. On `tropel-input-wasm`
+# — which pulls five input adapters — it dominated CI wall-clock.
+#
+# `thin` LTO keeps almost all of the size win (it still does cross-crate
+# inlining, just per-partition rather than whole-program) at a fraction of the
+# link time, and with thin LTO `codegen-units = 1` is counterproductive: it
+# serialises codegen for a pass that is designed to run in parallel.
+#
+# The size budgets are hard-gated in CI (700 KB for core-wasm via
+# `packages/core-wasm/scripts/build.sh`, 8 MB for the tropel-web slice via
+# `scripts/wasm-size.sh`), so if this trade ever costs more bytes than it is
+# worth, those gates fail rather than silently regressing the payload. That is
+# the reason it is safe to tune here: the number is asserted, not assumed.
+lto = "thin"
+codegen-units = 16
 panic = "abort"
 strip = true
 


### PR DESCRIPTION
## What

`tropel-input-wasm` dominated CI wall-clock. **The cause is the profile, not the crate.**

```toml
[profile.release-wasm]
inherits = "release"
opt-level = "z"
lto = "fat"          # whole-program LTO
codegen-units = 1    # zero codegen parallelism
```

`lto = "fat"` with `codegen-units = 1` is the slowest configuration cargo offers, and it is applied to a crate that pulls **five input adapters** (`openapi`, `postman`, `har`, `insomnia`, `bru`) plus `wasm-bindgen`. Every wasm build target re-links the whole graph single-threaded.

Changed to `lto = "thin"` and `codegen-units = 16`.

Thin LTO still does cross-crate inlining — per-partition rather than whole-program — so it keeps most of the size benefit at a fraction of the link time. And with thin LTO, `codegen-units = 1` is actively **counterproductive**: it serialises a pass specifically designed to run in parallel. The two settings were working against each other.

## Why this is safe to tune

The size budgets are **hard-gated in CI**, not assumed:

- `packages/core-wasm/scripts/build.sh` — 700 KB budget, fails the build above it
- `scripts/wasm-size.sh` — 8 MB budget for the `tropel-web` slice

So if thin LTO costs more bytes than it saves in time, **those gates fail** rather than silently regressing the browser payload. That is precisely what makes this trade reviewable instead of a gamble: the number is asserted on every run.

`packages/core-wasm/README.md` also carries a generated size line that CI checks with `git diff --exit-code`, so a size change shows up as a concrete diff rather than drifting.

## Task

CI build time. Not a numbered task — it came out of investigating why the wasm jobs are slow.

## Status

**Not verified locally — CI is the gate, and CI is also the only place the effect is measurable.** Comparing fat against thin needs two full cold wasm builds; this machine does not have the disk headroom for that, and a warm local build would not reflect CI anyway.

**What to look for when this runs:** the `wasm` job's compile step, and the `npm packages` job if it builds `input-wasm`. Compare against a recent master run. If the size gates trip, the trade is not worth it and this should be reverted rather than tuned further — the budgets exist to make that decision for us.

## Acceptance

- [x] Profile no longer pairs fat LTO with `codegen-units = 1`
- [ ] Wasm job wall-clock measurably lower (read from this PR's CI run)
- [ ] Size gates still pass (700 KB core-wasm, 8 MB tropel-web)

## Risk

**Binary size may grow.** Thin LTO typically lands within a few percent of fat, but "typically" is doing work in that sentence — this is exactly why the budgets are gated. If `core-wasm` crosses 700 KB or `tropel-web` crosses 8 MB, revert.

This profile is shared by every `release-wasm` build, so it affects the browser payload for `core-wasm`, `input-wasm`, `runtime-wasm` and the `tropel-web` slice — not just the crate that motivated it. That breadth is the reason to watch the gates rather than only the timing.

No behaviour change: optimisation settings only, same `opt-level = "z"`, same `panic = "abort"`, same `strip`.