### PR TITLE
fix(metrics): emit data_sent on the declarative failure path [TR-121]

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -849,6 +849,30 @@ impl ScenarioRunner {
                                         sample_type: SampleType::Trend,
                                     });
                                 }
+                                // TR-121: data_sent — the metric this path
+                                // kept omitting. The k6 driver's
+                                // push_http_failure emits it; this one did
+                                // not, so `data_sent` undercounted by every
+                                // failed request and the two drivers reported
+                                // different totals for the same run.
+                                //
+                                // The bytes were serialised and handed to the
+                                // transport whether or not a response came
+                                // back, so the honest count is the body size,
+                                // not zero. `Body::wire_size` lives in the SDK
+                                // precisely so this crate can reach it —
+                                // tropel-http is a dev-dependency here, kept
+                                // out of the library graph for the wasm slice.
+                                result.samples.push(tropel_sdk::types::Sample {
+                                    metric: "data_sent".into(),
+                                    value: request
+                                        .body
+                                        .as_ref()
+                                        .map_or(0.0, |b| b.wire_size() as f64),
+                                    tags: err_tags.clone(),
+                                    timestamp: now,
+                                    sample_type: SampleType::Counter,
+                                });
                             }
                         }
                     }
@@ -2523,6 +2547,26 @@ mod tests {
                 "failure path must emit {sub}"
             );
         }
+
+        // TR-121: `data_sent` must be emitted here too. The k6 driver's
+        // push_http_failure emits it; this path did not, so a run's total
+        // undercounted by every failed request and the two drivers disagreed
+        // for the same scenario.
+        //
+        // Fails on pre-fix code: no `data_sent` sample reached this path at
+        // all. The old test COMMENT claimed it was emitted and never asserted
+        // it — which is exactly how it survived TR-121 being marked done.
+        let sent: Vec<_> = samples.iter().filter(|s| s.metric == "data_sent").collect();
+        assert_eq!(
+            sent.len(),
+            2,
+            "each failed request must emit data_sent, as the k6 driver does — got {}",
+            sent.len()
+        );
+        assert!(
+            sent.iter().all(|s| s.sample_type == SampleType::Counter),
+            "data_sent is a Counter, matching the success path"
+        );
 
         // TR-202/TR-203: the identity must hold on the failure path too.
         // `http_req_duration` is DEFINED as sending + waiting + receiving; the


### PR DESCRIPTION
## What

The last open half of TR-121, and the finding tracked as **F-08**.

On a transport failure the k6 driver's `push_http_failure` emits `data_sent`. The declarative runner emitted **8 of the 9** metrics and omitted it. So a run's `data_sent` total **undercounted by every failed request**, and the two drivers reported different totals for the same scenario.

The bytes were serialised and handed to the transport whether or not a response came back, so the honest count is the body size — not zero.

## Why it took a cross-repo change

`Body::wire_size` had to move into `tropel-sdk` first (merged as tropel-sdk#24). `tropel-runtime` keeps `tropel-http` as a **dev-dependency only**, deliberately, so the browser slice compiles — which put the size helper out of reach of the one crate that needed it. Feature-gating the emit would have left the wasm slice silently missing a metric.

## Task

TR-121. Closes F-08.

## Tests

The existing failure-path test **now asserts `data_sent`** — two samples, `Counter` type — instead of claiming it in a comment.

That comment is the reason this survived: it read

> Two failures: each emits duration + http_reqs + errors + http_req_failed + **data_sent** + 7 sub-timings

and never checked. **Fails on pre-fix code**: no `data_sent` sample reached that path at all.

`cargo test -p tropel-runtime` → **22 passed / 0 failed**.

## Evidence

READ + EXEC. Verified `data_sent` was absent from the failure path on current master before changing it (`grep -c '"data_sent"'` → 1, the success path only). `cargo check -p tropel-runtime` clean, `cargo fmt --all` applied.

## Risk

`data_sent` totals will **increase** for any run containing transport failures — previously undercounted, now correct. A dashboard tracking that metric will step up. That is the fix, but it is a visible number change rather than a silent one.

No new dependency: `Body::wire_size` is already in the pinned SDK.