### PR TITLE
fix(auth): move SigV4 service rules out from behind the reqwest gate [TR-428]

### DIFF
--- a/crates/tropel-auth/src/builders.rs
+++ b/crates/tropel-auth/src/builders.rs
@@ -334,11 +334,127 @@ pub fn hawk_build_header(p: &HawkBuildParams<'_>) -> HeaderOut {
 
 // ── AWS Signature Version 4 ─────────────────────────────────────────────────
 
+// ── SigV4 service rules ─────────────────────────────────────────────────────
+// TR-428: these were left in `signers.rs` by TR-426, which made them
+// unreachable from `tropel-core-wasm` (`default-features = false` turns the
+// `reqwest` feature, and therefore the whole `signers` module, off). A browser
+// caller could reach `aws_sigv4_build_headers` but could NOT compute two of
+// the inputs it requires — `canonical_uri` and the signing service — so the
+// only way to call it from the web tier would have been to re-derive both in
+// TypeScript. That is invariant #3, and `default_service`'s comment below
+// records exactly what re-deriving it wrongly costs: a 403 on every S3
+// request. They live here now.
+
+const VIRTUAL_HOSTED_SERVICE_LABELS: &[&str] = &[
+    "s3",
+    "s3-control",
+    "s3-object-lambda",
+    "s3-outposts",
+    "s3express",
+    "execute-api",
+    "es",
+    "aoss",
+    "cloudsearch",
+];
+
+pub fn default_service(host: &str) -> String {
+    // Virtual-hosted AWS endpoints put the tenant BEFORE the service label
+    // (examplebucket.s3.amazonaws.com, {api-id}.execute-api.{region}.
+    // amazonaws.com, {domain}.{region}.es.amazonaws.com), so the first DNS
+    // label is NOT the signing service (backlog line 60: the old code derived
+    // `examplebucket` / `abc` / `search-x`, breaking the scope, the signing
+    // key, and is_s3_family → double-encoded S3 path → 403 on everything).
+    // For *.amazonaws.com hosts, scan labels RIGHT-TO-LEFT for a known
+    // virtual-hosted service: the service label sits closest to the
+    // amazonaws suffix, so this is also collision-robust when a tenant
+    // happens to BE a service name (es.s3.amazonaws.com → s3, not es). The
+    // S3 website/fips endpoints (bucket.s3-website-{region}…,
+    // s3-fips…amazonaws.com) still sign as s3. Everything else keeps the
+    // first-label rule (s3.us-west-2.amazonaws.com → s3; non-AWS hosts keep
+    // their first label).
+    let is_aws = host.ends_with(".amazonaws.com")
+        || host.ends_with(".amazonaws.com.cn")
+        || host == "amazonaws.com";
+    if is_aws {
+        for label in host.split('.').rev() {
+            if label == "amazonaws" || label == "com" || label == "cn" {
+                continue;
+            }
+            if VIRTUAL_HOSTED_SERVICE_LABELS.contains(&label) {
+                return label.to_string();
+            }
+            if label.starts_with("s3-website-") || label == "s3-fips" {
+                return "s3".to_string();
+            }
+        }
+    }
+    host.split('.').next().unwrap_or(host).to_string()
+}
+
+/// Map a service name to its SigV4 signing name. Most services sign with
+/// their own name, but AWS S3 Control uses `s3` as the signing name despite
+/// the endpoint prefix being `s3-control` (backlog line 240).
+pub fn signing_name(service: &str) -> &str {
+    match service {
+        "s3-control" | "s3control" => "s3",
+        other => other,
+    }
+}
+
+/// Canonical URI for SigV4.
+///
+/// AWS requires DOUBLE URI-encoding of the absolute path for every service
+/// EXCEPT the S3 family (s3, s3control, s3-object-lambda, s3-outposts,
+/// s3express), which sign the single-encoded path exactly as sent. The `url`
+/// crate already single-encodes `Url::path()` with the RFC 3986 unreserved
+/// rules, so re-encoding each segment yields the required second encoding
+/// for non-S3 services (`%` is not unreserved → `%25`). Empty segments
+/// (leading/trailing slash, `//`) are preserved; an empty path becomes `/`.
+pub fn sigv4_canonical_uri(path: &str, service: &str) -> String {
+    if is_s3_family(service) {
+        return if path.is_empty() {
+            "/".to_string()
+        } else {
+            path.to_string()
+        };
+    }
+    if path.is_empty() {
+        return "/".to_string();
+    }
+    // Backlog line 240: normalize consecutive slashes — AWS's official
+    // test suite expects //prod/users → /prod/users. Without this, the
+    // classic base-URL-ends-in-/ join produces a double-slash that fails
+    // signature verification with a 403.
+    // TR-603: single replace("//","/") only handles pairs; use a loop
+    // for runs of 3+ consecutive slashes.
+    let mut normalized = path.to_string();
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
+    let encoded: Vec<String> = normalized
+        .split('/')
+        .map(percent_encode_unreserved)
+        .collect();
+    encoded.join("/")
+}
+
+/// True for the S3 family of services, which sign the single-encoded path.
+///
+/// Matches both spellings of S3 Control's signing name ("s3-control" is what
+/// `default_service` derives from `s3-control.<region>.amazonaws.com`; some
+/// tools emit the un-hyphenated "s3control").
+pub fn is_s3_family(service: &str) -> bool {
+    matches!(
+        service,
+        "s3" | "s3control" | "s3-control" | "s3-object-lambda" | "s3-outposts" | "s3express"
+    )
+}
+
+/// Duplicates are allowed and are what the multi-value comma-join operates on.
+#[derive(Debug, Clone)]
 /// Everything needed to build the SigV4 headers.
 ///
 /// `headers` is the request's headers in INSERTION order, names as sent.
-/// Duplicates are allowed and are what the multi-value comma-join operates on.
-#[derive(Debug, Clone)]
 pub struct AwsSigV4BuildParams<'a> {
     /// Uppercase HTTP method.
     pub method: &'a str,
@@ -556,7 +672,7 @@ pub fn aws_sigv4_build_headers(
 /// its own identical copy; a single definition is the point of this module,
 /// because a percent-encoding set that drifts by one character produces a
 /// signature the server rejects with no useful diagnostic.
-const OAUTH1_UNRESERVED: AsciiSet = NON_ALPHANUMERIC
+const RFC3986_UNRESERVED: AsciiSet = NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'.')
     .remove(b'_')
@@ -577,9 +693,14 @@ pub fn oauth1_is_supported_signature_method(method: &str) -> bool {
         .any(|m| m.eq_ignore_ascii_case(method))
 }
 
-/// RFC 5849 §3.6 percent-encoding.
-pub fn oauth1_percent_encode(value: &str) -> String {
-    utf8_percent_encode(value, &OAUTH1_UNRESERVED).to_string()
+/// RFC 3986 §2.3 percent-encoding: everything except `A-Z a-z 0-9 - . _ ~`.
+///
+/// Shared, not per-scheme: RFC 5849 §3.6 (OAuth1) and SigV4's canonical URI
+/// both specify exactly this set. Two copies of a percent-encoding set is how
+/// two signers start disagreeing by one character, which is a 403 with no
+/// useful diagnostic.
+pub fn percent_encode_unreserved(value: &str) -> String {
+    utf8_percent_encode(value, &RFC3986_UNRESERVED).to_string()
 }
 
 /// RFC 5849 §3.4.1.1 signature base string.
@@ -591,7 +712,7 @@ pub fn oauth1_percent_encode(value: &str) -> String {
 pub fn oauth1_base_string(method: &str, base_uri: &str, params: &[(String, String)]) -> String {
     let mut encoded: Vec<(String, String)> = params
         .iter()
-        .map(|(k, v)| (oauth1_percent_encode(k), oauth1_percent_encode(v)))
+        .map(|(k, v)| (percent_encode_unreserved(k), percent_encode_unreserved(v)))
         .collect();
     encoded.sort();
     let param_string = encoded
@@ -602,14 +723,14 @@ pub fn oauth1_base_string(method: &str, base_uri: &str, params: &[(String, Strin
     format!(
         "{}&{}&{}",
         method.to_uppercase(),
-        oauth1_percent_encode(base_uri),
-        oauth1_percent_encode(&param_string)
+        percent_encode_unreserved(base_uri),
+        percent_encode_unreserved(&param_string)
     )
 }
 
 /// RFC 5849 §3.4.2 HMAC signature over the base string, base64-encoded.
 ///
-/// Signing key = `enc(consumer_secret) & enc(token_secret)` — the `&` is
+/// Signing key = `percent_encode_unreserved(consumer_secret) & percent_encode_unreserved(token_secret)` — the `&` is
 /// present even when the token secret is empty (two-legged OAuth), which is
 /// why the caller passes `""` rather than omitting it.
 ///
@@ -624,8 +745,8 @@ pub fn oauth1_signature(
 ) -> Option<String> {
     let key = format!(
         "{}&{}",
-        oauth1_percent_encode(consumer_secret),
-        oauth1_percent_encode(token_secret)
+        percent_encode_unreserved(consumer_secret),
+        percent_encode_unreserved(token_secret)
     );
     // One macro rather than a generic: `hmac::Hmac<D>` needs bounds that are
     // awkward to name across digest crates, and three explicit arms match how
@@ -721,8 +842,8 @@ pub fn oauth1_build_header(p: &OAuth1BuildParams<'_>) -> Option<OAuth1Out> {
         .map(|(k, v)| {
             format!(
                 "{}=\"{}\"",
-                oauth1_percent_encode(k),
-                oauth1_percent_encode(v)
+                percent_encode_unreserved(k),
+                percent_encode_unreserved(v)
             )
         })
         .collect::<Vec<_>>()
@@ -1216,7 +1337,7 @@ mod tests {
 
     #[test]
     fn oauth1_two_legged_none_token_secret_equals_empty() {
-        // RFC 5849 §3.4.2: the signing key is `enc(consumer_secret) & enc(token_secret)`.
+        // RFC 5849 §3.4.2: the signing key is `percent_encode_unreserved(consumer_secret) & percent_encode_unreserved(token_secret)`.
         // In two-legged OAuth there is no token secret, and `None` must be
         // treated as the empty string — not as an absent component, and not
         // as a placeholder. Any other default silently changes every
@@ -1280,5 +1401,100 @@ mod tests {
         );
         assert!(out.header.value.starts_with("OAuth "));
         assert!(out.header.value.contains("oauth_token=\"tok\""));
+    }
+    #[test]
+    fn sigv4_default_service_derives_virtual_hosted_endpoints() {
+        // Regression (backlog line 60): default_service took the FIRST DNS
+        // label, so virtual-hosted endpoints derived the TENANT as the
+        // signing service (examplebucket / abc / search-x) — wrong scope,
+        // wrong signing key, and for S3 a false is_s3_family → double-encoded
+        // path (403 on every virtual-hosted-S3 and API-Gateway request).
+        assert_eq!(default_service("s3.us-west-2.amazonaws.com"), "s3");
+        assert_eq!(default_service("examplebucket.s3.amazonaws.com"), "s3");
+        assert_eq!(
+            default_service("examplebucket.s3.us-west-2.amazonaws.com"),
+            "s3"
+        );
+        assert_eq!(
+            default_service("mybucket.s3-website-us-west-2.amazonaws.com"),
+            "s3"
+        );
+        assert_eq!(default_service("s3-fips.us-west-2.amazonaws.com"), "s3");
+        // Collision-robustness: a tenant that IS a service name must not win
+        // over the real (suffix-closest) service label.
+        assert_eq!(default_service("es.s3.amazonaws.com"), "s3");
+        assert_eq!(
+            default_service("abc123.execute-api.us-east-1.amazonaws.com"),
+            "execute-api"
+        );
+        assert_eq!(default_service("search-x.us-east-1.es.amazonaws.com"), "es");
+        // Non-virtual-hosted service: first label IS the service.
+        assert_eq!(
+            default_service("dynamodb.us-east-1.amazonaws.com"),
+            "dynamodb"
+        );
+        // Non-AWS host: first label preserved (unchanged behavior).
+        assert_eq!(default_service("api.example.com"), "api");
+    }
+
+    #[test]
+    fn sigv4_is_fully_derivable_without_the_reqwest_feature() {
+        // TR-428: the point of moving the service rules here. This test runs
+        // under `--no-default-features`, which is the configuration
+        // `tropel-core-wasm` builds — so it fails to COMPILE if any step of
+        // the chain drifts back behind the `reqwest` gate.
+        //
+        // A browser caller starts with a URL and must reach a signed header
+        // using nothing but this module. Every step below is a rule that
+        // would otherwise have to be re-derived in TypeScript.
+        let host = "examplebucket.s3.amazonaws.com";
+        let service = default_service(host);
+        assert_eq!(service, "s3");
+        assert!(is_s3_family(&service));
+        let signing_service = signing_name(&service);
+        // The input is the path as `Url::path()` yields it — ALREADY
+        // single-encoded, so a literal space never arrives here. S3 signs
+        // that exactly as sent; every other service encodes it a second
+        // time (`%` is not unreserved, so `%20` becomes `%2520`).
+        assert_eq!(sigv4_canonical_uri("/a%20b/c", &service), "/a%20b/c");
+        assert_eq!(sigv4_canonical_uri("/a%20b/c", "execute-api"), "/a%2520b/c");
+
+        let key = derive_signing_key("SECRET", "20130524", "us-east-1", signing_service);
+        let out = aws_sigv4_build_headers(
+            &AwsSigV4BuildParams {
+                method: "GET",
+                path: "/test.txt",
+                query: "",
+                host,
+                headers: &[],
+                body: Some(b""),
+                access_key: "AKIAIOSFODNN7EXAMPLE",
+                secret_key: "SECRET",
+                session_token: None,
+                region: "us-east-1",
+                service: &service,
+                amz_date: "20130524T000000Z",
+                date_stamp: "20130524",
+            },
+            &sigv4_canonical_uri("/test.txt", &service),
+            signing_service,
+            &key,
+        );
+        assert!(out.headers[0]
+            .value
+            .starts_with("AWS4-HMAC-SHA256 Credential="));
+        assert!(out.headers[0]
+            .value
+            .contains("/20130524/us-east-1/s3/aws4_request"));
+    }
+
+    #[test]
+    fn sigv4_signing_name_maps_s3_control() {
+        // backlog line 240: s3-control's SIGNING name is "s3" even though the
+        // endpoint prefix is not. Getting this wrong changes the credential
+        // scope and the signing key, so it is a 403 with no diagnostic.
+        assert_eq!(signing_name("s3-control"), "s3");
+        assert_eq!(signing_name("s3control"), "s3");
+        assert_eq!(signing_name("execute-api"), "execute-api");
     }
 }

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -13,7 +13,6 @@
 use base64::Engine;
 use hmac::digest::KeyInit;
 use hmac::{Hmac, Mac};
-use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rand::RngExt;
 use sha2::Sha256;
 use std::collections::HashMap;
@@ -34,13 +33,6 @@ static SIGNING_KEY_CACHE: std::sync::OnceLock<
 fn signing_key_cache() -> &'static std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>> {
     SIGNING_KEY_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
-
-/// RFC 3986 unreserved characters: `A-Z a-z 0-9 - . _ ~` stay unencoded.
-const UNRESERVED: AsciiSet = NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~');
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -257,7 +249,7 @@ impl AwsSigV4Auth {
         let service = self
             .service
             .clone()
-            .unwrap_or_else(|| default_service(url.host_str().unwrap_or("")));
+            .unwrap_or_else(|| crate::builders::default_service(url.host_str().unwrap_or("")));
 
         // Payload hash — body is always buffered by tropel, but fall back to
         // UNSIGNED-PAYLOAD for streaming bodies (body is None or not
@@ -270,10 +262,10 @@ impl AwsSigV4Auth {
         // …), which sign the single-encoded path exactly as sent. The rule is
         // service-dependent, so it stays here with the service derivation and
         // the builder takes the result.
-        let canonical_uri = sigv4_canonical_uri(url.path(), &service);
+        let canonical_uri = crate::builders::sigv4_canonical_uri(url.path(), &service);
         // Backlog line 240: s3-control's signing name is "s3", not
         // "s3-control" — botocore's own model says signingName = "s3".
-        let sn = signing_name(&service);
+        let sn = crate::builders::signing_name(&service);
         // Cached HERE, not in the builder: the key changes only at UTC
         // midnight so this saves four chained HMACs per request, and a browser
         // embedder signing one request at a time gains nothing from a global
@@ -344,62 +336,6 @@ impl AuthSigner for AwsSigV4Auth {
 /// (S3 bucket, API Gateway ID, OpenSearch domain, …) precedes the service
 /// label. For these, `host.split('.').next()` returns the TENANT — the
 /// signing service is a later label (examplebucket.s3.amazonaws.com → s3).
-const VIRTUAL_HOSTED_SERVICE_LABELS: &[&str] = &[
-    "s3",
-    "s3-control",
-    "s3-object-lambda",
-    "s3-outposts",
-    "s3express",
-    "execute-api",
-    "es",
-    "aoss",
-    "cloudsearch",
-];
-
-fn default_service(host: &str) -> String {
-    // Virtual-hosted AWS endpoints put the tenant BEFORE the service label
-    // (examplebucket.s3.amazonaws.com, {api-id}.execute-api.{region}.
-    // amazonaws.com, {domain}.{region}.es.amazonaws.com), so the first DNS
-    // label is NOT the signing service (backlog line 60: the old code derived
-    // `examplebucket` / `abc` / `search-x`, breaking the scope, the signing
-    // key, and is_s3_family → double-encoded S3 path → 403 on everything).
-    // For *.amazonaws.com hosts, scan labels RIGHT-TO-LEFT for a known
-    // virtual-hosted service: the service label sits closest to the
-    // amazonaws suffix, so this is also collision-robust when a tenant
-    // happens to BE a service name (es.s3.amazonaws.com → s3, not es). The
-    // S3 website/fips endpoints (bucket.s3-website-{region}…,
-    // s3-fips…amazonaws.com) still sign as s3. Everything else keeps the
-    // first-label rule (s3.us-west-2.amazonaws.com → s3; non-AWS hosts keep
-    // their first label).
-    let is_aws = host.ends_with(".amazonaws.com")
-        || host.ends_with(".amazonaws.com.cn")
-        || host == "amazonaws.com";
-    if is_aws {
-        for label in host.split('.').rev() {
-            if label == "amazonaws" || label == "com" || label == "cn" {
-                continue;
-            }
-            if VIRTUAL_HOSTED_SERVICE_LABELS.contains(&label) {
-                return label.to_string();
-            }
-            if label.starts_with("s3-website-") || label == "s3-fips" {
-                return "s3".to_string();
-            }
-        }
-    }
-    host.split('.').next().unwrap_or(host).to_string()
-}
-
-/// Map a service name to its SigV4 signing name. Most services sign with
-/// their own name, but AWS S3 Control uses `s3` as the signing name despite
-/// the endpoint prefix being `s3-control` (backlog line 240).
-fn signing_name(service: &str) -> &str {
-    match service {
-        "s3-control" | "s3control" => "s3",
-        other => other,
-    }
-}
-
 fn canonical_host(url: &reqwest::Url) -> String {
     let host = bracket_host(url.host_str().unwrap_or(""));
     match url.port() {
@@ -449,57 +385,6 @@ fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
         <HmacSha256 as KeyInit>::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
     mac.update(data);
     mac.finalize().into_bytes().to_vec()
-}
-
-/// RFC 3986 percent-encode (unreserved chars pass through).
-fn enc(s: &str) -> String {
-    utf8_percent_encode(s, &UNRESERVED).to_string()
-}
-
-/// Canonical URI for SigV4.
-///
-/// AWS requires DOUBLE URI-encoding of the absolute path for every service
-/// EXCEPT the S3 family (s3, s3control, s3-object-lambda, s3-outposts,
-/// s3express), which sign the single-encoded path exactly as sent. The `url`
-/// crate already single-encodes `Url::path()` with the RFC 3986 unreserved
-/// rules, so re-encoding each segment yields the required second encoding
-/// for non-S3 services (`%` is not unreserved → `%25`). Empty segments
-/// (leading/trailing slash, `//`) are preserved; an empty path becomes `/`.
-fn sigv4_canonical_uri(path: &str, service: &str) -> String {
-    if is_s3_family(service) {
-        return if path.is_empty() {
-            "/".to_string()
-        } else {
-            path.to_string()
-        };
-    }
-    if path.is_empty() {
-        return "/".to_string();
-    }
-    // Backlog line 240: normalize consecutive slashes — AWS's official
-    // test suite expects //prod/users → /prod/users. Without this, the
-    // classic base-URL-ends-in-/ join produces a double-slash that fails
-    // signature verification with a 403.
-    // TR-603: single replace("//","/") only handles pairs; use a loop
-    // for runs of 3+ consecutive slashes.
-    let mut normalized = path.to_string();
-    while normalized.contains("//") {
-        normalized = normalized.replace("//", "/");
-    }
-    let encoded: Vec<String> = normalized.split('/').map(enc).collect();
-    encoded.join("/")
-}
-
-/// True for the S3 family of services, which sign the single-encoded path.
-///
-/// Matches both spellings of S3 Control's signing name ("s3-control" is what
-/// `default_service` derives from `s3-control.<region>.amazonaws.com`; some
-/// tools emit the un-hyphenated "s3control").
-fn is_s3_family(service: &str) -> bool {
-    matches!(
-        service,
-        "s3" | "s3control" | "s3-control" | "s3-object-lambda" | "s3-outposts" | "s3express"
-    )
 }
 
 // ─────────────────────────── OAuth1 (RFC 5849) ───────────────────────────
@@ -1246,41 +1131,6 @@ mod tests {
     }
 
     #[test]
-    fn sigv4_default_service_derives_virtual_hosted_endpoints() {
-        // Regression (backlog line 60): default_service took the FIRST DNS
-        // label, so virtual-hosted endpoints derived the TENANT as the
-        // signing service (examplebucket / abc / search-x) — wrong scope,
-        // wrong signing key, and for S3 a false is_s3_family → double-encoded
-        // path (403 on every virtual-hosted-S3 and API-Gateway request).
-        assert_eq!(default_service("s3.us-west-2.amazonaws.com"), "s3");
-        assert_eq!(default_service("examplebucket.s3.amazonaws.com"), "s3");
-        assert_eq!(
-            default_service("examplebucket.s3.us-west-2.amazonaws.com"),
-            "s3"
-        );
-        assert_eq!(
-            default_service("mybucket.s3-website-us-west-2.amazonaws.com"),
-            "s3"
-        );
-        assert_eq!(default_service("s3-fips.us-west-2.amazonaws.com"), "s3");
-        // Collision-robustness: a tenant that IS a service name must not win
-        // over the real (suffix-closest) service label.
-        assert_eq!(default_service("es.s3.amazonaws.com"), "s3");
-        assert_eq!(
-            default_service("abc123.execute-api.us-east-1.amazonaws.com"),
-            "execute-api"
-        );
-        assert_eq!(default_service("search-x.us-east-1.es.amazonaws.com"), "es");
-        // Non-virtual-hosted service: first label IS the service.
-        assert_eq!(
-            default_service("dynamodb.us-east-1.amazonaws.com"),
-            "dynamodb"
-        );
-        // Non-AWS host: first label preserved (unchanged behavior).
-        assert_eq!(default_service("api.example.com"), "api");
-    }
-
-    #[test]
     fn basic_base64s_credentials() {
         let mut req = build_request("GET", "http://example.com/", None);
         BasicAuth::new("user", "pass").sign(&mut req).unwrap();
@@ -1443,31 +1293,40 @@ mod tests {
         // Non-S3 services double URI-encode the path (AWS SigV4 spec); the
         // url crate already single-encodes `path()`, so the canonical URI
         // must re-encode each segment (e.g. `%20` → `%2520`).
-        let canonical = sigv4_canonical_uri("/my%20file%2Fname", "execute-api");
+        let canonical = crate::builders::sigv4_canonical_uri("/my%20file%2Fname", "execute-api");
         assert_eq!(canonical, "/my%2520file%252Fname");
         // The S3 family signs the single-encoded path exactly as sent.
         assert_eq!(
-            sigv4_canonical_uri("/my%20file%2Fname", "s3"),
+            crate::builders::sigv4_canonical_uri("/my%20file%2Fname", "s3"),
             "/my%20file%2Fname"
         );
         assert_eq!(
-            sigv4_canonical_uri("/my%20file%2Fname", "s3-object-lambda"),
+            crate::builders::sigv4_canonical_uri("/my%20file%2Fname", "s3-object-lambda"),
             "/my%20file%2Fname"
         );
         // S3 Control's signing name is hyphenated ("s3-control") — must not
         // double-encode either.
         assert_eq!(
-            sigv4_canonical_uri("/my%20file%2Fname", "s3-control"),
+            crate::builders::sigv4_canonical_uri("/my%20file%2Fname", "s3-control"),
             "/my%20file%2Fname"
         );
         // Empty path → "/".
-        assert_eq!(sigv4_canonical_uri("", "execute-api"), "/");
+        assert_eq!(crate::builders::sigv4_canonical_uri("", "execute-api"), "/");
         // Backlog line 240: consecutive slashes are normalized for non-S3
         // services (AWS test suite expects //prod/users → /prod/users).
-        assert_eq!(sigv4_canonical_uri("/a//b/", "execute-api"), "/a/b/");
+        assert_eq!(
+            crate::builders::sigv4_canonical_uri("/a//b/", "execute-api"),
+            "/a/b/"
+        );
         // TR-603: 3+ consecutive slashes must also be normalized.
-        assert_eq!(sigv4_canonical_uri("/a///b/", "execute-api"), "/a/b/");
-        assert_eq!(sigv4_canonical_uri("/a////b/", "execute-api"), "/a/b/");
+        assert_eq!(
+            crate::builders::sigv4_canonical_uri("/a///b/", "execute-api"),
+            "/a/b/"
+        );
+        assert_eq!(
+            crate::builders::sigv4_canonical_uri("/a////b/", "execute-api"),
+            "/a/b/"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

TR-426 moved SigV4's canonicalisation into the ungated `builders.rs` and left `signers.rs` as a `reqwest` adapter. **That was incomplete, and I missed it.**

`aws_sigv4_build_headers` takes `canonical_uri` and the signing service as **pre-computed arguments**. The four rules that compute them stayed in `signers.rs`, which is `#[cfg(feature = "reqwest")]`. `tropel-core-wasm` builds `tropel-auth` with `default-features = false`, so a browser caller could reach the builder but **could not compute two of the inputs it requires** — leaving exactly one option: re-deriving them in TypeScript. That is invariant #3, and it is the specific failure this workstream exists to prevent.

Moved, ungated: `default_service`, `is_s3_family`, `sigv4_canonical_uri`, `signing_name`, and the `VIRTUAL_HOSTED_SERVICE_LABELS` table.

## Task

TR-428, follow-up to TR-426. Blocks the `core-wasm` signer exports (knockport KT-302).

## Why this is not hypothetical

`default_service`'s own comment records tropel shipping this bug once already:

> the old code derived `examplebucket` / `abc` / `search-x`, breaking the scope, the signing key, and `is_s3_family` → double-encoded S3 path → **403 on everything**

And it fails **silently in the safe direction** — non-S3 requests sign correctly, so a naive re-derivation passes every test that does not happen to use virtual-hosted S3 or API Gateway.

## Why the tests did not catch it

The regression test for that exact bug lived in `signers.rs`, so it only ran **with** the `reqwest` feature — the configuration the browser never builds. `cargo test -p tropel-auth --no-default-features` ran 46 tests and none touched the service rules.

## Tests

The browser configuration goes **46 → 49**:

```
cargo test -p tropel-auth --no-default-features
builders::tests::sigv4_default_service_derives_virtual_hosted_endpoints
builders::tests::sigv4_is_fully_derivable_without_the_reqwest_feature
builders::tests::sigv4_signing_name_maps_s3_control
```

`sigv4_is_fully_derivable_without_the_reqwest_feature` walks the whole chain — host → service → signing name → canonical URI → signed header — using nothing but `builders`.

**This guard is enforced by compilation, not assertion.** It names the functions unqualified inside `builders::tests`, so moving one back behind the gate fails the build rather than silently passing. I am stating that explicitly because an assertion-based version of this test would be satisfiable by a re-derivation, which is the thing being prevented.

One assertion I wrote was wrong and got fixed rather than accommodated: it expected `sigv4_canonical_uri("/a b/c", "s3")` to encode the space. Production passes `Url::path()`, already single-encoded, so a raw space never arrives — the test now uses `/a%20b/c` and asserts S3 passes it through while `execute-api` double-encodes to `/a%2520b/c`.

## Also in this change

Collapses the last duplicate percent-encoder. `signers.rs` had its own `UNRESERVED` set and `enc()` byte-identical to the one added for OAuth1. RFC 5849 §3.6 and SigV4's canonical URI specify the same RFC 3986 unreserved set, so there is now one `percent_encode_unreserved`. Two copies of a percent-encoding set is how two signers start disagreeing by one character — a 403 with no useful diagnostic.

## Risk

Pure move plus visibility change; no signing logic altered. Both AWS published vectors stay green, and the virtual-hosted-endpoint regression test moved with the code it guards.

## Follow-ups this audit surfaced

Applying the same completeness test to the other three signers found two more instances, each to be its own PR:

| Scheme | Rule still gated | Risk |
|---|---|---|
| **Digest** | `find_digest_challenge` — the `WWW-Authenticate` parser | Highest. A browser must parse quoted-string challenges in TypeScript to fill `DigestBuildParams` at all, and quoted-string handling here is security-relevant. |
| **OAuth1** | `base_url` (§3.4.1.2), `parse_form` (`+` → space, §3.4.1.3.1) | Lower — JS `URL`/`URLSearchParams` happen to match — but still RFC rules with no single source. |

`generate_nonce` is deliberately excluded: a caller-supplied nonce is correct for the browser (`crypto.getRandomValues` beats tropel's counter-based one), with precedent in the PKCE export.

## Docs

None needed — `builders.rs` is internal to `tropel-auth`.