### PR TITLE
ci: build release binaries for 5 targets + wasm; fail fast on a missing toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,297 @@
+# Release binaries.
+#
+# Fires on a `v*` tag, which `scripts/release.sh --publish` pushes as its last
+# step. Cross-compiles the CLI for five targets, builds the wasm artifacts,
+# checksums everything, and creates the GitHub release with all of it attached.
+#
+# WHY THIS EXISTS: before it, `release.sh` ran `gh release create` directly and
+# the release page carried no downloadable binary at all — tropel was
+# installable only by people who already had a Rust toolchain. For a load
+# generator competing with k6, which ships prebuilt binaries everywhere, that
+# is the difference between a release and a source tag.
+#
+# WHY LINUX IS musl: a statically-linked binary runs unmodified in Alpine,
+# distroless and scratch containers, which is where a load generator actually
+# gets deployed. The usual musl objection — a slower allocator under heavy
+# threading — is already answered here: `alloc-mimalloc` is a default feature.
+#
+# WHY `--locked` EVERYWHERE: the release must build the exact dependency graph
+# CI tested. A resolver update between CI and release day would otherwise ship
+# something no test ever ran against.
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build artifacts for"
+        required: true
+
+permissions:
+  contents: write # required to create the release and upload assets
+
+env:
+  CARGO_TERM_COLOR: always
+  # Release binaries must not carry a panic=abort assumption; the VU pool
+  # depends on unwinding (see the comment in the root Cargo.toml).
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  # ── Guard ───────────────────────────────────────────────────────────────────
+  # The tag must match the version the tree actually declares. A tag typo would
+  # otherwise produce `tropel v0.2.0` binaries that report 0.1.0 on --version.
+  verify:
+    name: tag matches declared version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - id: v
+        # TAG goes through env, never straight into the script body: a
+        # workflow_dispatch input is attacker-controlled text, and inlining it
+        # as `${{ }}` splices it into the shell before bash ever parses it.
+        # Write access is needed to dispatch this, but "the caller is trusted"
+        # is not a property worth depending on in a job holding contents:write.
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "::error::refusing tag '$TAG' — must look like v1.2.3"; exit 1 ;;
+          esac
+          declared=$(awk '/^\[package\]/{p=1} p&&/^version = /{gsub(/[",]/,""); print $3; exit}' \
+                     crates/tropel/Cargo.toml)
+          echo "tag=$TAG  declared=$declared"
+          if [[ "$TAG" != "v$declared" ]]; then
+            echo "::error::tag $TAG does not match declared version $declared"
+            exit 1
+          fi
+          echo "version=$declared" >> "$GITHUB_OUTPUT"
+      - name: version surfaces agree
+        run: bash scripts/version-lockstep.sh
+
+  # ── Native binaries ─────────────────────────────────────────────────────────
+  binaries:
+    name: ${{ matrix.target }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cross: false
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            cross: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      # `cross` runs the build in a target-matched container, which is what
+      # makes aarch64-musl work from an x86 runner without a local sysroot.
+      - name: install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+
+      - name: build
+        shell: bash
+        env:
+          T: ${{ matrix.target }}
+          CROSS: ${{ matrix.cross }}
+        run: |
+          set -euo pipefail
+          tool=$([[ "$CROSS" == "true" ]] && echo cross || echo cargo)
+          $tool build --release --locked --target "$T" \
+            -p tropel -p tropel-distributed
+
+      # Ship the distributed binaries too: a load generator that cannot be run
+      # in controller/agent mode is only half the product.
+      - name: stage artifacts
+        shell: bash
+        env:
+          V: ${{ needs.verify.outputs.version }}
+          T: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          v="$V"
+          t="$T"
+          out="tropel-v$v-$t"
+          mkdir -p "dist/$out"
+          ext=""
+          [[ "$t" == *windows* ]] && ext=".exe"
+          for b in tropel tropel-controller tropel-agent; do
+            src="target/$t/release/$b$ext"
+            if [[ -f "$src" ]]; then
+              cp "$src" "dist/$out/"
+            else
+              echo "::error::expected binary missing: $src"; exit 1
+            fi
+          done
+          cp README.md LICENSE-APACHE "dist/$out/" 2>/dev/null || true
+          cd dist
+          if [[ "$t" == *windows* ]]; then
+            7z a -tzip "$out.zip" "$out" >/dev/null
+          else
+            tar czf "$out.tar.gz" "$out"
+          fi
+          rm -rf "$out"
+          ls -la
+
+      # Prove the thing we are about to ship actually runs, on every target we
+      # can execute natively. A binary that builds but does not start is the
+      # failure mode a release must not have.
+      - name: smoke the built binary
+        if: ${{ !matrix.cross }}
+        shell: bash
+        env:
+          V: ${{ needs.verify.outputs.version }}
+          T: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          ext=""
+          [[ "$T" == *windows* ]] && ext=".exe"
+          got=$("target/$T/release/tropel$ext" --version)
+          echo "$got"
+          echo "$got" | grep -q "$V" \
+            || { echo "::error::--version disagrees with the tag"; exit 1; }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  # ── wasm ────────────────────────────────────────────────────────────────────
+  # The browser/edge tier. Built with the same pinned wasm-bindgen the lockfile
+  # names — a mismatch fails with a confusing schema error, not a version one.
+  wasm:
+    name: wasm artifacts
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-wasm
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install wasm toolchain
+        run: |
+          set -euo pipefail
+          wb=$(awk '/^name = "wasm-bindgen"$/{getline; gsub(/[",]/,""); print $3; exit}' Cargo.lock)
+          echo "pinning wasm-bindgen-cli to $wb (from Cargo.lock)"
+          cargo install wasm-bindgen-cli --version "$wb" --locked
+          sudo apt-get update -qq && sudo apt-get install -y binaryen
+
+      # These are the same scripts release.sh runs, and they carry the
+      # 700 KB / 8 MB size gates plus the README Size-line regeneration.
+      - name: build npm packages
+        run: |
+          set -euo pipefail
+          for p in core-wasm input-wasm runtime-wasm shims; do
+            echo "── $p"
+            bash "packages/$p/scripts/build.sh"
+          done
+
+      # If a build.sh rewrote a README Size line, the tag was cut from a tree
+      # whose committed sizes are stale — CI fails on that, so catch it here
+      # rather than after the release is public.
+      - name: size lines are committed
+        run: |
+          if [[ -n "$(git status --porcelain -- packages/)" ]]; then
+            echo "::error::a build.sh regenerated a README Size line; commit it and re-tag"
+            git status --porcelain -- packages/
+            exit 1
+          fi
+
+      - name: stage wasm bundle
+        env:
+          V: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          v="$V"
+          out="tropel-wasm-v$v"
+          mkdir -p "dist/$out"
+          for p in core-wasm input-wasm runtime-wasm shims; do
+            mkdir -p "dist/$out/$p"
+            cp -r "packages/$p"/{pkg,dist,shim,*.js,*.json,*.md} "dist/$out/$p/" 2>/dev/null || true
+          done
+          cd dist && tar czf "$out.tar.gz" "$out" && rm -rf "$out" && ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-wasm
+          path: dist/*
+          if-no-files-found: error
+
+  # ── Publish ─────────────────────────────────────────────────────────────────
+  release:
+    name: create GitHub release
+    needs: [verify, binaries, wasm]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: staged
+          pattern: dist-*
+          merge-multiple: true
+
+      # One checksum file over everything, generated where the files finally
+      # sit — checksums computed per-job would not cover the assembled set.
+      - name: checksums
+        run: |
+          set -euo pipefail
+          cd staged
+          ls -la
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: tropel v${{ needs.verify.outputs.version }}
+          body_path: CHANGELOG.md
+          files: staged/*
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: ${{ contains(needs.verify.outputs.version, '-') }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,6 +97,47 @@ git fetch -q origin master
 VERSION=$(crate_version tropel)
 grn "  release version: $VERSION"
 
+# Toolchain check FIRST — before the test suite (minutes) and long before any
+# irreversible publish. The npm step shells out to four build.sh scripts that
+# need wasm-bindgen/wasm-opt/node; discovering a missing one at step 2 used to
+# cost a full build and reported it as "size gate?", which is misleading.
+# Every message below carries the exact command to fix it.
+step "Toolchain"
+WB_VERSION=$(awk '/^name = "wasm-bindgen"$/{getline; gsub(/[",]/,""); print $3; exit}' Cargo.lock)
+missing=0
+need() { # need <cmd> <install hint>
+  if command -v "$1" >/dev/null 2>&1; then
+    grn "  $1"
+  else
+    red "  $1 — MISSING"
+    echo "      $2"
+    missing=1
+  fi
+}
+need node    "install Node 20+ (https://nodejs.org)"
+need npm     "ships with Node"
+need gh      "brew install gh   # needed for the GitHub release"
+need wasm-opt "brew install binaryen   # or: npm i -g wasm-opt"
+# wasm-bindgen-cli MUST match the wasm-bindgen crate in Cargo.lock exactly —
+# a mismatch fails with a confusing schema error, not a version error.
+need wasm-bindgen "cargo install wasm-bindgen-cli --version $WB_VERSION --locked"
+if command -v wasm-bindgen >/dev/null 2>&1; then
+  have=$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')
+  if [[ -n "$WB_VERSION" && "$have" != "$WB_VERSION" ]]; then
+    red "  wasm-bindgen is $have but Cargo.lock pins $WB_VERSION"
+    echo "      cargo install wasm-bindgen-cli --version $WB_VERSION --locked --force"
+    missing=1
+  fi
+fi
+if ! rustup target list --installed 2>/dev/null | grep -qx wasm32-unknown-unknown; then
+  red "  wasm32-unknown-unknown target — MISSING"
+  echo "      rustup target add wasm32-unknown-unknown"
+  missing=1
+else
+  grn "  wasm32-unknown-unknown"
+fi
+(( missing == 0 )) || die "install the tools above, then re-run"
+
 bash scripts/version-lockstep.sh || die "version surfaces disagree"
 bash scripts/sdk-guard.sh        || die "sdk guard failed"
 
@@ -163,16 +204,29 @@ fi
 
 # ── 3 · Tag ──────────────────────────────────────────────────────────────────
 step "Tag and GitHub release"
+# Pushing the tag is the LAST thing this script does, and it is the trigger:
+# .github/workflows/release.yml fires on `v*`, cross-compiles the binaries for
+# five targets, and creates the GitHub release with them attached.
+#
+# This script deliberately does NOT create the release itself. It used to, with
+# `gh release create --notes-file CHANGELOG.md`, which meant a release page
+# with no downloadable binary on it — and it ran AFTER every crate had gone to
+# crates.io, where versions are permanent. Anything that failed there failed
+# with the irreversible half already done.
 if (( DRY )); then
-  ylw "  WOULD tag v$VERSION and create the GitHub release"
+  ylw "  WOULD tag v$VERSION and push it, triggering release.yml"
+  if [[ ! -f .github/workflows/release.yml ]]; then
+    die "release.yml is missing — the tag would produce a release with no binaries"
+  fi
+  grn "  release.yml present"
 else
   git tag -a "v$VERSION" -m "tropel v$VERSION"
   git push origin "v$VERSION"
-  gh release create "v$VERSION" \
-    --title "tropel v$VERSION" \
-    --notes-file CHANGELOG.md \
-    --verify-tag
-  grn "  released v$VERSION"
+  grn "  tagged and pushed v$VERSION"
+  echo
+  echo "  release.yml is now building binaries for 5 targets + wasm."
+  echo "  Watch it:   gh run watch \$(gh run list --workflow=release.yml --limit=1 --json databaseId -q '.[0].databaseId')"
+  echo "  Then:       gh release view v$VERSION"
 fi
 
 step "Done"


### PR DESCRIPTION
## The gap

`release.sh` published crates, published npm packages, then ran `gh release create`. It never built a binary — no `cargo build --release`, no `--target`, no artifact upload anywhere in the repo. The only workflows were `audit.yml` and `ci.yml`.

So `v0.1.0` would have shipped with **no downloadable binary on the release page**. tropel would be installable only by people who already have a Rust toolchain — for a load generator competing with k6, which ships prebuilt binaries for every platform, that's the difference between a release and a source tag.

## `release.yml`

Fires on a `v*` tag and cross-compiles:

| target | runner |
|---|---|
| `x86_64-unknown-linux-musl` | ubuntu (cross) |
| `aarch64-unknown-linux-musl` | ubuntu (cross) |
| `x86_64-apple-darwin` | macos |
| `aarch64-apple-darwin` | macos |
| `x86_64-pc-windows-msvc` | windows |

plus the wasm bundle (`core-wasm`, `input-wasm`, `runtime-wasm`, `shims`), with `SHA256SUMS` computed over the assembled set.

**Linux is musl** so the binary runs unmodified in Alpine, distroless and scratch — where a load generator actually gets deployed. The usual musl objection, a slower allocator under heavy threading, is already answered in this repo: `alloc-mimalloc` is a default feature.

**Ships `tropel-controller` and `tropel-agent` alongside `tropel`** — a load generator you can't run in controller/agent mode is half the product.

## Guards

A release is the one thing you can't take back, so:

- **The tag must equal the version `crates/tropel/Cargo.toml` declares.** A tag typo would otherwise ship `v0.2.0` binaries that report `0.1.0` on `--version`.
- **Every natively-runnable target executes `tropel --version` and greps for the tag before upload.** A binary that builds but doesn't start is precisely the failure a release must not have.
- **The wasm job fails if a `build.sh` regenerated a README `Size` line** — that means the tag was cut from a tree whose committed sizes are stale, which CI already rejects.
- **`workflow_dispatch` input is validated against `^v[0-9]` and passed via `env:`,** never spliced into a `run:` body. This job holds `contents: write`; "the caller needs write access anyway" isn't a property worth depending on there.

## Ordering fix

`release.sh` no longer creates the release — it pushes the tag and hands off. Previously the release-page step ran **after** every crate had gone to crates.io, where versions are permanent, so anything failing in step 3 failed with the irreversible half already done.

## Verification

`bash -n scripts/release.sh` clean, `release.yml` parses, the toolchain block was executed in isolation to confirm it detects the real missing tools and extracts `0.2.126` from the lockfile correctly.
