### PR TITLE
fix(ci): cut debug-info generation and raise the Windows test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ env:
   # Keep incremental off in CI: it bloats the cache and doesn't help cold builds.
   CARGO_INCREMENTAL: "0"
   RUST_BACKTRACE: "1"
+  # Windows was hitting the 45-minute wall (45m05s) building tests. Nothing in
+  # CI attaches a debugger, but every job was emitting FULL debug info for the
+  # whole graph — wasmtime, aws-lc-sys, oxc and the QuickJS C sources. On
+  # Windows that means writing PDBs for all of it, which is by far the most
+  # expensive part of the build.
+  #
+  # `line-tables-only` rather than `0`: RUST_BACKTRACE=1 is deliberately on
+  # above, and a backtrace without file:line is much harder to act on. This
+  # keeps panic locations while dropping variable and type debug info, which is
+  # the bulk of the cost and the part nothing here reads.
+  CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
 
 jobs:
   fmt:
@@ -105,7 +117,19 @@ jobs:
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # 90, not 45. Windows was landing on 45m05s — i.e. the cap was set below
+    # what this workspace legitimately takes there, so the job reported a
+    # timeout rather than a result. A Windows Rust build of a graph containing
+    # wasmtime, aws-lc-sys, oxc and the QuickJS C sources is genuinely ~2-3x a
+    # Linux one, and MSVC linking is single-threaded per crate.
+    #
+    # The debug-info reduction in `env:` above cuts roughly 10% (measured on
+    # macOS: 124s -> 111s cold for tropel-engine; the Windows saving should be
+    # larger because PDB emission is the expensive part, but that is untested).
+    # 10% does not rescue a job sitting one minute over its own limit, so the
+    # limit moves too. A timeout should mean "something hung", not "this is
+    # how long it takes".
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Windows was landing on **45m05s against a 45-minute cap** — the limit was set *below* what this workspace legitimately takes there, so the job reported a timeout instead of a result.

Two changes, because one is not enough.

### 1. Stop emitting full debug info in CI

```yaml
CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
CARGO_PROFILE_DEV_DEBUG:  "line-tables-only"
```

Nothing in CI attaches a debugger, but every job was emitting **full** debug info for the whole graph — wasmtime, aws-lc-sys, oxc, and the QuickJS C sources. On Windows that means writing PDBs for all of it, which is the single most expensive part of the build.

`line-tables-only` rather than `0` on purpose: `RUST_BACKTRACE=1` is deliberately set in the same block, and a backtrace without `file:line` is much harder to act on. This keeps panic locations and drops the variable/type info nothing here reads.

✅**MEAS**, macOS, cold, `cargo test -p tropel-engine --no-run`:

| | time | target |
|---|---|---|
| full debug (CI today) | 124 s | 3.4 G |
| `line-tables-only` | **111 s** | **2.7 G** |
| | **−10 %** | **−21 %** |

### 2. Raise the timeout 45 → 90 minutes

**10 % does not rescue a job sitting one minute over its own limit.** A Windows Rust build of this graph is genuinely ~2–3× a Linux one, and MSVC linking is single-threaded per crate.

A timeout should mean *"something hung"*, not *"this is how long it takes"*. At 45 minutes it was measuring the latter.

## Honesty about the measurement

The 10 % figure is **macOS**, because I have no Windows runner. The Windows saving should be **larger** — PDB emission is the expensive part and Windows is where it bites — but that is an expectation, not a measurement. Read the actual Windows duration on this PR's run.

If Windows still exceeds 90 minutes, the debug-info change is not the answer and the next lever is scoping *what* Windows tests rather than how it builds. The platform-specific surface that justifies a Windows job at all is narrow: `GetProcessMemoryInfo`, path handling, and a past LNK1140 link failure.

## Task

CI wall-clock. Third in the series, after the thin-LTO profile change and excluding the wasm-target crates from the three-OS matrix.

## Acceptance

- [x] Debug info reduced without losing backtrace line numbers
- [x] Timeout reflects real build cost
- [ ] Windows completes inside 90 min — **read from this PR's CI run**

## Risk

`line-tables-only` means a debugger attached to a CI-built binary sees no local variables. Nothing does that today; if someone starts, this is the line to change.

Raising a timeout can mask a genuine hang. The mitigation is that 90 min is still well under the 6-hour runner cap, so a real hang still fails rather than running forever — and the engine has known hang paths, which is why every job here carries a timeout at all.