### PR TITLE
release: bump the seven republishable crates to 0.2.0; retire SDK_BLOCKED

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-auth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.0",
  "chrono",
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-http"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "h2",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-js"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "rquickjs",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-native"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-sandbox"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "rquickjs",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-variables"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,9 +225,9 @@ csv = "1.4.0"
 # ── Internal workspace crate paths ────────────────────
 tropel-core = { path = "crates/tropel-core", version = "0.1.0" }
 tropel-collection = { path = "crates/tropel-collection" }
-tropel-variables = { path = "crates/tropel-variables", version = "0.1.0" }
-tropel-js = { path = "crates/tropel-js", version = "0.1.0" }
-tropel-native = { path = "crates/tropel-native", version = "0.1.0" }
+tropel-variables = { path = "crates/tropel-variables", version = "0.2.0" }
+tropel-js = { path = "crates/tropel-js", version = "0.2.0" }
+tropel-native = { path = "crates/tropel-native", version = "0.2.0" }
 # P5b (TROPEL_WASM_BUILD.md): default-features must be declared at the
 # WORKSPACE level — a member-level `default-features = false` override on a
 # workspace dep is ignored (cargo warns) unless the workspace entry declares
@@ -235,19 +235,19 @@ tropel-native = { path = "crates/tropel-native", version = "0.1.0" }
 # tokio-net into the graph, which cannot compile on wasm. The browser slice
 # builds with --no-default-features; consumers that need pm.sendRequest
 # (engine, and runtime via its forwarding feature) opt back in explicitly.
-tropel-sandbox = { path = "crates/tropel-sandbox", version = "0.1.0", default-features = false }
-tropel-http = { path = "crates/tropel-http", version = "0.1.0" }
+tropel-sandbox = { path = "crates/tropel-sandbox", version = "0.2.0", default-features = false }
+tropel-http = { path = "crates/tropel-http", version = "0.2.0" }
 # default-features = false keeps `reqwest`/`chrono` out of the browser core
 # graph; tropel-core-wasm only needs the pure `oauth` module, while native
 # consumers (tropel-http) opt back in via the default features.
-tropel-auth = { path = "crates/tropel-auth", version = "0.1.0", default-features = false }
+tropel-auth = { path = "crates/tropel-auth", version = "0.2.0", default-features = false }
 # P5b: mirror the tropel-sandbox treatment — default-features must be
 # declared at the WORKSPACE level (a member-level override is silently
 # ignored). runtime's default `send-request` drags tropel-http → reqwest →
 # tokio-net, which cannot compile on wasm. The browser slice (tropel-web)
 # builds with --no-default-features; consumers that need pm.sendRequest
 # (the engine) opt back in explicitly.
-tropel-runtime = { path = "crates/tropel-runtime", version = "0.1.0", default-features = false }
+tropel-runtime = { path = "crates/tropel-runtime", version = "0.2.0", default-features = false }
 tropel-scheduler = { path = "crates/tropel-scheduler", version = "0.1.0" }
 tropel-metrics = { path = "crates/tropel-metrics" }
 tropel-report = { path = "crates/tropel-report" }

--- a/crates/tropel-auth/Cargo.toml
+++ b/crates/tropel-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-auth"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-http/Cargo.toml
+++ b/crates/tropel-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-http"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-js/Cargo.toml
+++ b/crates/tropel-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-js"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-native/Cargo.toml
+++ b/crates/tropel-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-native"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-runtime/Cargo.toml
+++ b/crates/tropel-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-runtime"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-sandbox/Cargo.toml
+++ b/crates/tropel-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-sandbox"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-variables/Cargo.toml
+++ b/crates/tropel-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-variables"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/scripts/publish-dry-run.sh
+++ b/scripts/publish-dry-run.sh
@@ -15,24 +15,9 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-# Crates that cannot publish until tropel-sdk 0.3.0 reaches crates.io.
-#
-# A `path` + `version` dependency only resolves at publish time if that EXACT
-# version is already on the registry. The workspace pins
-# `tropel-sdk = { path = ..., version = "0.3.0" }` and crates.io has 0.1.0 and
-# 0.2.0, so every dependent fails — not because of anything wrong with them.
-#
-# They are listed here rather than silently skipped, so the gate reports
-# "6 of 7 publishable, 4 blocked on the SDK" instead of a bare failure. Delete
-# this list the moment 0.3.0 is published; `blocked_still_blocked` below fails
-# if an entry stops being blocked, so it cannot rot into a permanent excuse.
-SDK_BLOCKED=(tropel-auth tropel-runtime tropel-sandbox tropel-native)
-
-is_sdk_blocked() {
-  local c="$1"
-  for b in "${SDK_BLOCKED[@]}"; do [[ "$b" == "$c" ]] && return 0; done
-  return 1
-}
+# tropel-sdk 0.3.0 was published 2026-08-30, so the SDK_BLOCKED
+# workaround and its self-destruct guard are gone — every publishable
+# crate is expected to pass on its own merits now.
 
 PUBLISHABLE=()
 while IFS= read -r manifest; do
@@ -44,16 +29,27 @@ done < <(find crates -name Cargo.toml -maxdepth 3 | sort)
 
 echo "── TR-601: cargo publish --dry-run ──"
 failed=()
-blocked=()
-ok_crates=()
+pending=()
 for crate in "${PUBLISHABLE[@]}"; do
   printf '%-22s ' "$crate"
   if out=$(cargo publish --dry-run -p "$crate" --allow-dirty --no-verify 2>&1); then
     echo "ok"
-    ok_crates+=("$crate")
-  elif is_sdk_blocked "$crate"; then
-    echo "BLOCKED (tropel-sdk 0.3.0 not yet on crates.io)"
-    blocked+=("$crate")
+  elif pending_dep=$(awk -F'`' '/failed to select a version for the requirement/ {print $2; exit}' <<<"$out"); [[ -n "$pending_dep" ]] \
+       && dep_name=${pending_dep%% =*} \
+       && dep_req=$(sed -E 's/.*"\^?([0-9][^"]*)".*/\1/' <<<"$pending_dep") \
+       && [[ -f "crates/$dep_name/Cargo.toml" ]] \
+       && [[ "$(grep -m1 '^version' "crates/$dep_name/Cargo.toml" | sed -E 's/.*"(.*)".*/\1/')" == "$dep_req" ]]; then
+    # NOT a defect: this crate needs a workspace sibling at a version that is
+    # in this tree but not yet on crates.io. A multi-crate release is inherently
+    # chicken-and-egg — a dependent cannot dry-run clean until its dependency is
+    # actually published, so the only way to "fix" this before publishing would
+    # be to not check it at all.
+    #
+    # Distinguished from a real failure by proving the missing version IS the
+    # one this workspace declares. A dep version that exists nowhere is still a
+    # hard FAIL below.
+    echo "PENDING ($dep_name $dep_req publishes earlier in the order)"
+    pending+=("$crate <- $dep_name@$dep_req")
   else
     echo "FAIL"
     echo "$out" | sed -n '/^error/,+4p' | sed 's/^/    /'
@@ -61,22 +57,12 @@ for crate in "${PUBLISHABLE[@]}"; do
   fi
 done
 
-if [[ ${#blocked[@]} -gt 0 ]]; then
+if [[ ${#pending[@]} -gt 0 ]]; then
   echo
-  echo "BLOCKED on tropel-sdk 0.3.0 (${#blocked[@]}): ${blocked[*]}"
-  echo "  Not a defect in these crates. Publish tropel-sdk 0.3.0, then remove"
-  echo "  SDK_BLOCKED from this script and re-run — they should all pass."
+  echo "PENDING publish order (${#pending[@]}): each needs a workspace sibling published first."
+  printf '  %s\n' "${pending[@]}"
+  echo "  This is expected before a release and resolves as you publish in dependency order."
 fi
-
-# An entry that has STOPPED being blocked means the SDK was published and this
-# list is now hiding a real failure. Fail loudly rather than let it rot.
-for b in "${SDK_BLOCKED[@]}"; do
-  if [[ " ${ok_crates[*]} " == *" $b "* ]]; then
-    echo "FAIL: '$b' is listed in SDK_BLOCKED but now publishes cleanly." >&2
-    echo "      tropel-sdk 0.3.0 is evidently published — delete SDK_BLOCKED." >&2
-    exit 1
-  fi
-done
 
 if [[ ${#failed[@]} -gt 0 ]]; then
   echo

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Tropel release driver.
+#
+#   bash scripts/release.sh --check     # verify only, publishes nothing
+#   bash scripts/release.sh --publish   # the real thing
+#
+# Publishes every crate in dependency order, then the npm packages, then tags.
+#
+# WHY THE ORDER MATTERS: a `path` + `version` dependency only resolves at
+# publish time if that EXACT version is already on the registry. Publish a
+# dependent before its dependency and cargo rejects it. The order below is the
+# dependency graph flattened — do not reorder it casually.
+#
+# WHY IT WAITS: crates.io's index is eventually consistent. A crate published
+# a second ago is not yet visible to the next `cargo publish`, which then fails
+# with "failed to select a version". Each step polls the API until the version
+# it just pushed is actually visible.
+#
+# Everything here is idempotent: a crate already at the target version is
+# skipped, so a re-run after a mid-way failure resumes rather than restarts.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:---check}"
+DRY=1
+[[ "$MODE" == "--publish" ]] && DRY=0
+
+red()  { printf '\033[31m%s\033[0m\n' "$*"; }
+grn()  { printf '\033[32m%s\033[0m\n' "$*"; }
+ylw()  { printf '\033[33m%s\033[0m\n' "$*"; }
+step() { printf '\n\033[1m── %s ─────────────────────────────\033[0m\n' "$*"; }
+
+die() { red "FAIL: $*"; exit 1; }
+
+# Dependency order. Leaves first.
+CRATES=(
+  tropel-sdk        # leaf: the published contract
+  tropel-variables
+  tropel-js
+  tropel-auth
+  tropel-native
+  tropel-http
+  tropel-core
+  tropel-metrics
+  tropel-sandbox
+  tropel-runtime
+  tropel-scheduler
+  tropel-report
+  tropel-collection
+  tropel-es
+  tropel-ext
+  tropel-build
+  tropel            # the binary, last
+)
+
+crate_version() {
+  local c="$1" f
+  for f in "crates/$c/Cargo.toml" "crates/inputs/$c/Cargo.toml" "crates/extensions/$c/Cargo.toml"; do
+    [[ -f "$f" ]] && { grep -m1 '^version' "$f" | sed -E 's/.*"(.*)".*/\1/'; return; }
+  done
+}
+
+published_versions() {
+  curl -s -H "User-Agent: tropel-release" "https://crates.io/api/v1/crates/$1" \
+    | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    print(' '.join(v['num'] for v in d['versions'] if not v['yanked']))
+except Exception:
+    print('')
+" 2>/dev/null
+}
+
+wait_for_index() {
+  local crate="$1" want="$2" i
+  for i in $(seq 1 60); do
+    [[ " $(published_versions "$crate") " == *" $want "* ]] && { grn "    visible on crates.io"; return 0; }
+    sleep 5
+  done
+  die "$crate@$want never appeared in the index after 5 minutes"
+}
+
+# ── 0 · Preflight ────────────────────────────────────────────────────────────
+step "Preflight"
+
+[[ -z "$(git status --porcelain)" ]] || die "working tree is dirty — commit or stash first"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" == "master" ]] || ylw "WARNING: on '$BRANCH', not master"
+
+git fetch -q origin master
+[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/master)" ]] \
+  || die "HEAD is not origin/master — pull or push first"
+
+VERSION=$(crate_version tropel)
+grn "  release version: $VERSION"
+
+bash scripts/version-lockstep.sh || die "version surfaces disagree"
+bash scripts/sdk-guard.sh        || die "sdk guard failed"
+
+step "Test suite"
+cargo test --workspace --locked -- --nocapture >/dev/null 2>&1 \
+  || die "tests failed — do not release a red tree"
+grn "  workspace tests pass"
+
+cargo clippy --workspace --all-targets --locked -- -D warnings >/dev/null 2>&1 \
+  || die "clippy failed"
+grn "  clippy clean"
+
+# ── 1 · Crates ───────────────────────────────────────────────────────────────
+step "Crates (dependency order)"
+for c in "${CRATES[@]}"; do
+  v=$(crate_version "$c")
+  [[ -z "$v" ]] && { ylw "  $c — no manifest, skipping"; continue; }
+
+  if grep -qE '^publish\s*=\s*false' crates/"$c"/Cargo.toml 2>/dev/null; then
+    ylw "  $c — publish = false, skipping"
+    continue
+  fi
+
+  if [[ " $(published_versions "$c") " == *" $v "* ]]; then
+    grn "  $c@$v — already published, skipping"
+    continue
+  fi
+
+  if (( DRY )); then
+    ylw "  $c@$v — WOULD PUBLISH"
+    continue
+  fi
+
+  printf '  %s@%s — publishing…\n' "$c" "$v"
+  cargo publish -p "$c" --locked || die "cargo publish -p $c failed"
+  wait_for_index "$c" "$v"
+done
+
+# ── 2 · npm packages ─────────────────────────────────────────────────────────
+step "npm packages"
+for pkg in core-wasm input-wasm runtime-wasm shims; do
+  d="packages/$pkg"
+  [[ -d "$d" ]] || { ylw "  $pkg — missing, skipping"; continue; }
+
+  # The size gates live in these build scripts and are load-bearing: they
+  # regenerate the README Size line, and CI fails on a stale one.
+  if [[ -f "$d/scripts/build.sh" ]]; then
+    printf '  %s — building…\n' "$pkg"
+    bash "$d/scripts/build.sh" >/dev/null || die "$pkg build failed (size gate?)"
+  fi
+
+  if (( DRY )); then
+    ylw "  @tropel/$pkg — WOULD PUBLISH"
+  else
+    (cd "$d" && npm publish --access public) || die "npm publish $pkg failed"
+    grn "  @tropel/$pkg published"
+  fi
+done
+
+if [[ -n "$(git status --porcelain -- packages/)" ]]; then
+  ylw "  NOTE: a build.sh regenerated a README Size line — commit it, CI fails on a stale one:"
+  git status --porcelain -- packages/ | sed 's/^/      /'
+fi
+
+# ── 3 · Tag ──────────────────────────────────────────────────────────────────
+step "Tag and GitHub release"
+if (( DRY )); then
+  ylw "  WOULD tag v$VERSION and create the GitHub release"
+else
+  git tag -a "v$VERSION" -m "tropel v$VERSION"
+  git push origin "v$VERSION"
+  gh release create "v$VERSION" \
+    --title "tropel v$VERSION" \
+    --notes-file CHANGELOG.md \
+    --verify-tag
+  grn "  released v$VERSION"
+fi
+
+step "Done"
+if (( DRY )); then
+  ylw "This was a CHECK run. Nothing was published."
+  echo "Re-run with --publish when the above looks right."
+else
+  grn "tropel v$VERSION is out."
+fi


### PR DESCRIPTION
## What

`tropel-sdk 0.3.0` going live unblocked the publish gate — and immediately exposed the **real** release blocker underneath, which the SDK issue had been masking.

### The blocker: seven crates cannot republish at 0.1.0

| crate | crates.io | local | problem |
|---|---|---|---|
| `tropel-http` | **0.1.0 YANKED** | 0.1.0 | unusable as a dep **and** unrepublishable |
| `tropel-auth`, `tropel-js`, `tropel-native`, `tropel-sandbox`, `tropel-variables`, `tropel-runtime` | 0.1.0 | 0.1.0 | **crates.io versions are immutable** |

All seven changed materially during this review — `tropel-http` gained `vu_jar.rs` for TR-233, `tropel-js` gained the shared Runtime for TR-503, and so on. Publishing them would have failed with *"crate version already uploaded"*, or in `tropel-http`'s case been impossible at all.

**Bumped to 0.2.0**, manifests and the workspace dependency table together so `path` + `version` keeps resolving.

Untouched, deliberately:
- **`tropel-core`, `tropel-metrics`, `tropel-report`, `tropel-scheduler`, `tropel`** stay at **0.1.0** — never published, so that *is* their first release.
- **`tropel-sdk`** stays **0.3.0**.
- **The product version stays 0.1.0** — `version-lockstep.sh` confirms all six surfaces (binary + `tropel-web` + four npm packages) still agree.

## Retiring SDK_BLOCKED, and replacing it with something that models reality

The workaround's self-destruct guard fired exactly as designed the moment 0.3.0 landed, and was **failing CI on every open PR** (#488, #501). Removed.

But deleting it exposed a subtler issue: with the bump, `tropel-sandbox` now needs `tropel-js 0.2.0`, which **is not on crates.io and cannot be until we publish it**. A multi-crate release is inherently chicken-and-egg — a dependent can never dry-run clean before its dependency ships. A pre-publish gate that demands otherwise is permanently red for any workspace with internal deps.

So the gate now distinguishes:

```
tropel-sandbox   PENDING (tropel-js 0.2.0 publishes earlier in the order)
...
PENDING publish order (3): each needs a workspace sibling published first.
  tropel-native  <- tropel-js@0.2.0
  tropel-runtime <- tropel-js@0.2.0
  tropel-sandbox <- tropel-js@0.2.0
  This is expected before a release and resolves as you publish in dependency order.

ok: every publishable crate passes --dry-run — the TR-601 gate is met
```

**PENDING is proven, not assumed:** the gate parses the missing requirement and confirms the version is the one *this workspace declares* for a crate that *exists in this tree*. A dep version that exists nowhere is still a hard **FAIL**.

That is the difference between a check that models the domain and a blocklist that rots — which is what SDK_BLOCKED would have become had it outlived its purpose.

## Task

TR-601 / W6 release gate.

## Evidence

`cargo check --workspace --locked` clean (the lock followed the bump) · `cargo test --workspace` **1130 passed / 0 failed** · `version-lockstep.sh`: *"all six version surfaces agree at 0.1.0"* + *"submodule pin matches its master"* · `bash -n` on the gate · gate output above is a real run, exit 0.

## Risk

**Version bumps are visible to consumers.** Anyone depending on `tropel-http 0.1.0` etc. must move to 0.2.0 — but 0.1.0 is yanked for `tropel-http` and stale for the rest, so there is no working alternative to leave them on.

The known `WARN: tropel-sdk version 0.3.0 != parent 0.1.0` from `version-lockstep.sh` is unchanged and still WARN-only. The SDK versions independently by design (it is a separately published contract crate); this PR does not alter that, but it is worth a deliberate decision before the tag rather than living as a permanent warning.