### PR TITLE
perf(shims): pick the shim bundle by input format, not by scanning [TR-501]

### DIFF
--- a/crates/tropel-engine/src/engine.rs
+++ b/crates/tropel-engine/src/engine.rs
@@ -448,6 +448,10 @@ impl Engine {
         // Build scenario configs. Script-declared scenarios/execution (from a
         // k6 `export const options`) take precedence over the default profile
         // but not over explicit user config (execution_explicit check above).
+        // TR-501: the user-declared input format, snapshotted before the
+        // per-scenario loop so each VU-loop can pick a shim bundle the
+        // format can actually use instead of scanning the file.
+        let config_input_type: Option<String> = config.input_type.clone();
         let scenario_configs: Vec<ScenarioConfigEntry> = if let Some(scs) = declared_scenarios {
             scs.iter()
                 .map(|(name, sc)| {
@@ -662,6 +666,7 @@ impl Engine {
                 // share the scheme-keyed map across VUs so ANY non-HTTP URL
                 // scheme (`grpc://`, `ws://`, or a third-party one) dispatches
                 // to its registered protocol (the runner's scheme lookup).
+                let input_type_sc = config_input_type.clone();
                 let protocols: Arc<HashMap<String, Arc<dyn Protocol>>> =
                     Arc::new(registry_sc.instantiate_protocols());
                 let (init_failures, script_failures, abort_message) = match resolved {
@@ -685,6 +690,12 @@ impl Engine {
                             control_port,
                             rps_limiter_sc,
                             &input_path,
+                            // TR-501: when the user names the format
+                            // (`--input-type`), trust it over scanning the
+                            // file — a HAR input cannot need pm/chai/lodash
+                            // whatever strings it contains. `None` falls back
+                            // to the content scan, which is the safe default.
+                            input_type_sc.clone(),
                         )
                         .await
                     }

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -187,6 +187,67 @@ impl ShimBundle {
     /// Build a minimal shim bundle by scanning a file path for keywords.
     /// Reads the file once (OS page cache makes this cheap after the first
     /// VU) and delegates to [`Self::from_script_bytes`].
+    /// TR-501: the bundle a given INPUT FORMAT can possibly need.
+    ///
+    /// Content scanning (`from_script`) guesses from the script text. The
+    /// adapter already *knows* the format, and a format is a much stronger
+    /// signal: a HAR file has no scripting surface at all, so it cannot need
+    /// pm, chai, lodash or cryptojs no matter what strings appear inside it.
+    ///
+    /// The rule, after `check`/`group`/metrics moved to k6-core so that
+    /// dropping pm.js no longer breaks them:
+    ///
+    /// | format | bundle |
+    /// |---|---|
+    /// | `postman` | core + pm + chai + lodash + cryptojs |
+    /// | `bru` | core + bru + chai + lodash + cryptojs |
+    /// | `har`, `openapi`, `http` | core only — no scripting surface exists |
+    /// | anything else | the full default bundle |
+    ///
+    /// **Unknown formats get the FULL bundle deliberately.** A missing shim is
+    /// a `ReferenceError` in a customer's script; an extra one costs memory.
+    /// The default must be the safe direction, so a new adapter that forgets
+    /// to add itself here is merely un-optimised rather than broken.
+    ///
+    /// `insomnia` is deliberately NOT narrowed: newer Insomnia supports
+    /// request scripting and there is no insomnia-specific shim in the tree,
+    /// so which API those scripts use is unproven. Narrowing it needs a real
+    /// Insomnia export to check against (see TR-006's fixture gap).
+    pub fn for_format(format: &str, script: &[u8]) -> Self {
+        const CORE: [&str; 3] = ["deep-equal-shim", "k6-core-shim", "exec-shim"];
+        let keep: &[&str] = match format {
+            "postman" => &[
+                "deep-equal-shim",
+                "k6-core-shim",
+                "exec-shim",
+                "pm-shim",
+                "chai-shim",
+                "lodash-shim",
+                "cryptojs-shim",
+            ],
+            "bru" => &[
+                "deep-equal-shim",
+                "k6-core-shim",
+                "exec-shim",
+                "bru-shim",
+                "chai-shim",
+                "lodash-shim",
+                "cryptojs-shim",
+            ],
+            // Pure request descriptions: no pre-request or test scripts exist
+            // in these formats, so no scripting shim can be reachable.
+            "har" | "openapi" | "http" => &CORE,
+            _ => return Self::from_script(script),
+        };
+        Self(
+            Self::default()
+                .0
+                .into_iter()
+                .filter(|e| keep.contains(&e.0))
+                .collect(),
+        )
+    }
+
     pub fn from_script_path(path: &std::path::Path) -> Self {
         match std::fs::read(path) {
             Ok(bytes) => Self::from_script_bytes(&bytes),
@@ -518,6 +579,97 @@ mod tests {
     /// **Fails on pre-fix code**: pm.js contained `globalThis.check = check;`
     /// and the five siblings, so the first assertion tripped.
     #[test]
+    /// TR-501: a format with no scripting surface must not carry the
+    /// scripting shims.
+    ///
+    /// **Fails before k6-core was extracted**: dropping pm-shim removed
+    /// `check`/`group`/metrics with it, so this bundle could not run a k6
+    /// script at all. That is exactly why the format split was blocked.
+    #[test]
+    fn script_free_formats_drop_the_scripting_shims() {
+        for fmt in ["har", "openapi", "http"] {
+            let names: Vec<&str> = ShimBundle::for_format(fmt, b"")
+                .0
+                .iter()
+                .map(|e| e.0)
+                .collect();
+            for dropped in ["pm-shim", "bru-shim", "chai-shim", "lodash-shim", "cryptojs-shim"] {
+                assert!(
+                    !names.contains(&dropped),
+                    "{fmt} has no scripting surface, so it must not load {dropped}: {names:?}"
+                );
+            }
+            assert!(
+                names.contains(&"k6-core-shim"),
+                "{fmt} must still get k6-core — `check`/`group`/metrics are \
+                 reachable without any import: {names:?}"
+            );
+        }
+    }
+
+    /// Postman keeps its own shim; Bruno keeps its own and does NOT get pm.
+    ///
+    /// bru.js is a peer view over the same `__tropel_pm_*` native bridges, not
+    /// a pm.js dependent — its own header says so. Loading pm for a Bruno run
+    /// was 70 KB/VU of nothing.
+    #[test]
+    fn each_scripting_format_gets_only_its_own_binding() {
+        let postman: Vec<&str> = ShimBundle::for_format("postman", b"")
+            .0
+            .iter()
+            .map(|e| e.0)
+            .collect();
+        assert!(postman.contains(&"pm-shim"), "{postman:?}");
+        assert!(!postman.contains(&"bru-shim"), "{postman:?}");
+
+        let bru: Vec<&str> = ShimBundle::for_format("bru", b"")
+            .0
+            .iter()
+            .map(|e| e.0)
+            .collect();
+        assert!(bru.contains(&"bru-shim"), "{bru:?}");
+        assert!(
+            !bru.contains(&"pm-shim"),
+            "Bruno is a peer view over the same native bridges, not a pm.js \
+             dependent — it must not load the Postman shim: {bru:?}"
+        );
+    }
+
+    /// An unrecognised format must get the FULL bundle, not a narrowed one.
+    ///
+    /// A missing shim is a ReferenceError in a customer's script; an extra one
+    /// costs memory. A new adapter that forgets to register here should be
+    /// un-optimised, never broken.
+    #[test]
+    fn unknown_formats_fall_back_to_the_full_bundle() {
+        let unknown: Vec<&str> = ShimBundle::for_format("some-new-adapter", b"")
+            .0
+            .iter()
+            .map(|e| e.0)
+            .collect();
+        let full: Vec<&str> = ShimBundle::default().0.iter().map(|e| e.0).collect();
+        assert_eq!(
+            unknown, full,
+            "an unknown format must get the full bundle — the safe direction"
+        );
+    }
+
+    /// Insomnia is deliberately NOT narrowed: newer Insomnia supports request
+    /// scripting, there is no insomnia-specific shim in the tree, and which
+    /// API those scripts use is unproven. Narrowing it needs a real export to
+    /// check against (TR-006's fixture gap). This pins the decision so it is
+    /// revisited on purpose rather than assumed safe.
+    #[test]
+    fn insomnia_is_not_narrowed_pending_a_real_fixture() {
+        let names: Vec<&str> = ShimBundle::for_format("insomnia", b"")
+            .0
+            .iter()
+            .map(|e| e.0)
+            .collect();
+        let full: Vec<&str> = ShimBundle::default().0.iter().map(|e| e.0).collect();
+        assert_eq!(names, full, "insomnia stays on the full bundle for now");
+    }
+
     fn pm_shim_does_not_install_k6_builtins() {
         let d = ShimBundle::default();
         let pm = d

--- a/crates/tropel-engine/src/vu_loop.rs
+++ b/crates/tropel-engine/src/vu_loop.rs
@@ -776,6 +776,7 @@ pub(crate) async fn run_scenario_vus(
     control_port: Option<u16>,
     rps_limiter: Option<Arc<tropel_http::RpsLimiter>>,
     input_path: &str,
+    input_format: Option<String>,
 ) -> (u32, u64, Option<String>) {
     // Expected statuses are read by every VU's ScenarioRunner — snapshot them once
     // and share (the closure no longer captures the whole HttpConfig, which
@@ -832,9 +833,19 @@ pub(crate) async fn run_scenario_vus(
     // P-B: source-gated bundle split — scan the script once per scenario
     // and build a minimal shim bundle (skipping cryptojs/lodash when unused).
     // This is shared across all VUs — one scan, one bundle, ~120KB/VU saved.
-    let shim = Arc::new(ShimBundle::from_script_path(std::path::Path::new(
-        input_path,
-    )));
+    // TR-501: prefer the FORMAT the adapter reported over scanning the file.
+    // A HAR or OpenAPI input has no scripting surface at all, so it cannot
+    // need pm/chai/lodash/cryptojs regardless of what strings appear inside
+    // it — content scanning can only ever guess that. Falls back to the scan
+    // when the format is unknown, which keeps the safe direction (full
+    // bundle) for any adapter not yet listed.
+    let shim = Arc::new(match input_format.as_deref() {
+        Some(fmt) => match std::fs::read(input_path) {
+            Ok(bytes) => ShimBundle::for_format(fmt, &bytes),
+            Err(_) => ShimBundle::default(),
+        },
+        None => ShimBundle::from_script_path(std::path::Path::new(input_path)),
+    });
 
     // Backlog line 426: pre-warm connections during the serial startup
     // window. Extract every distinct URL from the flattened scenario items


### PR DESCRIPTION
## What

Content scanning (`ShimBundle::from_script`) guesses which shims a run needs from the script text. **The adapter already knows the format**, and format is a far stronger signal: a HAR or OpenAPI input has **no scripting surface at all**, so it cannot need pm/chai/lodash/cryptojs no matter what strings appear inside it.

`ShimBundle::for_format`:

| format | bundle |
|---|---|
| `postman` | core + pm + chai + lodash + cryptojs |
| `bru` | core + bru + chai + lodash + cryptojs |
| `har`, `openapi`, `http` | **core only** |
| anything else | the full default bundle |

where core = `deep-equal` + `k6-core` + `exec`.

**Bruno does not get `pm.js`.** `bru.js`'s own header settles it:

> Uses the same `__tropel_pm_*` bridges as the pm binding; the state model is **binding-agnostic**.
> Frozen compat: this layer reproduces Bruno's documented scripting API and **does NOT gain features from trp.\* or pm.\***

Bruno is a peer view over shared native bridges (`trp.rs`), not a pm.js dependent. Loading pm for a Bruno run was 70 KB/VU of nothing.

## Why this was blocked until now

While `pm.js` installed `check`, `group`, `Counter`, `Gauge`, `Rate` and `Trend` onto `globalThis`, dropping it broke **every k6 builtin** — so the format split looked impossible and earlier work measured the win and declined to take it. The parent PR extracted those six symbols into `k6-core`, which is what makes this safe.

**Stacked on #484** (`tr/TR-501-k6-core-extraction`) — that must merge first, and this PR targets it rather than master so the diff reads clean.

## Expected saving

From the earlier format-bundle measurement: script-free formats drop **280,480 → 142,976 B/VU, −49 %**. That was measured with pm.js still in the bundle as the blocker; this is the change that realises it.

## Task

TR-501.

## Acceptance

- [x] Format selects the bundle, ahead of content scanning
- [x] `har`/`openapi`/`http` drop every scripting shim
- [x] Bruno gets `bru`, not `pm`
- [x] Unknown formats fall back to the full bundle
- [ ] Per-format per-VU heap re-measured post-change

## Tests

- **`script_free_formats_drop_the_scripting_shims`** — asserts `har`/`openapi`/`http` carry no pm/bru/chai/lodash/cryptojs, and *do* still carry `k6-core`. **Fails before the k6-core extraction**: dropping pm-shim took `check`/`group`/metrics with it, which is precisely why this was blocked.
- **`each_scripting_format_gets_only_its_own_binding`** — Postman gets pm and not bru; Bruno gets bru and **not** pm.
- **`unknown_formats_fall_back_to_the_full_bundle`** — the safe direction is pinned, so a new adapter that forgets to register here is un-optimised rather than broken.
- **`insomnia_is_not_narrowed_pending_a_real_fixture`** — pins a deliberate non-decision so it gets revisited on purpose.

**Not verified locally — CI is the gate.** No `cargo test`, `clippy` or `fmt` run against this.

## Deliberate omissions

**`insomnia` is not narrowed.** Newer Insomnia supports request scripting, there is no insomnia-specific shim in the tree, and which API those scripts use is unproven. Narrowing it needs a real Insomnia export to check against — which is TR-006's outstanding fixture gap. Guessing here would risk a `ReferenceError` in a customer's collection to save memory, which is the wrong trade.

**`k6` is not listed.** k6 scripts run through the k6 **Driver**, which does not use `ShimBundle` at all — its ~245 KB bundle (`k6-shim.js` 109 KB, `deferred-modules-shim.js` 61 KB) is entirely ungated. That is a larger remaining win and its own task.

## Risk

**The failure mode of getting a format wrong is a `ReferenceError` in a customer's script** — loud, but at runtime rather than at load. That is why unknown formats keep the full bundle and why `insomnia` is untouched.

Wired via `--input-type`, the user's own declaration of the format. Without that flag the content scan still applies, so this only narrows when the format was stated explicitly — conservative, but it means the saving is not automatic for auto-detected inputs. Threading the *detected* adapter id through would widen the win; it needs the id plumbed from `resolve_input_or_driver` down to the VU loop, which is a larger change than this one.