### PR TITLE
fix(core-wasm): 0.4.1 — surface the signers in the JS facade [TR-436]

### DIFF
--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core-wasm/smoke.mjs
+++ b/packages/core-wasm/smoke.mjs
@@ -19,6 +19,11 @@ import {
   oauth2JwtExpiresAt,
   oauth2SignJwt,
   wsseSign,
+  digestSign,
+  hawkSign,
+  awsSigV4Sign,
+  oauth1Sign,
+  oauth1SignatureMethods,
   resolveTemplate,
   resolveTemplateDetailed,
   maxVariableResolutionPasses,
@@ -299,6 +304,78 @@ if (maxVariableResolutionPasses() !== 20) {
   throw new Error(`pass cap: ${maxVariableResolutionPasses()}`);
 }
 
+
+// ── TR-436: the signers reach the wasm through THIS facade ─────────────────
+// 0.4.0 shipped the Rust exports and did not surface them here, so they were
+// present in the artifact and unreachable from JS. Importing them is not
+// enough to catch that — an unexported name is `undefined` and only fails
+// when CALLED. Each is therefore invoked, and each assertion is one a wrong
+// or missing wiring would fail.
+const sigv4 = awsSigV4Sign({
+  method: "GET",
+  host: "examplebucket.s3.amazonaws.com",
+  path: "/test.txt",
+  accessKey: "AKIAIOSFODNN7EXAMPLE",
+  secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  region: "us-east-1",
+  amzDate: "20130524T000000Z",
+  dateStamp: "20130524",
+});
+if (!Array.isArray(sigv4) || sigv4.length === 0) throw new Error("awsSigV4Sign returned no headers");
+// The service must derive to s3 from a VIRTUAL-HOSTED bucket host, not to the
+// bucket name — the rule tropel TR-428 moved out from behind the reqwest gate.
+if (!sigv4[0].value.includes("/20130524/us-east-1/s3/aws4_request")) {
+  throw new Error(`awsSigV4Sign derived the wrong service: ${sigv4[0].value}`);
+}
+
+const hawk = hawkSign({
+  method: "GET", resource: "/resource", host: "example.com", port: 443,
+  id: "dh37fgj492je", key: "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+  ts: "1353832234", nonce: "j4h3g2",
+});
+if (!hawk.value.startsWith("Hawk ")) throw new Error(`hawkSign: ${hawk.value}`);
+
+const oauth1 = oauth1Sign({
+  method: "POST", scheme: "http", host: "::1", port: 8080, path: "/request",
+  formBody: "c2=&a3=2+q",
+  consumerKey: "ck", consumerSecret: "cs",
+  signatureMethod: "HMAC-SHA1", nonce: "n", timestamp: "1",
+});
+if (!oauth1.value.includes("oauth_signature=")) throw new Error(`oauth1Sign: ${oauth1.value}`);
+
+const methods = oauth1SignatureMethods();
+if (!Array.isArray(methods) || !methods.includes("HMAC-SHA1")) {
+  throw new Error(`oauth1SignatureMethods: ${JSON.stringify(methods)}`);
+}
+// An unsupported method must THROW, not downgrade to HMAC-SHA1 (TR-409).
+let refused = false;
+try {
+  oauth1Sign({ method: "GET", scheme: "https", host: "example.com", path: "/",
+    consumerKey: "ck", consumerSecret: "cs", signatureMethod: "RSA-SHA1",
+    nonce: "n", timestamp: "1" });
+} catch { refused = true; }
+if (!refused) throw new Error("oauth1Sign accepted RSA-SHA1 instead of refusing it");
+
+// Digest is challenge-response: the Digest challenge here is listed AFTER
+// Basic and carries a quoted qop list — the two things a naive parser gets
+// wrong (tropel TR-429).
+const digest = digestSign({
+  wwwAuthenticate: 'Basic realm="b", Digest realm="r", qop="auth, auth-int", nonce="n", opaque="o"',
+  username: "u", password: "p", method: "GET", uri: "/dir/index.html",
+  nc: 1, cnonce: "0a4f113b",
+});
+if (digest === null || !digest.value.startsWith("Digest ")) {
+  throw new Error(`digestSign: ${JSON.stringify(digest)}`);
+}
+if (!digest.value.includes('realm="r"') || !digest.value.includes('opaque="o"')) {
+  throw new Error(`digestSign lost challenge fields: ${digest.value}`);
+}
+// A header offering only Basic must yield null, not a bogus Digest header.
+if (digestSign({ wwwAuthenticate: 'Basic realm="b"', username: "u", password: "p",
+                 method: "GET", uri: "/", nc: 1, cnonce: "c" }) !== null) {
+  throw new Error("digestSign must return null when no Digest challenge is offered");
+}
+
 console.log(
-  `core-wasm smoke OK — catalog: ${meta.length} variables · oauth2 flows verified · resolveTemplate verified (grammar, 3 escape modes, chains, pass cap ${maxVariableResolutionPasses()}) · corpus ${corpusRun}/${corpus.cases.length} cases`,
+  `core-wasm smoke OK — catalog: ${meta.length} variables · oauth2 flows verified · 5 signers verified · resolveTemplate verified (grammar, 3 escape modes, chains, pass cap ${maxVariableResolutionPasses()}) · corpus ${corpusRun}/${corpus.cases.length} cases`,
 );

--- a/packages/core-wasm/src/index.d.ts
+++ b/packages/core-wasm/src/index.d.ts
@@ -242,3 +242,78 @@ export function wsseSign(params: {
   nonce?: string;
   created?: string;
 }): { authorization: string; nonce: string; created: string };
+
+/** One header the signer says must reach the wire. */
+export interface SignedHeader {
+  name: string;
+  value: string;
+}
+
+/** Answer a digest challenge (RFC 7616). `wwwAuthenticate` is the server's RAW
+ *  header value; `nc` is the caller's per-(host, realm, nonce) counter starting
+ *  at 1; `cnonce` is caller-generated. Returns `null` when the header carries
+ *  no Digest challenge. */
+export function digestSign(params: {
+  wwwAuthenticate: string;
+  username: string;
+  password: string;
+  method: string;
+  uri: string;
+  nc: number;
+  cnonce: string;
+}): SignedHeader | null;
+
+/** Build a Hawk `Authorization` header. */
+export function hawkSign(params: {
+  method: string;
+  resource: string;
+  host: string;
+  port: number;
+  id: string;
+  key: string;
+  algorithm?: string;
+  ts: string;
+  nonce: string;
+  ext?: string;
+}): SignedHeader;
+
+/** Sign a request with AWS SigV4. `host` is `URL.hostname` (IPv6 brackets are
+ *  re-added by the Rust); omit `service` to derive it from the host.
+ *  `bodyBase64` throws if undecodable rather than signing an empty body. */
+export function awsSigV4Sign(params: {
+  method: string;
+  host: string;
+  path: string;
+  query?: string;
+  headers?: readonly (readonly [string, string])[];
+  bodyBase64?: string;
+  accessKey: string;
+  secretKey: string;
+  sessionToken?: string;
+  region?: string;
+  service?: string;
+  amzDate: string;
+  dateStamp: string;
+}): SignedHeader[];
+
+/** Sign a request with OAuth 1.0a (RFC 5849). Throws when `signatureMethod`
+ *  is not one of `oauth1SignatureMethods()` — never a silent downgrade. */
+export function oauth1Sign(params: {
+  method: string;
+  scheme: string;
+  host: string;
+  port?: number;
+  path: string;
+  queryParams?: readonly (readonly [string, string])[];
+  formBody?: string;
+  consumerKey: string;
+  consumerSecret: string;
+  token?: string;
+  tokenSecret?: string;
+  signatureMethod: string;
+  nonce: string;
+  timestamp: string;
+}): SignedHeader;
+
+/** The signature methods `oauth1Sign` accepts. */
+export function oauth1SignatureMethods(): string[];

--- a/packages/core-wasm/src/index.js
+++ b/packages/core-wasm/src/index.js
@@ -327,3 +327,78 @@ export function oauth2SignJwt(payload, header, algorithm, secret) {
 export function wsseSign(params) {
   return JSON.parse(requireGlue("wsseSign").wsseSign(JSON.stringify(params)));
 }
+
+// ── Per-request signing (TR-432) ────────────────────────────────────────────
+// TR-436: the Rust exports landed in 0.4.0 but this facade did not surface
+// them, so the signers were present in the wasm and unreachable from JS. The
+// wasm export names are the source of truth; `requireGlue` fails loudly when
+// one is missing rather than returning undefined.
+//
+// Every one of these takes RAW request components and returns finished
+// headers. That is deliberate: assembling them here would put the AWS service
+// derivation, the S3 double-encoding rule, the RFC 5849 base-string URI and
+// the digest challenge parse into JavaScript, which is the divergence the
+// Rust side exists to prevent (tropel TR-428..TR-431).
+
+/**
+ * Answer a digest challenge (RFC 7616).
+ * @param {object} params `{wwwAuthenticate, username, password, method, uri, nc, cnonce}`
+ *   — `wwwAuthenticate` is the server's RAW header value, parsed here
+ *   (multi-scheme and quoted-pair rules included). `nc` is the caller's
+ *   per-(host, realm, nonce) counter, starting at 1; a repeated value is a
+ *   replay. `cnonce` is caller-generated (`crypto.getRandomValues`).
+ * @returns {{name:string, value:string}|null} `null` when the header carries
+ *   no Digest challenge — a server may legitimately offer only Basic, and the
+ *   caller should fall through rather than attach a bogus header.
+ */
+export function digestSign(params) {
+  return JSON.parse(requireGlue("digestSign").digestSign(JSON.stringify(params)));
+}
+
+/**
+ * Build a Hawk `Authorization` header.
+ * @param {object} params `{method, resource, host, port, id, key, algorithm?, ts, nonce, ext?}`
+ * @returns {{name:string, value:string}}
+ */
+export function hawkSign(params) {
+  return JSON.parse(requireGlue("hawkSign").hawkSign(JSON.stringify(params)));
+}
+
+/**
+ * Sign a request with AWS Signature Version 4.
+ * @param {object} params `{method, host, path, query?, headers?, bodyBase64?,
+ *   accessKey, secretKey, sessionToken?, region?, service?, amzDate, dateStamp}`
+ *   — `host` is `URL.hostname` (IPv6 brackets are re-added by the Rust);
+ *   `service` omitted derives from the host. `bodyBase64` is base64 because
+ *   the payload hash is over exact bytes; an undecodable value THROWS rather
+ *   than signing an empty body.
+ * @returns {Array<{name:string, value:string}>} every header that must reach
+ *   the wire, `Authorization` first.
+ */
+export function awsSigV4Sign(params) {
+  return JSON.parse(requireGlue("awsSigV4Sign").awsSigV4Sign(JSON.stringify(params)));
+}
+
+/**
+ * Sign a request with OAuth 1.0a (RFC 5849).
+ * @param {object} params `{method, scheme, host, port?, path, queryParams?,
+ *   formBody?, consumerKey, consumerSecret, token?, tokenSecret?,
+ *   signatureMethod, nonce, timestamp}` — `formBody` is the raw body when it
+ *   is `application/x-www-form-urlencoded`, decoded here so the `+`-is-a-space
+ *   rule stays in Rust.
+ * @returns {{name:string, value:string}}
+ * @throws when `signatureMethod` is not one of {@link oauth1SignatureMethods}
+ *   — never a silent downgrade to HMAC-SHA1.
+ */
+export function oauth1Sign(params) {
+  return JSON.parse(requireGlue("oauth1Sign").oauth1Sign(JSON.stringify(params)));
+}
+
+/**
+ * The OAuth1 signature methods {@link oauth1Sign} accepts.
+ * @returns {string[]} use this to populate a picker, so a UI cannot offer a
+ *   method the signer refuses.
+ */
+export function oauth1SignatureMethods() {
+  return JSON.parse(requireGlue("oauth1SignatureMethods").oauth1SignatureMethods());
+}


### PR DESCRIPTION
## What

**0.4.0 is broken and I shipped it.** The five signer exports landed in the *wasm* but were never added to the package's hand-written JS facade, so `digestSign`, `hawkSign`, `awsSigV4Sign`, `oauth1Sign` and `oauth1SignatureMethods` are present in the artifact and **unreachable from JavaScript**. #530 claimed the publish unblocked knockport KT-302. It did not.

```
$ grep -c digestSign packages/core-wasm/src/index.js
0
$ node -e "…wasm.includes('digestSign')"
PRESENT in wasm
```

This adds all five to `src/index.js` and `src/index.d.ts`, matching the `wsseSign` shape — JSON in, JSON out, through `requireGlue` so a missing wasm export fails loudly rather than returning `undefined`.

## Why it got through

**Nothing called them.** An unexported name imports as `undefined` and only fails at the *call site*, so an import-only check passes. The build was green, the tests were green, the tarball was correct — and the feature was unreachable.

## The fix for that, not just for this

The smoke test now **invokes** each one, and every assertion is one that wrong wiring fails:

| Signer | Assertion |
|---|---|
| `awsSigV4Sign` | derives `s3` from `examplebucket.s3.amazonaws.com` rather than signing as the bucket — the TR-428 rule |
| `hawkSign` | returns a `Hawk ` header |
| `oauth1Sign` | signs an IPv6 host with a form body; **refuses** `RSA-SHA1` rather than downgrading to HMAC-SHA1 (TR-409) |
| `oauth1SignatureMethods` | lists `HMAC-SHA1` |
| `digestSign` | parses a Digest challenge listed **after** Basic with a quoted `qop` list (TR-429); returns **`null`**, not a bogus header, when only Basic is offered |

Verified non-vacuous by mutation: un-exporting a single function fails the smoke test.

```
core-wasm smoke OK — catalog: 38 variables · oauth2 flows verified ·
5 signers verified · resolveTemplate verified (…) · corpus 16/16 cases
```

## Publishing

0.4.1 tarball is built and verified. `npm publish` is blocked in my environment:

```bash
cd packages/core-wasm && npm publish --access public
```

**0.4.0 should be deprecated** once 0.4.1 is up — it advertises exports it does not deliver:

```bash
npm deprecate @tropel/core-wasm@0.4.0 "signer exports missing from the JS facade — use 0.4.1"
```

## Unblocks

knockport KT-302, **this time actually**.