### PR TITLE
chore(core-wasm): 0.4.0 — signer exports + the halved payload [TR-435]

### DIFF
--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## What

Minor bump for the five new exports (`digestSign`, `hawkSign`, `awsSigV4Sign`, `oauth1Sign`, `oauth1SignatureMethods`) landed in #529, plus a wasm artifact that is **smaller than 0.3.0's despite carrying them**.

| | raw | brotli |
|---|---|---|
| 0.3.0 | 606,318 | ~193 KB |
| **0.4.0** | **395,435** | **127 KB** |

Additive only — every 0.3.0 export keeps its name and shape.

## Publishing

I could not run `npm publish` — it is blocked in this environment. The command is:

```bash
cd packages/core-wasm && npm publish --access public
```

`npm whoami` reports `prasadthx`, and `build.sh` has already produced the 0.4.0 tarball and verified it (smoke: 38 catalogue variables, resolution corpus 16/16, all three escape modes).

Note this publishes **only** `@tropel/core-wasm`. `scripts/release.sh --publish` would also push ~20 crates to crates.io, which is a larger step than this needs.

`@tropel/runtime-wasm` and `@tropel/input-wasm` also embed `tropel-variables` and would shrink from TR-434 on a rebuild, but neither is needed for KT-302 — worth a separate release when convenient.

## Unblocks

knockport **KT-302**: flip `auth.digest` / `hawk` / `awsSigV4` / `oauth1` to `true` on both shipped transports and delete the refusal arms. **6 refused schemes → 2.**