### PR TITLE
fix(release.yml): build tropel_web.wasm before the npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          # BOTH targets. wasm32-unknown-unknown builds core-wasm/input-wasm;
+          # wasm32-wasip1 builds tropel-web, whose artifact runtime-wasm copies.
+          targets: wasm32-unknown-unknown, wasm32-wasip1
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -223,6 +225,24 @@ jobs:
 
       # These are the same scripts release.sh runs, and they carry the
       # 700 KB / 8 MB size gates plus the README Size-line regeneration.
+      # @tropel/runtime-wasm does NOT compile tropel-web — it copies the
+      # prebuilt target/wasm32-wasip1/release-wasm/tropel_web.wasm produced by
+      # scripts/wasm-size.sh (which also asserts the 2.9 MB budget). Without
+      # this step the v0.2.0 tag failed here with
+      #
+      #   ── runtime-wasm
+      #   error: tropel_web.wasm not found — run the wasm job /
+      #          scripts/wasm-size.sh first, or set TROPEL_WASM_PATH
+      #
+      # after all five binary targets had already built successfully — and
+      # because `create GitHub release` needs this job, the release was skipped
+      # and 20 minutes of binaries were discarded.
+      #
+      # ci.yml runs wasm-size.sh in its own wasm job, and release.sh was fixed
+      # to run it too; this workflow was the sibling that got missed.
+      - name: build the tropel-web wasm artifact
+        run: bash scripts/wasm-size.sh
+
       - name: build npm packages
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What happened to the v0.2.0 binaries

The tag fired `release.yml`. **All five binary targets built and uploaded successfully.** Then the release was never created:

```
success  tag matches declared version
success  x86_64-unknown-linux-musl
success  aarch64-unknown-linux-musl
success  x86_64-apple-darwin
success  aarch64-apple-darwin
success  x86_64-pc-windows-msvc
failure  wasm artifacts         <--
skipped  create GitHub release  <-- needs: [verify, binaries, wasm]
```

The wasm job died on:

```
── runtime-wasm
error: tropel_web.wasm not found — run the wasm job / scripts/wasm-size.sh first, or set TROPEL_WASM_PATH
```

## The cause, and it's mine

`@tropel/runtime-wasm` doesn't *compile* tropel-web — it copies the prebuilt `target/wasm32-wasip1/release-wasm/tropel_web.wasm` that `scripts/wasm-size.sh` produces.

`ci.yml` runs `wasm-size.sh` in its own wasm job. `release.sh` was fixed to run it in #511. **This workflow is the sibling that got missed** — same defect, same session, one file over. It's precisely the *"a guard added in one place, not its siblings"* pattern this review has spent its time closing, and I wrote that pattern into `release.sh`'s comments without checking the workflow I'd authored two PRs earlier.

## Fix

- run `bash scripts/wasm-size.sh` before the package loop
- request `wasm32-wasip1` as well as `wasm32-unknown-unknown` — the job only had the latter, so the new step would have failed on a missing target anyway

## The binaries are not lost

All five archives survived as workflow artifacts on run `33380114411`, unexpired:

| artifact | size |
|---|---|
| `dist-x86_64-unknown-linux-musl` | 38.5 MB |
| `dist-aarch64-unknown-linux-musl` | 33.8 MB |
| `dist-x86_64-apple-darwin` | 37.4 MB |
| `dist-aarch64-apple-darwin` | 33.4 MB |
| `dist-x86_64-pc-windows-msvc` | 36.2 MB |

They're simply not attached to a release, which is why none are visible.

## On `needs:`

Worth noting the blast radius argues for *keeping* `needs` rather than loosening it: a secondary artifact failing discarded 20 minutes of binaries. But loosening it would instead publish a release silently missing the wasm bundle. Fixing the job is the correct repair, not relaxing the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)