### PR TITLE
fix(release): build shims BEFORE runtime-wasm — the npm loop order was wrong

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,10 +254,24 @@ jobs:
       - name: install workspace deps
         run: npm install --no-audit --no-fund
 
+      # ORDER IS LOAD-BEARING: shims BEFORE runtime-wasm.
+      #
+      # runtime-wasm's src/index.ts imports `@tropel/shims`, whose package.json
+      # points `types` at ./dist/bundle.d.ts — a GENERATED file that only
+      # exists after shims' own build.sh runs. With shims last, the v0.2.0 tag
+      # failed here with
+      #
+      #   src/index.ts(16,55): error TS2307: Cannot find module '@tropel/shims'
+      #     or its corresponding type declarations.
+      #
+      # It passed locally only because a previous run had left packages/shims/
+      # dist/ on disk. release.sh's crate loop carries a "do not reorder it
+      # casually" warning for exactly this reason; the npm loop had no such
+      # note and was in fact already wrong.
       - name: build npm packages
         run: |
           set -euo pipefail
-          for p in core-wasm input-wasm runtime-wasm shims; do
+          for p in core-wasm input-wasm shims runtime-wasm; do
             echo "── $p"
             bash "packages/$p/scripts/build.sh"
           done
@@ -281,7 +295,7 @@ jobs:
           v="$V"
           out="tropel-wasm-v$v"
           mkdir -p "dist/$out"
-          for p in core-wasm input-wasm runtime-wasm shims; do
+          for p in core-wasm input-wasm shims runtime-wasm; do
             mkdir -p "dist/$out/$p"
             cp -r "packages/$p"/{pkg,dist,shim,*.js,*.json,*.md} "dist/$out/$p/" 2>/dev/null || true
           done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -329,7 +329,7 @@ else
 fi
 
 step "npm packages"
-for pkg in core-wasm input-wasm runtime-wasm shims; do
+for pkg in core-wasm input-wasm shims runtime-wasm; do
   d="packages/$pkg"
   [[ -d "$d" ]] || { ylw "  $pkg — missing, skipping"; continue; }
 
@@ -372,6 +372,10 @@ for pkg in core-wasm input-wasm runtime-wasm shims; do
     continue
   fi
 
+  # ORDER IS LOAD-BEARING: shims BEFORE runtime-wasm. runtime-wasm imports
+  # `@tropel/shims`, whose `types` points at the GENERATED dist/bundle.d.ts.
+  # With shims last, tsc fails with "Cannot find module '@tropel/shims'".
+  #
   # The size gates live in these build scripts and are load-bearing: they
   # regenerate the README Size line, and CI fails on a stale one.
   if [[ -f "$d/scripts/build.sh" ]]; then


### PR DESCRIPTION
Third failure of the same job. **This is the actual cause**, not another missing precondition:

```
── runtime-wasm
  copied wasm: 2.6M
src/index.ts(16,55): error TS2307: Cannot find module '@tropel/shims'
  or its corresponding type declarations.
```

## Cause

`packages/runtime-wasm/src/index.ts:16` imports `@tropel/shims`. shims' `package.json` points `types` at `./dist/bundle.d.ts` and `main` at `./dist/bundle.js` — **both generated** by shims' own `build.sh`.

The loop was:

```
core-wasm  input-wasm  runtime-wasm  shims
```

So `runtime-wasm` ran `tsc` against a package whose `dist/` didn't exist yet. Reordered to:

```
core-wasm  input-wasm  shims  runtime-wasm
```

No cycle — shims declares no `@tropel/*` dependency; `runtime-wasm` is the only package that does.

## Why it hid

It never reproduced locally because earlier runs in the session had left `packages/shims/dist/` on disk, so `tsc` always found it. `ci.yml` doesn't use this loop, so CI never caught it either.

Both callers are fixed — `scripts/release.sh` and `.github/workflows/release.yml` (two loops) — each now carrying an `ORDER IS LOAD-BEARING` comment. Worth noting `release.sh`'s **crate** loop has carried a *"do not reorder it casually"* warning from the start for exactly this hazard. The npm loop had no such note, and was already wrong.

## Verified properly this time

I simulated the entire wasm job against a genuinely clean tree — `node_modules`, `packages/*/{dist,pkg,wasm,shim}` and the wasm artifact all deleted first. That is what the three previous attempts failed to do, and why each fix only revealed the next error:

```
build the tropel-web wasm artifact  PASS: under 2832 KiB budget (2215 KiB)
install workspace deps              ok
build npm packages                  core-wasm / input-wasm / shims /
                                    runtime-wasm — all four pack as 0.2.0
size lines are committed            ok — no tracked file changed
stage wasm bundle                   tropel-wasm-v0.2.0.tar.gz (726,328 B)

ALL WASM-JOB STEPS PASSED
```