### PR TITLE
fix: unblock cargo publish -p tropel-runtime — path-only dev-dep on tropel-http

### DIFF
--- a/crates/tropel-runtime/Cargo.toml
+++ b/crates/tropel-runtime/Cargo.toml
@@ -28,7 +28,23 @@ async-trait.workspace = true
 
 [dev-dependencies]
 # Test-only concrete DriverHttpClient wrapper (TestHttpClient) in runner.rs.
-tropel-http.workspace = true
+#
+# PATH ONLY — deliberately NOT `.workspace = true`. The workspace entry
+# carries `version = "0.2.0"`, and a dev-dependency with a version must
+# resolve from crates.io at publish time. `tropel-http` is `publish = false`
+# and its sole registry version (0.1.0) is yanked, so that resolution cannot
+# succeed and `cargo publish -p tropel-runtime` failed with:
+#
+#   no matching package named `tropel-http` found
+#   help: packages with similar names: tropel-http
+#
+# (That "similar names" hint is cargo saying the crate exists but no usable
+# version does — which is what a fully-yanked crate looks like.)
+#
+# A dev-dependency with only a path is STRIPPED from the published manifest:
+# consumers never build this crate's tests, so they never need it. Local
+# `cargo test` resolves it by path exactly as before.
+tropel-http = { path = "../tropel-http" }
 # tokio is TEST-ONLY in this crate (`#[tokio::test]` + `tokio::time::timeout`
 # in runner.rs). Declaring it as a dev-dep keeps the library build free of
 # tokio's wasm-incompatible features (`net`/`signal`/`rt-multi-thread` don't


### PR DESCRIPTION
The release is stopped mid-publish:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `tropel-http` found
  location searched: crates.io index
  required by package `tropel-runtime v0.2.0`
  help: packages with similar names: tropel-http
```

## Diagnosis

That `help: packages with similar names: tropel-http` line is cargo saying **the crate exists but no usable version does**. Confirmed against the sparse index cargo actually resolves against:

| crate | registry state |
|---|---|
| `tropel-http` | **0.1.0 only, YANKED** — and `publish = false` |
| `tropel-core` | absent from the index |
| `tropel-metrics` | absent from the index |

So there is nothing for `tropel-http` to resolve to.

**The requirement came from a dev-dependency.** `tropel-runtime` has no regular dependency on `tropel-http` — its `[dependencies]` are sdk/sandbox/js/variables. It declared:

```toml
[dev-dependencies]
tropel-http.workspace = true
```

and the workspace entry carries a version:

```toml
tropel-http = { path = "crates/tropel-http", version = "0.2.0" }
```

A dev-dependency **with a version** must resolve from the registry at publish time — even though consumers never build this crate's tests.

## Fix

Declare it path-only. Cargo strips a version-less dev-dependency from the published manifest entirely.

## Verification

`cargo publish --dry-run` isn't available in this environment, so I verified against the generated artifact instead. The packaged `Cargo.toml` inside `tropel-runtime-0.2.0.crate`:

```toml
[dev-dependencies.tokio]
version = "1.53.1"
...
```

`tropel-http` is gone. `cargo package -p tropel-runtime` now completes where it previously failed at the same resolution step. `cargo test -p tropel-runtime` — **22 passed**, still resolving by path. No lockfile churn.

## Where this leaves crates.io

Already published in this run and **permanent**: `tropel-sdk 0.3.0`, and `tropel-variables` / `tropel-js` / `tropel-auth` / `tropel-native` / `tropel-sandbox` at `0.2.0`.

`tropel-runtime` is the **last publishable crate** in the release order — everything after it (`scheduler`, `report`, `collection`, `es`, `ext`, `build`, `tropel`) is `publish = false`. So this unblocks the entire crates step, and `release.sh` is idempotent: re-running skips the six already-published crates and resumes at `tropel-runtime`.
