### PR TITLE
fix(release): install workspace deps in the wasm job, and make build.sh self-sufficient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,17 @@ jobs:
       - name: build the tropel-web wasm artifact
         run: bash scripts/wasm-size.sh
 
+      # @tropel/runtime-wasm compiles TS with the workspace's own `typescript`
+      # devDependency, so the root install must happen first. ci.yml does this;
+      # release.sh does this; this job did not, so the v0.2.0 tag failed at
+      # runtime-wasm with "typescript not installed" AFTER the wasm artifact
+      # had already been built and copied.
+      #
+      # There is no root package-lock.json, so `npm install` — matching ci.yml
+      # exactly — not `npm ci`.
+      - name: install workspace deps
+        run: npm install --no-audit --no-fund
+
       - name: build npm packages
         run: |
           set -euo pipefail

--- a/packages/runtime-wasm/scripts/build.sh
+++ b/packages/runtime-wasm/scripts/build.sh
@@ -50,12 +50,34 @@ echo "  copied wasm: $(du -h wasm/tropel_web.wasm | cut -f1)"
 # a release build will silently download and EXECUTE an arbitrary registry
 # package under a name the project never vendored. Resolve the local binary
 # explicitly and fail loudly if it is absent.
-TSC=""
-for candidate in ./node_modules/.bin/tsc ../../node_modules/.bin/tsc; do
-  if [[ -x "$candidate" ]]; then TSC="$candidate"; break; fi
-done
+find_tsc() {
+  local candidate
+  for candidate in ./node_modules/.bin/tsc ../../node_modules/.bin/tsc; do
+    if [[ -x "$candidate" ]]; then printf '%s' "$candidate"; return 0; fi
+  done
+  return 1
+}
+
+# SELF-SUFFICIENT, deliberately. Requiring every caller to remember a prior
+# `npm install` has now cost two failed releases: ci.yml runs it, release.sh
+# was fixed to run it, and release.yml — the third caller — was missed, so the
+# v0.2.0 tag failed here with the error below AFTER the wasm artifact had been
+# built and copied. Installing the workspace's own declared devDependency is a
+# precondition of this script, so this script owns it rather than each caller
+# re-implementing it.
+#
+# This does NOT weaken the registry protection: it installs the pinned
+# workspace devDependency and re-resolves the LOCAL binary. If that still
+# fails it errors out; it never falls back to `npx`, which would fetch and
+# execute a package this project never vendored.
+TSC=$(find_tsc || true)
 if [[ -z "$TSC" ]]; then
-  echo "error: typescript not installed — run 'npm install' at the repo root" >&2
+  echo "  typescript not resolved locally — running 'npm install' at the repo root" >&2
+  ( cd ../.. && npm install --no-audit --no-fund ) >/dev/null 2>&1 || true
+  TSC=$(find_tsc || true)
+fi
+if [[ -z "$TSC" ]]; then
+  echo "error: typescript still not installed after 'npm install' at the repo root" >&2
   echo "       (typescript is a devDependency of this workspace package)." >&2
   echo "       Refusing to 'npx tsc', which would fetch an unrelated registry package." >&2
   exit 1


### PR DESCRIPTION
The re-tagged `v0.2.0` run got **past** the wasm artifact — #512 worked — and failed one step later:

```
── runtime-wasm
  copied wasm: 2.6M
error: typescript not installed — run 'npm install' at the repo root
       Refusing to 'npx tsc', which would fetch an unrelated registry package.
```

## This is my mistake, twice in the same file

That's my own #511 guard firing correctly. It fired because `release.sh` needed **two** things before building the npm packages — the tropel-web wasm artifact, and a root `npm install`. I carried the first into `release.yml` (#512) and not the second.

Side by side:

```
release.sh         : Toolchain → tropel-web wasm artifact → npm workspace deps → npm packages
release.yml (wasm) : install wasm toolchain → build tropel-web wasm artifact → [MISSING] → build npm packages
```

Same "fixed one sibling, not the other" pattern, one PR apart. So this PR fixes it in two places rather than one, because patching only the workflow leaves the class alive for the next caller.

## 1 · `release.yml` gains the explicit step

`npm install --no-audit --no-fund`, matching `ci.yml`. No root `package-lock.json` exists, so `npm install`, not `npm ci`.

## 2 · `build.sh` is now self-sufficient

If `tsc` doesn't resolve locally, the script runs the root install itself and re-resolves.

Requiring every caller to remember a prior `npm install` has now cost **two failed releases across three callers** (`ci.yml`, `release.sh`, `release.yml`). Installing this package's own declared devDependency is a precondition *of this script*, so the script should own it — not each caller.

**This does not weaken the registry protection.** It installs the pinned workspace devDependency and re-resolves the **local** binary; if that still fails it errors out. There is no `npx` fallback left in the file — every remaining occurrence is a comment or the refusal message.

## Verified against CI's exact condition

With `node_modules` removed entirely:

```
copied wasm: 2.6M
typescript not resolved locally — running 'npm install' at the repo root
compiled dist/
tropel-runtime-wasm-0.2.0.tgz
```