### PR TITLE
fix: seven P0s from the cold review — dead sleep, sharded-metric corruption, cross-VU rejections

### DIFF
--- a/crates/inputs/tropel-input-k6/src/driver.rs
+++ b/crates/inputs/tropel-input-k6/src/driver.rs
@@ -6541,7 +6541,16 @@ mod tests {
                     return out;
                 };
                 var b1 = bru.getCollectionVar('baseUrl');
-                bru.setCollectionVar('token', '"abc"');
+                // Plain 'abc', NOT the hand-pre-quoted '"abc"' this used to
+                // pass. The store holds JSON-encoded values (see the seeded
+                // baseUrl), and the setter now encodes — so a caller passing a
+                // plain string gets a plain string back. Pre-quoting was the
+                // workaround for the setter using String() while the getter
+                // used JSON.parse.
+                bru.setCollectionVar('token', 'abc');
+                var rt = bru.getCollectionVar('token');
+                globalThis.__rt_type = typeof rt;
+                globalThis.__rt = String(rt);
                 var h1 = bru.hasCollectionVar('baseUrl');
                 var h2 = bru.hasCollectionVar('missing');
                 bru.deleteCollectionVar('retries');
@@ -6576,6 +6585,20 @@ mod tests {
                 ctx.eval::<String, _>("__after").unwrap(),
                 "{\"baseUrl\":\"\\\"https://api.example.com\\\"\",\"token\":\"\\\"abc\\\"\"}",
                 "setCollectionVar must add, deleteCollectionVar must remove (the stub store keeps JSON-encoded values, hence the escaped quotes)"
+            );
+            // The property that matters: set/get are inverses. Fails on the
+            // pre-fix String()-in / JSON.parse-out asymmetry, where setting
+            // 'abc' stored the bare 3 chars and getting it back threw or
+            // returned undefined.
+            assert_eq!(
+                ctx.eval::<String, _>("__rt_type").unwrap(),
+                "string",
+                "bru.setCollectionVar('token','abc') must read back as a string"
+            );
+            assert_eq!(
+                ctx.eval::<String, _>("__rt").unwrap(),
+                "abc",
+                "bru collection var set/get must round-trip unchanged"
             );
             assert_eq!(
                 ctx.eval::<String, _>("__after_all").unwrap(),

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -620,42 +620,42 @@ pub(crate) async fn create_vu_js_context(
     ctx.with_ctx(|rq_ctx| {
         let globals = rq_ctx.globals();
         let deadline_sleep = deadline.clone();
-        // TR-502 proper fix: sleep is now async (Promise-based) so the VU's
-        // thread yields and other VUs on the same worker can progress. The old
-        // sync std::thread::sleep parked the OS thread. With rquickjs
-        // full-async, host functions can be async and the job queue is pumped
-        // via finish_promise/pump_promise_queue.
+        // MUST be a SYNC host fn. `JsContext` builds a plain `rquickjs::Runtime`
+        // (tropel-js/src/context.rs), which has NO spawner — `Opaque::spawner()`
+        // is `.expect("tried to use async function in non async runtime")`. An
+        // `Async` host fn calls `ctx.spawn` on first invocation and panics
+        // there; rquickjs's ffi layer catches the panic, stashes it in the
+        // runtime's `Opaque`, and throws into JS, so the VU sees an opaque
+        // "Async script rejected" — and the stashed payload then `resume_unwind`s
+        // on whichever VU next raises an exception, which on a shared runtime is
+        // a DIFFERENT VU. A previous revision registered this as `Async` and the
+        // guard below only checked `typeof sleep`, so 1130 tests passed while
+        // `sleep()` was dead on every declarative format.
+        //
+        // Absolute deadline, not `remaining -= slice`: OS overshoot compounds
+        // in the subtractive form (TR-502). Mirrors the k6 driver's copy.
         let _ = globals.set(
             "__tropel_native_sleep",
-            rquickjs::function::Func::from(rquickjs::function::Async(
-                move |_ctx: rquickjs::Ctx<'_>, ms: f64| {
-                    let deadline_sleep = deadline_sleep.clone();
-                    let force_stop_sleep = force_stop_sleep.clone();
-                    async move {
-                        if ms <= 0.0 {
-                            tropel_js::rearm_deadline(&deadline_sleep, max_exec);
-                            return Ok::<(), rquickjs::Error>(());
+            rquickjs::function::Func::from(move |ms: f64| {
+                if ms > 0.0 {
+                    let total = Duration::from_secs_f64(ms / 1000.0);
+                    let deadline_inner = std::time::Instant::now() + total;
+                    let step = Duration::from_millis(10);
+                    loop {
+                        if force_stop_sleep.load(Ordering::Acquire) {
+                            deadline_sleep.store(0, Ordering::Relaxed);
+                            return;
                         }
-                        let total = Duration::from_secs_f64(ms / 1000.0);
-                        let deadline_inner = std::time::Instant::now() + total;
-                        let step = Duration::from_millis(10);
-                        loop {
-                            if force_stop_sleep.load(Ordering::Acquire) {
-                                deadline_sleep.store(0, Ordering::Relaxed);
-                                return Err(rquickjs::Error::Exception);
-                            }
-                            let now = std::time::Instant::now();
-                            if now >= deadline_inner {
-                                break;
-                            }
-                            let remaining = deadline_inner - now;
-                            tokio::time::sleep(remaining.min(step)).await;
+                        let now = std::time::Instant::now();
+                        if now >= deadline_inner {
+                            break;
                         }
-                        tropel_js::rearm_deadline(&deadline_sleep, max_exec);
-                        Ok::<(), rquickjs::Error>(())
+                        let remaining = deadline_inner - now;
+                        std::thread::sleep(remaining.min(step));
                     }
-                },
-            )),
+                }
+                tropel_js::rearm_deadline(&deadline_sleep, max_exec);
+            }),
         );
     });
 
@@ -1076,6 +1076,23 @@ mod tests {
             ty, "function",
             "sleep must be installed on globalThis for the declarative path — \
              a block-scoped declaration silently leaves it undefined"
+        );
+
+        // `typeof` alone is not evidence: it passed for the whole period in
+        // which `sleep` was backed by an `Async` host fn on a runtime with no
+        // spawner, so the first CALL panicked with "tried to use async function
+        // in non async runtime". Call it, and assert it actually waits.
+        let elapsed = ctx
+            .eval_async(
+                "(async () => { const t = Date.now(); await sleep(0.05); return Date.now() - t; })()",
+            )
+            .await
+            .expect("sleep must be callable, not merely defined");
+        let ms: f64 = elapsed.trim().parse().unwrap_or(-1.0);
+        assert!(
+            ms >= 40.0,
+            "await sleep(0.05) must block ~50ms; got {elapsed:?} — the host fn \
+             is registered but not actually sleeping"
         );
     }
 
@@ -1599,10 +1616,22 @@ mod tests {
             for i in 0..N {
                 ctxs.push(new_vu_ctx(i, &bundle).await);
             }
-            let total: u64 = ctxs.iter().map(|c| c.quickjs_heap_bytes()).sum();
+            // `quickjs_heap_bytes()` reads the RUNTIME's heap, and since TR-503
+            // every context on this thread shares one runtime — so all N reads
+            // return the same figure and summing them is N x double-counting.
+            // The previous `sum / N` therefore printed the whole N-context
+            // runtime heap under a `B/VU` label, ~N x too large. Read once and
+            // divide once.
+            let whole = ctxs[0].quickjs_heap_bytes();
+            debug_assert_eq!(
+                whole,
+                ctxs[N as usize - 1].quickjs_heap_bytes(),
+                "contexts on one thread must share a runtime; if this fires, \
+                 sharing regressed and the arithmetic below is wrong"
+            );
             println!(
-                "{label:<40} = {:>9} B/VU  (N={N}, shims: {})",
-                total / u64::from(N),
+                "{label:<40} = {:>9} B/VU  (N={N}, runtime total {whole} B, shims: {})",
+                whole / u64::from(N),
                 shim_names(&bundle).join("+")
             );
             std::hint::black_box(ctxs);

--- a/crates/tropel-js/src/context.rs
+++ b/crates/tropel-js/src/context.rs
@@ -257,6 +257,31 @@ mod shared_runtime {
         /// `eval_async` calls nest correctly.
         pub(super) static ACTIVE_VU: RefCell<Option<(Arc<AtomicU64>, Arc<AtomicBool>)>> =
             const { RefCell::new(None) };
+        /// Per-VU unhandled-rejection maps, keyed by the VU's deadline `Arc`
+        /// address (a stable per-context identity).
+        ///
+        /// Like the interrupt handler, the rejection tracker is a property of
+        /// the RUNTIME, so a shared runtime cannot close over one VU's map.
+        /// It used to be installed unconditionally per context, so each new VU
+        /// REPLACED its predecessors' tracker: VU 3's rejection was recorded
+        /// into VU 50's map, VU 3 then drained an empty map and silently
+        /// passed, and VU 50 later failed with VU 3's error. This registry lets
+        /// one tracker route each rejection to whichever VU is executing.
+        pub(super) static REJECTION_ROUTES: RefCell<
+            std::collections::HashMap<usize, super::RejectionMap>,
+        > = RefCell::new(std::collections::HashMap::new());
+    }
+
+    /// Route a rejection to the currently-executing VU's map, if any.
+    pub(super) fn with_active_rejection_map<F: FnOnce(&super::RejectionMap)>(f: F) {
+        let key = ACTIVE_VU.with(|c| c.borrow().as_ref().map(|(d, _)| Arc::as_ptr(d) as usize));
+        if let Some(key) = key {
+            REJECTION_ROUTES.with(|r| {
+                if let Some(map) = r.borrow().get(&key) {
+                    f(map);
+                }
+            });
+        }
     }
 
     pub(super) fn sharing_enabled() -> bool {
@@ -299,6 +324,9 @@ mod shared_runtime {
 
 use shared_runtime::{ActiveVu, SharedRuntimeState};
 
+/// A VU's unhandled-rejection map: promise identity -> rejection reason.
+pub(crate) type RejectionMap = Arc<Mutex<HashMap<u64, String>>>;
+
 pub struct JsContext {
     /// Compiled script cache: source-hash → persistent function.
     /// Declared FIRST so it is dropped BEFORE ctx.
@@ -324,7 +352,7 @@ pub struct JsContext {
     /// rejected with no handler attached, and `true` when a handler is later
     /// attached — so a promise rejected then caught is inserted then removed,
     /// and only genuinely-unhandled rejections remain when we drain.
-    unhandled_rejections: Arc<Mutex<HashMap<u64, String>>>,
+    unhandled_rejections: RejectionMap,
 }
 
 // Safety: each JsContext owns its own rquickjs Runtime, and the thread-per-
@@ -451,23 +479,43 @@ impl JsContext {
         // and removes them when a handler is attached later (true); the
         // eval-family methods drain the map after pumping and fail the script
         // if anything is still unhandled.
-        let unhandled_rejections = Arc::new(Mutex::new(HashMap::new()));
-        {
-            let pending = unhandled_rejections.clone();
-            rt.set_host_promise_rejection_tracker(Some(Box::new(
-                move |ctx, promise, reason, is_handled| {
-                    let key = promise_identity(&promise);
+        let unhandled_rejections: RejectionMap = Arc::new(Mutex::new(HashMap::new()));
+        // Register this VU's map under its deadline-Arc address, then install a
+        // tracker that closes over NOTHING and routes via `ACTIVE_VU`. The
+        // statelessness is the point: the tracker is a property of the runtime,
+        // so on a shared runtime every context's install overwrites the last
+        // one. A tracker that captured its own VU's map therefore sent every
+        // VU's rejections into the newest VU's map. This closure is identical
+        // for every context, so overwriting it is a no-op.
+        shared_runtime::REJECTION_ROUTES.with(|r| {
+            r.borrow_mut().insert(
+                Arc::as_ptr(&interrupt_deadline) as usize,
+                unhandled_rejections.clone(),
+            );
+        });
+        rt.set_host_promise_rejection_tracker(Some(Box::new(
+            move |ctx, promise, reason, is_handled| {
+                let key = promise_identity(&promise);
+                let reason = if is_handled {
+                    None
+                } else {
+                    Some(rejection_reason_string(&ctx, &reason))
+                };
+                shared_runtime::with_active_rejection_map(|pending| {
                     // Poison-tolerant: a panicked thread must not permanently
                     // silence unhandled-rejection reporting (backlog P3).
                     let mut map = pending.lock().unwrap_or_else(|e| e.into_inner());
-                    if is_handled {
-                        map.remove(&key);
-                    } else {
-                        map.insert(key, rejection_reason_string(&ctx, &reason));
+                    match &reason {
+                        None => {
+                            map.remove(&key);
+                        }
+                        Some(r) => {
+                            map.insert(key, r.clone());
+                        }
                     }
-                },
-            )));
-        }
+                });
+            },
+        )));
 
         // Create a full-featured context
         let ctx = Context::full(&rt)
@@ -1336,6 +1384,12 @@ impl JsContext {
 
 impl Drop for JsContext {
     fn drop(&mut self) {
+        // Unconditional: the route is registered for private runtimes too, and
+        // leaving it behind would leak the map for the thread's whole life.
+        shared_runtime::REJECTION_ROUTES.with(|r| {
+            r.borrow_mut()
+                .remove(&(Arc::as_ptr(&self.interrupt_deadline) as usize));
+        });
         if !self.on_shared_runtime {
             return;
         }

--- a/crates/tropel-metrics/src/collector.rs
+++ b/crates/tropel-metrics/src/collector.rs
@@ -450,12 +450,27 @@ impl MetricsCollector {
         collector
     }
 
-    /// Hash a metric key to a shard index. Uses the metric name's hash;
-    /// per-shard channel retains ordering for a given metric.
+    /// Hash a metric key to a shard index. Hashes ONLY the metric **name**, so
+    /// every series of a given metric lands on the same shard.
+    ///
+    /// This is load-bearing for correctness, not just an optimisation. It used
+    /// to hash the whole key (name *and* tags), which scattered
+    /// `http_req_duration{url:/a}` and `{url:/b}` across different shards. Each
+    /// shard then computed its own partial `http_req_duration` summary, and
+    /// `merge_results` picked the single largest-count one and discarded the
+    /// rest — so the headline count, avg, min, max and p95 that users read were
+    /// computed from roughly 1/SHARD_COUNT of the population. The percentiles
+    /// could not be repaired at merge time either, because `MetricSummary`
+    /// carries precomputed scalars rather than a histogram.
+    ///
+    /// With name-only hashing a metric is owned end-to-end by one shard, which
+    /// aggregates it over the complete population with a real histogram. Load
+    /// stays balanced because a request emits ~12 distinct metric names, which
+    /// spread across the shards.
     fn shard_for_key(key: &MetricKey) -> usize {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        key.hash(&mut hasher);
+        key.metric.hash(&mut hasher);
         (hasher.finish() as usize) % SHARD_COUNT
     }
 
@@ -678,6 +693,8 @@ impl MetricsCollector {
             return shards.remove(0);
         }
         let mut out = MetricsResult::default();
+        let mut failed_weighted = 0.0f64;
+        let mut failed_weight = 0.0f64;
         // Keep the config from the first shard (all shards share the same config via broadcast).
         out.summary_trend_stats = shards[0].summary_trend_stats.clone();
         out.effective_thresholds = shards[0].effective_thresholds.clone();
@@ -714,13 +731,16 @@ impl MetricsCollector {
             out.data_sent += r.data_sent;
             out.errors += r.errors;
             out.series_dropped += r.series_dropped;
-            out.output_samples_dropped += r.output_samples_dropped;
-            out.aggregator_samples_dropped += r.aggregator_samples_dropped;
             out.dropped_iterations += r.dropped_iterations;
-            // http_req_failed is a rate; recompute from totals after merge would be ideal,
-            // but each shard's rate is already computed. Use weighted average by http_reqs.
-            // For now, max approximates the worst shard; will be refined by totals.
-            out.http_req_failed = out.http_req_failed.max(r.http_req_failed);
+            // `http_req_failed` is a RATE: it cannot be summed, and taking the
+            // max reported the worst shard as if it were the run (10 failures
+            // all landing on one of four 100-request shards read as 0.10, not
+            // the true 0.025). Sum the numerator and denominator instead and
+            // divide once, after the loop. Note this cannot be weighted by
+            // `r.http_reqs` — `shard_for_key` hashes the metric name, so
+            // `http_reqs` and `http_req_failed` live on different shards.
+            failed_weighted += r.http_req_failed_count;
+            failed_weight += r.http_req_failed_total;
             out.iterations += r.iterations;
             out.vus_max = out.vus_max.max(r.vus_max);
             out.requested_vus = out.requested_vus.max(r.requested_vus);
@@ -729,9 +749,19 @@ impl MetricsCollector {
                 out.effective_vus_reason = r.effective_vus_reason.clone();
             }
         }
-        // Recompute http_req_failed as weighted average if we have http_reqs
-        // (each shard's http_req_failed is failed/total for that shard).
-        // For now, keep max as conservative.
+        out.http_req_failed_count = failed_weighted;
+        out.http_req_failed_total = failed_weight;
+        if failed_weight > 0.0 {
+            out.http_req_failed = failed_weighted / failed_weight;
+        }
+        // These two are PROCESS-GLOBAL atomics, so every shard's `build_results`
+        // loaded the same figure and the loop above summed it SHARD_COUNT times —
+        // one lagging output that dropped 1,000 samples reported 4,000 lost.
+        // Read them exactly once, here, after the merge.
+        out.output_samples_dropped =
+            crate::OUTPUT_SAMPLES_DROPPED.load(std::sync::atomic::Ordering::Relaxed);
+        out.aggregator_samples_dropped =
+            crate::AGGREGATOR_SAMPLES_DROPPED.load(std::sync::atomic::Ordering::Relaxed);
         out
     }
 
@@ -1444,6 +1474,8 @@ impl Aggregator {
                 .get("dropped_iterations")
                 .copied()
                 .unwrap_or(0.0) as u64,
+            http_req_failed_count,
+            http_req_failed_total,
             http_req_failed: if http_req_failed_total > 0.0 {
                 http_req_failed_count / http_req_failed_total
             } else {
@@ -1587,6 +1619,11 @@ impl Aggregator {
                     // P2 line 165: respect the cardinality cap. Without this,
                     // 50 agents x 100k cap = 5M series on the controller.
                     if data_len >= self.max_series {
+                        // Count it. `Aggregator::record`'s equivalent guard does,
+                        // and `is_unverified()` reads `series_dropped` — silently
+                        // discarding here let a controller merge that lost
+                        // millions of series still report `"unverified": false`.
+                        self.series_dropped += 1;
                         continue;
                     }
                     v.insert(MetricSet {
@@ -1895,6 +1932,12 @@ pub struct MetricsResult {
     pub dropped_iterations: u64,
     /// HTTP request failure rate (0.0 - 1.0).
     pub http_req_failed: f64,
+    /// Numerator of [`Self::http_req_failed`] — failed requests. Carried
+    /// separately so sharded results can be merged: a rate cannot be summed,
+    /// and taking the max across shards reported the worst shard as the run.
+    pub http_req_failed_count: f64,
+    /// Denominator of [`Self::http_req_failed`] — requests observed.
+    pub http_req_failed_total: f64,
     /// Total iterations completed.
     pub iterations: u64,
     /// Maximum concurrent VUs observed.
@@ -1975,6 +2018,8 @@ impl Default for MetricsResult {
             aggregator_samples_dropped: 0,
             dropped_iterations: 0,
             http_req_failed: 0.0,
+            http_req_failed_count: 0.0,
+            http_req_failed_total: 0.0,
             iterations: 0,
             vus_max: 0,
             requested_vus: 0,
@@ -3461,6 +3506,84 @@ mod tests {
         assert_eq!(
             res.http_req_failed, 0.5,
             "rate must cover the dropped-series PASS too (1 failed / 2 total)"
+        );
+    }
+
+    /// Every series of one metric must land on one shard.
+    ///
+    /// Fails on the pre-fix code, which hashed the whole `MetricKey`: the two
+    /// keys below differ only by a tag, scattered across shards, and each
+    /// shard then built its own partial `http_req_duration` summary that
+    /// `merge_results` discarded all but one of.
+    #[test]
+    fn shard_is_chosen_by_metric_name_not_by_tags() {
+        let mk = |url: &str| {
+            let mut tags = tropel_sdk::types::TagMap::new();
+            tags.insert("url", url);
+            MetricKey::new("http_req_duration", &tags)
+        };
+        let a = MetricsCollector::shard_for_key(&mk("/a"));
+        for url in ["/b", "/c", "/d", "/e", "/f", "/g", "/h"] {
+            assert_eq!(
+                a,
+                MetricsCollector::shard_for_key(&mk(url)),
+                "http_req_duration{{url:{url}}} landed on a different shard \
+                 than {{url:/a}} — the headline summary would be computed from \
+                 a fraction of the population"
+            );
+        }
+    }
+
+    /// Process-global drop counters must be read once, not once per shard.
+    ///
+    /// Fails on the pre-fix code with `4000`, because every shard's
+    /// `build_results` loaded the same global and `merge_results` summed them.
+    #[test]
+    fn global_drop_counters_are_not_multiplied_by_shard_count() {
+        let shards: Vec<MetricsResult> = (0..SHARD_COUNT)
+            .map(|_| MetricsResult {
+                output_samples_dropped: 1000,
+                aggregator_samples_dropped: 7,
+                ..Default::default()
+            })
+            .collect();
+        let out = MetricsCollector::merge_results(shards);
+        let expected = crate::OUTPUT_SAMPLES_DROPPED.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            out.output_samples_dropped, expected,
+            "output_samples_dropped must be the global's single value, not \
+             SHARD_COUNT x it"
+        );
+        assert!(
+            out.output_samples_dropped < 1000 * SHARD_COUNT as u64,
+            "the per-shard values were summed"
+        );
+    }
+
+    /// A rate must merge by summing numerator and denominator.
+    ///
+    /// Fails on the pre-fix `max` with `0.10` — the worst shard reported as if
+    /// it were the whole run.
+    #[test]
+    fn http_req_failed_merges_as_a_rate_not_as_a_max() {
+        let shard = |failed: f64, total: f64| MetricsResult {
+            http_req_failed: if total > 0.0 { failed / total } else { 0.0 },
+            http_req_failed_count: failed,
+            http_req_failed_total: total,
+            ..Default::default()
+        };
+        // 10 failures out of 400 requests, all landing on one shard.
+        let out = MetricsCollector::merge_results(vec![
+            shard(0.0, 100.0),
+            shard(0.0, 100.0),
+            shard(0.0, 100.0),
+            shard(10.0, 100.0),
+        ]);
+        assert!(
+            (out.http_req_failed - 0.025).abs() < 1e-9,
+            "expected the true run rate 0.025, got {} (0.10 means the worst \
+             shard was reported as the run)",
+            out.http_req_failed
         );
     }
 

--- a/crates/tropel-metrics/src/thresholds.rs
+++ b/crates/tropel-metrics/src/thresholds.rs
@@ -1082,6 +1082,8 @@ mod tests {
         let metrics = MetricsResult {
             http_reqs: 0,
             errors: 0,
+            http_req_failed_count: 0.0,
+            http_req_failed_total: 0.0,
             series_dropped: 0,
             output_samples_dropped: 0,
             aggregator_samples_dropped: 0,

--- a/js/scripting-api/bru.js
+++ b/js/scripting-api/bru.js
@@ -30,9 +30,24 @@
         }
         return null;
     };
+    // The three setters below MUST JSON-encode, because their getters
+    // JSON.parse. `String(value)` made set/get non-inverse: setVar('id','1234')
+    // read back as the NUMBER 1234, and setVar('u',{id:7}) read back as the
+    // string "[object Object]" — a collection doing
+    // `bru.setVar('p', res.getBody()); req.setBody(bru.getVar('p'))` put that
+    // literal string on the wire and still ran green. pm.js has always
+    // stringified here; this is the sibling that was missed.
+    function encodeBruValue(value) {
+        if (value === undefined) return '';
+        try {
+            return JSON.stringify(value);
+        } catch (e) {
+            return String(value);
+        }
+    }
     bru.setEnvVar = function (key, value) {
         if (typeof __tropel_trp_environment_set === 'function') {
-            __tropel_trp_environment_set(key, String(value));
+            __tropel_trp_environment_set(key, encodeBruValue(value));
         }
     };
 
@@ -52,7 +67,7 @@
     };
     bru.setVar = function (key, value) {
         if (typeof __tropel_trp_variables_set === 'function') {
-            __tropel_trp_variables_set(key, value === undefined ? '' : String(value));
+            __tropel_trp_variables_set(key, encodeBruValue(value));
         }
     };
     bru.hasVar = function (key) {
@@ -110,7 +125,7 @@
     };
     bru.setCollectionVar = function (key, value) {
         if (typeof __tropel_trp_collection_vars_set === 'function') {
-            __tropel_trp_collection_vars_set(key, value === undefined ? '' : String(value));
+            __tropel_trp_collection_vars_set(key, encodeBruValue(value));
         }
     };
     bru.hasCollectionVar = function (key) {

--- a/packages/shims/scripts/build.sh
+++ b/packages/shims/scripts/build.sh
@@ -9,6 +9,7 @@ cd "$(dirname "$0")/.."
 # ── 1. Refresh the shim sources from ../../js/ ────────────────────────────
 mkdir -p shim
 cp ../../js/shared/deep-equal.js shim/deep-equal.js
+cp ../../js/shared/k6-core.js shim/k6-core.js
 cp ../../js/scripting-api/pm.js shim/pm.js
 cp ../../js/scripting-api/bru.js shim/bru.js
 cp ../../js/chai/chai-shim.js shim/chai-shim.js

--- a/packages/shims/scripts/render-bundle.mjs
+++ b/packages/shims/scripts/render-bundle.mjs
@@ -17,6 +17,7 @@ const root = join(here, "..");
 // content parity, not list completeness.
 const DEFAULT_ORDER = [
   ["deep-equal-shim", "shim/deep-equal.js"],
+  ["k6-core-shim", "shim/k6-core.js"],
   ["pm-shim", "shim/pm.js"],
   ["chai-shim", "shim/chai-shim.js"],
   ["lodash-shim", "shim/lodash-shim.js"],

--- a/packages/shims/smoke.mjs
+++ b/packages/shims/smoke.mjs
@@ -17,8 +17,69 @@ const repo = path.join(__dirname, "..", "..");
 // SINGLE AUTHORITY: crates/tropel-engine/src/js_bootstrap.rs
 // (ShimBundle::default()). If that file gains or reorders an entry, update
 // this list AND scripts/render-bundle.mjs's DEFAULT_ORDER together.
+//
+// LIST COMPLETENESS is checked separately, against the Rust source of truth —
+// see assertListMatchesRust() below. Content parity alone is what let
+// `k6-core-shim` be added to `Shim::ALL` and to 35 include_str! sites while
+// packages/shims/ kept shipping the 7-shim bundle: every published
+// @tropel/runtime-wasm embedder lost `check`/`group`/`Counter`/`Gauge`/
+// `Rate`/`Trend`, because those had just moved out of pm.js into k6-core.js.
+// Three hand-maintained copies of one list is the bug; the check has to read
+// the original.
+/**
+ * Assert this file's DEFAULT_ORDER matches `Shim::ALL` in the engine.
+ *
+ * The Rust enum is the single source of truth for which shims a default
+ * bundle contains (js_bootstrap.rs: `Shim::ALL` + `Shim::name()`). Parsing it
+ * is uglier than duplicating the list, and that is exactly the point — a
+ * duplicate silently diverges, a parse fails loudly.
+ */
+function assertListMatchesRust(order) {
+  const src = readFileSync(
+    new URL("../../crates/tropel-engine/src/js_bootstrap.rs", import.meta.url),
+    "utf8",
+  );
+
+  // `pub const ALL: [Shim; N] = [ Shim::DeepEqual, Shim::K6Core, … ];`
+  const allBlock = src.match(/pub const ALL: \[Shim; \d+\] = \[([\s\S]*?)\];/);
+  if (!allBlock) throw new Error("could not find `Shim::ALL` in js_bootstrap.rs");
+  const variants = [...allBlock[1].matchAll(/Shim::(\w+)/g)].map((m) => m[1]);
+
+  // `Shim::DeepEqual => "deep-equal-shim",`
+  const names = new Map(
+    [...src.matchAll(/Shim::(\w+)\s*=>\s*"([a-z0-9-]+)"/g)].map((m) => [m[1], m[2]]),
+  );
+
+  const expected = variants.map((v) => {
+    const n = names.get(v);
+    if (!n) throw new Error(`Shim::${v} is in ALL but has no name() arm`);
+    return n;
+  });
+  const actual = order.map(([name]) => name);
+
+  const missing = expected.filter((n) => !actual.includes(n));
+  const extra = actual.filter((n) => !expected.includes(n));
+  if (missing.length || extra.length) {
+    throw new Error(
+      `shim bundle list has drifted from Shim::ALL\n` +
+        `  missing here: ${missing.join(", ") || "(none)"}\n` +
+        `  not in Rust : ${extra.join(", ") || "(none)"}\n` +
+        `  Rust order  : ${expected.join(", ")}\n` +
+        `  this file   : ${actual.join(", ")}`,
+    );
+  }
+  if (expected.join() !== actual.join()) {
+    throw new Error(
+      `shim ORDER differs from Shim::ALL (load order is load-bearing: ` +
+        `k6-core must precede pm)\n  Rust: ${expected.join(", ")}\n  here: ${actual.join(", ")}`,
+    );
+  }
+  console.log(`  list matches Shim::ALL (${expected.length} shims, same order)`);
+}
+
 const DEFAULT_ORDER = [
   ["deep-equal-shim", "js/shared/deep-equal.js"],
+  ["k6-core-shim", "js/shared/k6-core.js"],
   ["pm-shim", "js/scripting-api/pm.js"],
   ["chai-shim", "js/chai/chai-shim.js"],
   ["lodash-shim", "js/lodash/lodash-shim.js"],
@@ -45,6 +106,10 @@ if (!existsSync(shimDir)) {
 }
 
 const { defaultBundle, k6Bundle, render } = await import("./dist/bundle.js");
+
+// Completeness FIRST: if the list itself has drifted from the engine, every
+// content comparison below is comparing the wrong set and will still pass.
+assertListMatchesRust(DEFAULT_ORDER);
 
 function fail(msg) {
   console.error(`FAIL: ${msg}`);


### PR DESCRIPTION
Found by re-deriving `master` against `tropel_plan/` and `TROPEL_MASTER_TODO.md` rather than trusting the ticks. **Every one of these passed CI because the guard covering it could not fail.**

## Release-blocking

### 1. `sleep()` was dead on the entire declarative path

Postman, HAR, OpenAPI, `.http`, Insomnia, Bruno. `__tropel_native_sleep` was registered as an `Async` host fn, but `JsContext` builds a plain `rquickjs::Runtime`, which has **no spawner**:

```
panicked at rquickjs-core-0.12.2/src/runtime/opaque.rs:154:14:
tried to use async function in non async runtime
```

rquickjs catches that panic, stashes it in the runtime's `Opaque` and throws into JS — so the VU saw an opaque `Async script rejected`, and the stashed payload then `resume_unwind`s on whichever VU *next* raises an exception. On a shared runtime that is a **different VU**.

Now sync with an absolute deadline, matching the k6 driver. The guard asserted `typeof sleep === "function"` and never called it; it now calls it and asserts it actually waits. This also fixes `bru.sleep(ms)`, which calls the bridge un-awaited.

### 2. Headline `http_req_duration` / `iteration_duration` came from one shard

`shard_for_key` hashed the whole `MetricKey` — name **and** tags — despite its own doc comment saying *"uses the metric name's hash"*. So `http_req_duration{url:/a}` and `{url:/b}` landed on different shards, each building its own partial summary, and `merge_results` kept the largest-count one and discarded the rest. Users read count, avg, min, max and p95 computed from ~1/4 of the population. It could not be repaired at merge time either — `MetricSummary` carries precomputed scalars, not a histogram.

Hashing the name only makes a metric owned end-to-end by one shard. Load stays balanced: a request emits ~12 distinct metric names.

### 3. `http_req_failed` was the max of per-shard rates

10 failures all landing on one of four 100-request shards reported **0.10** against a true **0.025**. The code admitted it: *"For now, max approximates the worst shard."* Now carries numerator and denominator and divides once.

### 4. Drop counters multiplied by `SHARD_COUNT`

`output_samples_dropped` and `aggregator_samples_dropped` are **process-global** atomics, but each shard's `build_results` loaded them and `merge_results` summed. One lagging output dropping 1,000 samples reported **4,000 lost**. Read once, after the merge.

### 5. `absorb_snapshot` dropped series without counting them

The over-cap `Vacant` arm `continue`d with no `series_dropped += 1`, unlike the equivalent guard in `Aggregator::record`. A controller merging 50 agents' snapshots could discard millions of series and still report `"unverified": false`.

### 6. Promise-rejection tracker overwritten by every new VU

The tracker is a property of the **runtime**, but was installed per-context. The interrupt handler right above it is correctly gated on `!on_shared_runtime`; this was not. So VU 50's construction replaced VU 1–49's trackers:

- VU 3's unhandled rejection recorded into **VU 50's** map → VU 3 drains an empty map and **silently passes** — precisely the defect the tracker exists to prevent.
- VU 50's next iteration then **fails with VU 3's rejection**, masking its own real error.

The tracker is now stateless and routes via `ACTIVE_VU`, so re-installation is a no-op.

### 7. `bru.setVar` / `setEnvVar` / `setCollectionVar` were not inverses of their getters

Setters used `String(value)`; getters `JSON.parse`. `setVar('id','1234')` read back as the **number** `1234`; `setVar('u',{id:7})` as the string `"[object Object]"`. A collection doing `bru.setVar('p', res.getBody())` then `req.setBody(bru.getVar('p'))` put that literal on the wire and **ran green**. `pm.js` has always stringified here — this was the sibling that was missed.

The existing test hand-pre-quoted its input (`'"abc"'`) to compensate for the asymmetry. Corrected to the real contract, plus a round-trip assertion.

## Also

- **`@tropel/shims` shipped without `k6-core.js`** — every `@tropel/runtime-wasm` embedder lost `check`/`group`/`Counter`/`Gauge`/`Rate`/`Trend`. My own regression from extracting `k6-core` out of `pm.js`: the Rust bundle and all 35 `include_str!` sites were updated, `packages/shims/` was not. `smoke.mjs` now parses `Shim::ALL` out of `js_bootstrap.rs`, so the two lists cannot silently diverge again — verified with a negative control.

- **`per_vu_heap_by_format` printed a figure ~25× too large.** It summed a *shared* runtime's heap N times and printed `sum/N` as `B/VU` — since every read returns the same runtime-scoped value, that is the whole 25-context total under a per-VU label. Read once, divide once, print the runtime total alongside.

  The **384,222 B/VU** figure in the release notes is unaffected — it came from the correct `H/N` arithmetic and re-measures at **384,842 B** (0.16% drift). But `README.md:101` says *"Do not quote a per-VU figure that this command does not print"*, and the command no longer printed it.

## New guards

Three regression tests that each fail on the old code: `shard_is_chosen_by_metric_name_not_by_tags`, `global_drop_counters_are_not_multiplied_by_shard_count`, `http_req_failed_merges_as_a_rate_not_as_a_max`.

## Verification

`cargo test --workspace` — **1141 passed / 0 failed**. `cargo clippy --workspace --all-targets -- -D warnings` — clean.
