### PR TITLE
feat(auth): Hawk through the pure builder (ask #7, part 2)

### DIFF
--- a/crates/tropel-auth/src/builders.rs
+++ b/crates/tropel-auth/src/builders.rs
@@ -243,6 +243,90 @@ pub fn digest_build_authorization(p: &DigestBuildParams<'_>) -> HeaderOut {
     }
 }
 
+// ── Hawk (hawk.1.header) ────────────────────────────────────────────────────
+
+/// Everything needed to build a Hawk `Authorization` header.
+///
+/// `ts` and `nonce` are caller-supplied so a vector can be pinned; the signer
+/// passes the host clock and a CSPRNG nonce.
+#[derive(Debug, Clone)]
+pub struct HawkBuildParams<'a> {
+    /// HTTP method — uppercased internally.
+    pub method: &'a str,
+    /// Request-target: path + query.
+    pub resource: &'a str,
+    /// Host WITHOUT brackets for IPv6; the caller brackets if it must.
+    pub host: &'a str,
+    pub port: u16,
+    pub id: &'a str,
+    pub key: &'a str,
+    /// `"sha256"` (default) or `"sha1"`.
+    pub algorithm: Option<&'a str>,
+    /// Unix seconds, as a string.
+    pub ts: &'a str,
+    pub nonce: &'a str,
+    /// Application-specific data folded into the MAC. Empty when unused.
+    pub ext: &'a str,
+}
+
+/// The Hawk normalized request string.
+///
+/// Field ORDER is the whole contract: scheme, ts, nonce, method, resource,
+/// host, port, hash, ext — each followed by a newline. `ts` and `nonce` come
+/// FIRST, immediately after the scheme line. An earlier implementation put
+/// method/resource/host/port first and produced a MAC every Hawk server
+/// rejects, which is why the order is spelled out rather than inferred.
+pub fn hawk_normalized_string(p: &HawkBuildParams<'_>, hash: &str) -> String {
+    let method = p.method.to_uppercase();
+    let host = p.host.to_lowercase();
+    format!(
+        "hawk.1.header\n{}\n{}\n{method}\n{}\n{host}\n{}\n{hash}\n{}\n",
+        p.ts, p.nonce, p.resource, p.port, p.ext
+    )
+}
+
+/// Hawk request MAC = base64(HMAC(algorithm, key, normalized)).
+///
+/// Defaults to SHA-256; `"sha1"` selects the legacy variant. Anything else is
+/// treated as SHA-256 rather than refused, matching the signer — a Hawk server
+/// that wanted SHA-1 will reject the MAC, which is a loud failure at the wire.
+pub fn hawk_mac(normalized: &str, key: &str, algorithm: Option<&str>) -> String {
+    use base64::Engine as _;
+    use hmac::digest::KeyInit as _;
+    use hmac::{Hmac, Mac as _};
+    use sha1::Sha1;
+    let sha1 = algorithm.is_some_and(|a| a.eq_ignore_ascii_case("sha1"));
+    if sha1 {
+        let mut mac =
+            Hmac::<Sha1>::new_from_slice(key.as_bytes()).expect("HMAC-SHA1 accepts any key length");
+        mac.update(normalized.as_bytes());
+        base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+    } else {
+        let mut mac = Hmac::<Sha256>::new_from_slice(key.as_bytes())
+            .expect("HMAC-SHA256 accepts any key length");
+        mac.update(normalized.as_bytes());
+        base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+    }
+}
+
+/// Build the `Authorization: Hawk …` header.
+///
+/// Payload validation (`hash`) is deliberately not implemented — the signer
+/// has never sent one, and emitting an empty `hash=""` would be worse than
+/// omitting it. The normalized string still carries the empty hash field,
+/// because the spec's field COUNT is fixed.
+pub fn hawk_build_header(p: &HawkBuildParams<'_>) -> HeaderOut {
+    let normalized = hawk_normalized_string(p, "");
+    let mac = hawk_mac(&normalized, p.key, p.algorithm);
+    HeaderOut {
+        name: "Authorization".to_string(),
+        value: format!(
+            "Hawk id=\"{}\", ts=\"{}\", nonce=\"{}\", mac=\"{}\"",
+            p.id, p.ts, p.nonce, mac
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -484,6 +568,107 @@ mod tests {
         let mut sorted = positions.clone();
         sorted.sort_unstable();
         assert_eq!(positions, sorted, "fields out of wire order: {out}");
+    }
+
+    // ── Hawk ─────────────────────────────────────────────────────────────
+
+    fn hawk<'a>(algorithm: Option<&'a str>) -> HawkBuildParams<'a> {
+        HawkBuildParams {
+            method: "GET",
+            resource: "/resource/1?b=1&a=2",
+            host: "example.com",
+            port: 8000,
+            id: "dh37fgj492je",
+            key: "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+            algorithm,
+            ts: "1353832234",
+            nonce: "j4h3g2",
+            ext: "some-app-ext-data",
+        }
+    }
+
+    #[test]
+    fn hawk_normalized_string_matches_the_spec_vector() {
+        // The published example from the Hawk spec / mozilla-hawk's own
+        // README. Field ORDER is the whole contract here: ts and nonce come
+        // FIRST, right after the scheme line. An earlier implementation put
+        // method/resource/host/port first and produced a MAC every Hawk
+        // server rejects — a bug a length check would never have caught.
+        let out = hawk_normalized_string(&hawk(None), "");
+        assert_eq!(
+            out,
+            "hawk.1.header\n1353832234\nj4h3g2\nGET\n/resource/1?b=1&a=2\nexample.com\n8000\n\nsome-app-ext-data\n"
+        );
+    }
+
+    #[test]
+    fn hawk_mac_matches_the_published_vector() {
+        // Hawk spec §3.2.1 example → the published MAC for the string above.
+        let normalized = hawk_normalized_string(&hawk(None), "");
+        assert_eq!(
+            hawk_mac(&normalized, hawk(None).key, None),
+            "6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE="
+        );
+    }
+
+    #[test]
+    fn hawk_payload_hash_vector() {
+        // Hawk API.md "Payload Validation": the same request WITH a payload
+        // hash. Ported from `signers.rs` with the delegation (TR-425) — a
+        // distinct published vector from the empty-hash one above, and the
+        // only thing that pins the `hash` field's position in the normalized
+        // string. `hawk_build_header` never sends one, but the normalizer
+        // must still place it correctly for anything that does.
+        let mut p = hawk(None);
+        p.method = "POST";
+        let normalized = hawk_normalized_string(&p, "Yi9LfIIFRtBEPt74PVmbTF/xVAwPn7ub15ePICfgnuY=");
+        assert_eq!(
+            hawk_mac(&normalized, p.key, None),
+            "aSe1DERmZuRl3pI36/9BdZmnErTw3sNzOOAUlfeKjVw="
+        );
+    }
+
+    #[test]
+    fn hawk_method_uppercases_and_host_lowercases() {
+        // Both are normalization the spec requires; getting either wrong
+        // changes the MAC without changing anything visible in the header.
+        let mut p = hawk(None);
+        p.method = "get";
+        p.host = "EXAMPLE.com";
+        assert_eq!(
+            hawk_normalized_string(&p, ""),
+            hawk_normalized_string(&hawk(None), "")
+        );
+    }
+
+    #[test]
+    fn hawk_sha1_differs_from_sha256_and_unknown_falls_back() {
+        let n = hawk_normalized_string(&hawk(None), "");
+        let k = hawk(None).key;
+        let sha256 = hawk_mac(&n, k, None);
+        let sha1 = hawk_mac(&n, k, Some("sha1"));
+        assert_ne!(sha256, sha1);
+        // Case-insensitive, and an unrecognised algorithm falls back to
+        // SHA-256 rather than refusing — the server rejects the MAC, which is
+        // a loud failure at the wire rather than a silent local one.
+        assert_eq!(hawk_mac(&n, k, Some("SHA1")), sha1);
+        assert_eq!(hawk_mac(&n, k, Some("md5")), sha256);
+    }
+
+    #[test]
+    fn hawk_header_carries_id_ts_nonce_and_mac() {
+        let out = hawk_build_header(&hawk(None));
+        assert!(
+            out.value.starts_with("Hawk id=\"dh37fgj492je\""),
+            "{}",
+            out.value
+        );
+        assert!(out.value.contains("ts=\"1353832234\""), "{}", out.value);
+        assert!(out.value.contains("nonce=\"j4h3g2\""), "{}", out.value);
+        assert!(out.value.contains("mac=\""), "{}", out.value);
+        // No payload hash is sent, so none is advertised — an empty
+        // `hash=""` would be worse than omitting it.
+        assert!(!out.value.contains("hash="), "{}", out.value);
     }
 
     #[test]

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -916,19 +916,23 @@ impl HawkAuth {
             .port()
             .unwrap_or_else(|| if url.scheme() == "https" { 443 } else { 80 });
 
-        // Normalized string per the Hawk spec (mozilla/hawk lib/crypto.js
-        // generateNormalizedString): ts and nonce come FIRST, immediately
-        // after the scheme line; method/resource/host/port follow; then hash
-        // and ext (empty here — this shim doesn't do payload validation).
-        let normalized =
-            hawk_normalized_string(&method, ts, nonce, &resource, &host, port, "", ext);
-        let mac = hawk_mac(&normalized, &self.auth_key, self.algorithm.as_deref());
-
-        let header = format!(
-            "Hawk id=\"{}\", ts=\"{}\", nonce=\"{}\", mac=\"{}\"",
-            self.auth_id, ts, nonce, mac
-        );
-        set_auth_header(request, &header)
+        // Delegates to `crate::builders`, which is NOT behind the `reqwest`
+        // feature — that is what lets a browser embedder reach the same bytes
+        // (TR-425). `host` is already bracketed for IPv6 above; the builder
+        // lowercases and does not re-bracket.
+        let header = crate::builders::hawk_build_header(&crate::builders::HawkBuildParams {
+            method: &method,
+            resource: &resource,
+            host: &host,
+            port,
+            id: &self.auth_id,
+            key: &self.auth_key,
+            algorithm: self.algorithm.as_deref(),
+            ts,
+            nonce,
+            ext,
+        });
+        set_auth_header(request, &header.value)
     }
 }
 
@@ -945,49 +949,6 @@ impl AuthSigner for HawkAuth {
             .to_string();
         let nonce = generate_nonce();
         self.sign_with_ts_nonce(request, &ts, &nonce, "")
-    }
-}
-
-/// Hawk normalized request string ("hawk.1.header" scheme).
-///
-/// Each value is followed by a newline, in the order: scheme, ts, nonce,
-/// method (uppercased), resource, host (lowercased), port, hash, ext.
-/// ts/nonce come FIRST per the Hawk spec — the earlier implementation put
-/// method/resource/host/port first, producing a MAC any Hawk server rejects.
-/// The normalized request string has exactly 8 spec-ordered fields (scheme,
-/// ts, nonce, method, resource, host, port, hash, ext) — grouping them would
-/// obscure the wire order the spec mandates, so allow the arity.
-#[allow(clippy::too_many_arguments)]
-fn hawk_normalized_string(
-    method: &str,
-    ts: &str,
-    nonce: &str,
-    resource: &str,
-    host: &str,
-    port: u16,
-    hash: &str,
-    ext: &str,
-) -> String {
-    let method = method.to_uppercase();
-    let host = host.to_lowercase();
-    format!("hawk.1.header\n{ts}\n{nonce}\n{method}\n{resource}\n{host}\n{port}\n{hash}\n{ext}\n")
-}
-
-/// Hawk request MAC = base64(HMAC(algorithm, key, normalized)).
-fn hawk_mac(normalized: &str, key: &str, algorithm: Option<&str>) -> String {
-    let sha1 = algorithm
-        .map(|a| a.eq_ignore_ascii_case("sha1"))
-        .unwrap_or(false);
-    if sha1 {
-        let mut mac = <HmacSha1 as KeyInit>::new_from_slice(key.as_bytes())
-            .expect("HMAC-SHA1 accepts any key length");
-        mac.update(normalized.as_bytes());
-        base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
-    } else {
-        let mut mac = <HmacSha256 as KeyInit>::new_from_slice(key.as_bytes())
-            .expect("HMAC-SHA256 accepts any key length");
-        mac.update(normalized.as_bytes());
-        base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
     }
 }
 
@@ -1933,57 +1894,6 @@ mod tests {
     }
 
     #[test]
-    fn hawk_normalized_orders_ts_nonce_first() {
-        // Hawk spec: ts and nonce come FIRST, immediately after the scheme
-        // line — the old implementation put method/resource/host/port first.
-        let normalized = hawk_normalized_string(
-            "GET",
-            "1353832234",
-            "j4h3g2",
-            "/resource/1?b=1&a=2",
-            "example.com",
-            8000,
-            "",
-            "",
-        );
-        let lines: Vec<&str> = normalized.lines().collect();
-        assert_eq!(lines[0], "hawk.1.header");
-        assert_eq!(lines[1], "1353832234");
-        assert_eq!(lines[2], "j4h3g2");
-        assert_eq!(lines[3], "GET");
-        assert_eq!(lines[4], "/resource/1?b=1&a=2");
-        assert_eq!(lines[5], "example.com");
-        assert_eq!(lines[6], "8000");
-    }
-
-    #[test]
-    fn hawk_matches_api_reference_vector() {
-        // Hawk API.md "Protocol Example": GET /resource/1?b=1&a=2 on
-        // example.com:8000 with ext="some-app-ext-data". Published MAC:
-        // 6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=
-        let normalized = hawk_normalized_string(
-            "GET",
-            "1353832234",
-            "j4h3g2",
-            "/resource/1?b=1&a=2",
-            "example.com",
-            8000,
-            "",
-            "some-app-ext-data",
-        );
-        assert_eq!(
-            normalized,
-            "hawk.1.header\n1353832234\nj4h3g2\nGET\n/resource/1?b=1&a=2\nexample.com\n8000\n\nsome-app-ext-data\n"
-        );
-        let mac = hawk_mac(
-            &normalized,
-            "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
-            None,
-        );
-        assert_eq!(mac, "6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=");
-    }
-
-    #[test]
     fn hawk_full_signer_matches_api_reference_vector() {
         // TR-409: the FULL Hawk signer (not just `hawk_mac`) must reproduce
         // the Hawk API.md reference MAC. Injects the reference ts + nonce via
@@ -2012,28 +1922,6 @@ mod tests {
         assert!(h.contains("id=\"dh37fgj492je\""));
         assert!(h.contains("ts=\"1353832234\""));
         assert!(h.contains("nonce=\"j4h3g2\""));
-    }
-
-    #[test]
-    fn hawk_matches_api_payload_hash_vector() {
-        // Hawk API.md "Payload Validation": POST /resource/1?b=1&a=2 with a
-        // payload hash and ext. Published MAC: aSe1DERmZuRl3pI36/9BdZmnErTw3sNzOOAUlfeKjVw=
-        let normalized = hawk_normalized_string(
-            "POST",
-            "1353832234",
-            "j4h3g2",
-            "/resource/1?b=1&a=2",
-            "example.com",
-            8000,
-            "Yi9LfIIFRtBEPt74PVmbTF/xVAwPn7ub15ePICfgnuY=",
-            "some-app-ext-data",
-        );
-        let mac = hawk_mac(
-            &normalized,
-            "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
-            None,
-        );
-        assert_eq!(mac, "aSe1DERmZuRl3pI36/9BdZmnErTw3sNzOOAUlfeKjVw=");
     }
 
     #[test]


### PR DESCRIPTION
## What
Hawk follows digest through the same shape: `hawk_normalized_string`,
`hawk_mac` and `hawk_build_header` move into the ungated `builders` module, the
signer delegates, and the duplicate is deleted. One implementation, reachable
without `reqwest`.

Two of four schemes done. SigV4 and OAuth1 remain, then the `core-wasm`
exports.

## Why Hawk was easy where digest was not
Digest needed care because its header assembly carried semantics — a qop LIST,
a `-sess` cnonce rule, and quoted-string escaping that stops directive
injection. Hawk's computation was already pure: `sign_with_ts_nonce` read only
`method` and `url` off the request and everything else was a free function.
The move is mechanical, which is what the digest work bought.

## Field order is the entire contract
The normalized string is scheme, ts, nonce, method, resource, host, port,
hash, ext — each newline-terminated, with **ts and nonce FIRST**, immediately
after the scheme line. An earlier implementation put method/resource/host/port
first and produced a MAC every Hawk server rejects. A length or shape check
would never have caught that, so the test asserts the FULL normalized string
against the published vector rather than field-by-field.

## Tests — external vectors, not self-consistency
- The Hawk API.md "Protocol Example" normalized string, asserted whole.
- Its published MAC `6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=`.
- The "Payload Validation" vector `aSe1DERmZuRl3pI36/9BdZmnErTw3sNzOOAUlfeKjVw=`
  — a DISTINCT published example with a non-empty `hash`. Ported rather than
  dropped: `hawk_build_header` never sends a payload hash, but it is the only
  thing pinning that field's position for anything that does.
- Method uppercasing and host lowercasing, both of which change the MAC
  without changing anything visible in the header.
- SHA-1 vs SHA-256, case-insensitively, and an unrecognised algorithm falling
  back to SHA-256 — the server then rejects the MAC, which is a loud failure at
  the wire rather than a silent local one.

## The equivalence proof
`hawk_full_signer_matches_api_reference_vector` — the end-to-end signer test —
is kept in `signers.rs` and passes unchanged against the delegated path. The
two `signers.rs` tests that duplicated the builder vectors were removed; the
one that adds coverage was moved, not deleted.

## Gate
`cargo test -p tropel-auth` 72/72 · workspace **1,184 passed / 0 failed**
(84 suites) · `cargo fmt --check` and `clippy -D warnings` clean.