### PR TITLE
fix(release): report WHICH test failed, and check disk before building

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -138,16 +138,53 @@ else
 fi
 (( missing == 0 )) || die "install the tools above, then re-run"
 
+# Disk headroom. A full --locked workspace build plus clippy --all-targets adds
+# several GB to target/, and when the disk fills mid-build cargo dies with
+# ENOSPC — which this script's next step reports as "tests failed". That has
+# already cost one misdiagnosis (a linker failure read as a code defect), so
+# check it up front where the message can name the real cause.
+AVAIL_KB=$(df -k . | awk 'NR==2 {print $4}')
+AVAIL_GB=$(( AVAIL_KB / 1024 / 1024 ))
+if (( AVAIL_GB < 5 )); then
+  red "  free disk: ${AVAIL_GB} GB"
+  echo "      A release build needs headroom. Reclaim it with:"
+  echo "        cargo clean            # this repo's target/ (rebuilds afterwards)"
+  echo "      Source edits survive cargo clean; only target/ is removed."
+  die "not enough free disk (${AVAIL_GB} GB) — see above"
+elif (( AVAIL_GB < 15 )); then
+  ylw "  free disk: ${AVAIL_GB} GB — tight; a mid-build ENOSPC will look like a test failure"
+else
+  grn "  free disk: ${AVAIL_GB} GB"
+fi
+
 bash scripts/version-lockstep.sh || die "version surfaces disagree"
 bash scripts/sdk-guard.sh        || die "sdk guard failed"
 
+# Output goes to a log, not /dev/null. `2>&1 >/dev/null` on a release gate is
+# actively hostile: it turns "one test failed" into "tests failed" with no name,
+# no assertion and no panic, so the operator cannot tell a real regression from
+# a flake without re-running the whole suite by hand.
 step "Test suite"
-cargo test --workspace --locked -- --nocapture >/dev/null 2>&1 \
-  || die "tests failed — do not release a red tree"
+LOG_DIR="${TMPDIR:-/tmp}/tropel-release-$$"
+mkdir -p "$LOG_DIR"
+if ! cargo test --workspace --locked > "$LOG_DIR/test.log" 2>&1; then
+  red "  tests failed — do not release a red tree"
+  echo
+  grep -E '^test .*FAILED|^failures:|panicked at|^test result: FAILED' "$LOG_DIR/test.log" \
+    | head -30 | sed 's/^/      /'
+  echo
+  echo "      full log: $LOG_DIR/test.log"
+  die "tests failed"
+fi
 grn "  workspace tests pass"
 
-cargo clippy --workspace --all-targets --locked -- -D warnings >/dev/null 2>&1 \
-  || die "clippy failed"
+if ! cargo clippy --workspace --all-targets --locked -- -D warnings \
+     > "$LOG_DIR/clippy.log" 2>&1; then
+  red "  clippy failed"
+  grep -E '^error' "$LOG_DIR/clippy.log" | head -20 | sed 's/^/      /'
+  echo "      full log: $LOG_DIR/clippy.log"
+  die "clippy failed"
+fi
 grn "  clippy clean"
 
 # ── 1 · Crates ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
`bash scripts/release.sh --publish` printed exactly this and stopped:

```
── Test suite ─────────────────────────────
FAIL: tests failed — do not release a red tree
```

No test name. No assertion. No panic. No log. The gate ran:

```bash
cargo test --workspace --locked -- --nocapture >/dev/null 2>&1
```

Every diagnostic went to `/dev/null`. On a release gate that's actively hostile — the operator cannot distinguish a real regression from a flake from a build failure without re-running the whole suite by hand.

## 1 · Failures are reported

Output goes to a log; on failure the gate prints the failing test names, the `failures:` block, panics, and the result line, plus the log path. Same treatment for clippy.

Verified by running the block against a stub that fails the way a red suite does:

```
-- Test suite --
  tests failed — do not release a red tree

      test js_bootstrap::tests::some_case ... FAILED
      failures:
      panicked at crates/x/src/y.rs:12: assertion failed: left == right
      test result: FAILED. 1155 passed; 1 failed; 2 ignored

      full log: /var/folders/.../tropel-release-64378/test.log
FAIL: tests failed
```

Also dropped `-- --nocapture`: with a log file it only interleaves output from parallel tests, making the failure harder to find. libtest already shows captured output for failing tests.

## 2 · Disk is checked in preflight

**This is the likely cause of the failure above.** A `--locked` workspace build plus `clippy --all-targets` adds several GB to `target/`. When the disk fills mid-build, cargo dies with `ENOSPC` — and step 1 reported that as "tests failed."

The disk hit **1.6 GB free** earlier in this session, and this exact condition has already produced one misdiagnosis here: an ENOSPC linker failure initially read as a code defect.

Dies under 5 GB, warns under 15 GB, and names the fix:

```
  free disk: 6 GB — tight; a mid-build ENOSPC will look like a test failure
```

```
FAIL: not enough free disk (3 GB) — see above
      A release build needs headroom. Reclaim it with:
        cargo clean            # this repo's target/ (rebuilds afterwards)
      Source edits survive cargo clean; only target/ is removed.
```

## On whether there's a real flake

I ran `cargo test --workspace --locked` repeatedly on master at `b83e2fe` looking for a code-level flake. **Three of six iterations confirmed clean at time of PR**, remainder still running; I'll update this if any iteration goes red. I also hammered `tropel-js` 12× specifically — the env-mutating `sharing_can_be_disabled` test is a known theoretical race — and got 0/12 failures.

So the evidence points at the environment, not the code. But the gate should have *told us that*, which is what this PR fixes.