### PR TITLE
fix(ci): stop building the wasm-target crates three times natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
+      # The wasm-target crates are excluded from the THREE-OS matrix and run
+      # once on ubuntu below.
+      #
+      # `tropel-input-wasm` pulls five input adapters plus wasm-bindgen, and
+      # building it natively on Windows was timing the job out at 45 min. It
+      # is a wasm-bindgen crate: its reason to exist is `wasm32-unknown-unknown`,
+      # which the dedicated `wasm` job builds properly via
+      # `packages/*/scripts/build.sh`. Compiling it three more times natively
+      # bought nothing.
+      #
+      # Their ~8 native tests are pure Rust (adapter dispatch, the variable
+      # catalog) with no platform-specific code, so running them once is real
+      # coverage, not a coverage cut. Excluding them from macOS/Windows only
+      # removes duplicate work.
       - name: Build tests
-        run: cargo test --workspace --no-run --locked
+        run: cargo test --workspace --exclude tropel-input-wasm --exclude tropel-core-wasm --no-run --locked
       # `cargo test` does NOT build `harness = false` bench targets, and clippy
       # runs on ubuntu only — so `tropel-bench` was compiled by no job on macOS
       # or Windows. It had been failing to lint on macOS (deprecated
@@ -129,9 +143,14 @@ jobs:
       # there. Benches are the measurement floor for all of W3/W5; they have to
       # at least compile everywhere (TR-002).
       - name: Build benches
-        run: cargo bench --workspace --no-run --locked
+        run: cargo bench --workspace --exclude tropel-input-wasm --exclude tropel-core-wasm --no-run --locked
       - name: Run tests
-        run: cargo test --workspace -- --nocapture
+        run: cargo test --workspace --exclude tropel-input-wasm --exclude tropel-core-wasm -- --nocapture
+      # Run the excluded pair exactly once, so the exclusion above trades
+      # duplicate work for wall-clock without trading away coverage.
+      - name: Test the wasm-target crates (ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test -p tropel-input-wasm -p tropel-core-wasm -- --nocapture
 
   msrv:
     name: MSRV 1.94


### PR DESCRIPTION
## What

The Windows `test` job was **timing out at 45 minutes** building `tropel-input-wasm`.

It is a `wasm-bindgen` crate that pulls five input adapters (`openapi`, `postman`, `har`, `insomnia`, `bru`), and **its reason to exist is `wasm32-unknown-unknown`** — which the dedicated `wasm` job already builds properly via `packages/*/scripts/build.sh`. Compiling it natively on three more OSes bought nothing.

`tropel-input-wasm` and `tropel-core-wasm` are now excluded from the three-OS matrix (build, bench-build, and run), with an **ubuntu-only step that tests the pair exactly once**.

## This trades duplicate work, not coverage

Worth being precise, because "exclude it from CI" is usually the wrong answer:

- Both crates have **4 native tests each**. Those are not dropped — they run on ubuntu.
- The tests are pure Rust (adapter dispatch, the variable catalog) with **no platform-specific code**, so running them on one platform is as meaningful as running them on three. Compare `tropel-bench`, which *does* have per-platform code (`mach task_info` / `/proc` / `GetProcessMemoryInfo`) and is deliberately still built everywhere.
- The wasm build itself is unaffected — the `wasm` job still compiles both for the real target and enforces the 700 KB / 8 MB size gates.

Verified locally: `cargo test -p tropel-input-wasm -p tropel-core-wasm` → **4 passed + 4 passed**, and `cargo test --workspace --exclude ... --no-run --locked` builds with 0 errors.

## Task

CI wall-clock. Pairs with the thin-LTO change already in master, which cut the `wasm` job's own link time.

## The other half of the story

Thin LTO fixed the *wasm* job; this fixes the *native* jobs. Its cost is now measured rather than estimated: **569,352 → 584,748 B (+15,396 B, +2.7%)**, leaving **115,252 B** of headroom under the 700 KB gate.

That number came out of the TR-404 guard failing on a stale generated README line — the guard working exactly as designed, and the second repaired guard to catch something real (the submodule pin guard has caught three drifts).

## Acceptance

- [x] Windows no longer builds `tropel-input-wasm`
- [x] Both crates' tests still run, once, on ubuntu
- [x] The `wasm` job's real-target build is untouched
- [ ] Windows job completes inside its timeout — **read from this PR's CI run**

## Evidence

READ + EXEC. Workflow YAML re-parsed after editing (16 jobs, valid). Native test counts confirmed by running them. Exclusion verified to build cleanly.

**Not verified on Windows** — I have no Windows runner. This PR's CI is the proof; watch the `test (windows-latest)` duration against the 45-minute timeout.

## Risk

If either crate ever gains genuinely platform-specific code, this would hide a Windows/macOS-only break. Neither has any today, and both are compiled for `wasm32` by the `wasm` job regardless — but it is the trade being made, and it should be revisited if these crates grow `#[cfg(windows)]` blocks.