### PR TITLE
feat(variables): assert_evaluate — the 28 predicates in Rust [TR-438]

### DIFF
--- a/crates/tropel-variables/src/assertions.rs
+++ b/crates/tropel-variables/src/assertions.rs
@@ -106,6 +106,318 @@ pub fn assertion_operator(name: &str) -> Option<&'static AssertionOperator> {
     ASSERTION_OPERATORS.iter().find(|o| o.name == name)
 }
 
+// ── Evaluation ──────────────────────────────────────────────────────────────
+//
+// Values are `serde_json::Value` because that is the shape a response already
+// has on both paths — the load runtime's parsed body and the browser tier's
+// JSON bridge.
+//
+// # Two callers, one evaluator
+//
+// KnockPort collections will run as LOAD TESTS, so this is evaluated in two
+// very different places:
+//
+//   one Send      in wasm, once, latency irrelevant
+//   a load run    natively, per-VU, per-request, at high RPS
+//
+// That is why every predicate is synchronous, allocation-light on the common
+// paths, and CANNOT panic: a panic here aborts a VU mid-iteration, and a
+// silent `false` is a check that reports failure it did not observe. The
+// `unwrap`-free style below is deliberate, not defensive habit.
+//
+// # Why the regex matcher is INJECTED
+//
+// `matches` / `notMatches` need a regex, and linking one here would undo
+// TR-434 — `regex` was 152 KB of the eager wasm tier and removing it halved
+// the artifact. Linking Rust's `regex` would ALSO be unfaithful: KnockPort's
+// operator uses JS `RegExp`, which has backreferences and lookaround that
+// Rust's engine deliberately does not.
+//
+// So the capability is passed in, the same way `ExecWasmOptions.transport`
+// passes in network access the wasm cannot have. The browser tier supplies
+// the host's `RegExp` (bit-identical to today's behaviour); the load runtime
+// supplies whatever engine it already links. Neither pays for the other.
+
+use serde_json::Value;
+
+/// Supplies regex matching for `matches` / `notMatches`.
+///
+/// Absent, those two operators evaluate to `false` and
+/// [`AssertionOutcome::unsupported`] is set, so a caller that forgot to wire
+/// one gets a NAMED reason rather than a silently failing assertion.
+pub trait RegexMatcher {
+    /// True when `pattern` matches `haystack`. Must not panic; an invalid
+    /// pattern is `false`.
+    fn is_match(&self, pattern: &str, haystack: &str) -> bool;
+}
+
+impl<F: Fn(&str, &str) -> bool> RegexMatcher for F {
+    fn is_match(&self, pattern: &str, haystack: &str) -> bool {
+        self(pattern, haystack)
+    }
+}
+
+/// The result of evaluating one assertion.
+///
+/// Carries `name` so a LOAD RUN can aggregate outcomes the way k6 aggregates
+/// checks — pass/fail counts grouped by assertion, not one row per request.
+/// Without the name in the outcome the aggregator would have to correlate by
+/// index, which breaks the moment a conditional assertion is skipped.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssertionOutcome {
+    pub name: String,
+    pub passed: bool,
+    /// Set when the assertion could not be evaluated at all — an unknown
+    /// operator, or `matches` with no matcher wired. Distinct from
+    /// `passed: false`, which means the predicate ran and said no.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unsupported: Option<String>,
+}
+
+/// Numeric coercion: both sides must be numbers, or numeric strings.
+///
+/// Strings included because YAML scalars and response headers are text — a
+/// `content-length` header compared against `1024` must work.
+fn numeric_pair(a: &Value, b: &Value) -> Option<(f64, f64)> {
+    fn to_num(v: &Value) -> Option<f64> {
+        match v {
+            Value::Number(n) => n.as_f64().filter(|f| !f.is_nan()),
+            Value::String(s) if !s.trim().is_empty() => {
+                s.trim().parse::<f64>().ok().filter(|f| !f.is_nan())
+            }
+            _ => None,
+        }
+    }
+    Some((to_num(a)?, to_num(b)?))
+}
+
+/// Key-sorted JSON, so two structurally equal objects compare equal
+/// regardless of key order.
+fn stable_json(v: &Value) -> String {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let pairs: Vec<String> = keys
+                .iter()
+                .map(|k| format!("{}:{}", Value::String((*k).clone()), stable_json(&map[*k])))
+                .collect();
+            format!("{{{}}}", pairs.join(","))
+        }
+        Value::Array(items) => {
+            let parts: Vec<String> = items.iter().map(stable_json).collect();
+            format!("[{}]", parts.join(","))
+        }
+        other => other.to_string(),
+    }
+}
+
+fn try_parse_json(v: &Value) -> Option<Value> {
+    match v {
+        Value::String(s) => serde_json::from_str(s).ok(),
+        _ => None,
+    }
+}
+
+/// KnockPort's `looseEqual`, ported exactly.
+///
+/// The order of the arms is load-bearing: numeric coercion runs BEFORE the
+/// structural comparison, so `200 == "200"` is true while `true == "true"` is
+/// false (neither side is numeric, neither is an object).
+fn loose_equal(a: &Value, b: &Value) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_null() || b.is_null() {
+        return false;
+    }
+    if let Some((x, y)) = numeric_pair(a, b) {
+        return x == y;
+    }
+    if a.is_object() || a.is_array() || b.is_object() || b.is_array() {
+        let pa = try_parse_json(a);
+        let pb = try_parse_json(b);
+        return match (pa, pb) {
+            (Some(x), Some(y)) => stable_json(&x) == stable_json(&y),
+            (Some(x), None) => stable_json(&x) == stable_json(b),
+            (None, Some(y)) => stable_json(a) == stable_json(&y),
+            (None, None) => stable_json(a) == stable_json(b),
+        };
+    }
+    false
+}
+
+/// Length of a string, array or object — `None` for anything else.
+fn length_of(v: &Value) -> Option<usize> {
+    match v {
+        Value::String(s) => Some(s.chars().count()),
+        Value::Array(a) => Some(a.len()),
+        Value::Object(o) => Some(o.len()),
+        _ => None,
+    }
+}
+
+fn is_empty(v: &Value) -> bool {
+    match v {
+        Value::Null => true,
+        Value::String(s) => s.is_empty(),
+        Value::Array(a) => a.is_empty(),
+        Value::Object(o) => o.is_empty(),
+        _ => false,
+    }
+}
+
+/// Truthiness, JS-style: `0`, `""`, `null`, `false` are falsy. An empty array
+/// or object is TRUTHY in JS, which surprises people — pinned by a test.
+fn is_truthy(v: &Value) -> bool {
+    match v {
+        Value::Null => false,
+        Value::Bool(b) => *b,
+        Value::Number(n) => n.as_f64().is_some_and(|f| f != 0.0 && !f.is_nan()),
+        Value::String(s) => !s.is_empty(),
+        Value::Array(_) | Value::Object(_) => true,
+    }
+}
+
+/// `contains`: substring for strings, membership for arrays, key for objects.
+fn contains_value(haystack: &Value, needle: &Value) -> bool {
+    match haystack {
+        Value::String(s) => s.contains(&as_string(needle)),
+        Value::Array(items) => items.iter().any(|i| loose_equal(i, needle)),
+        Value::Object(map) => map.contains_key(&as_string(needle)),
+        _ => false,
+    }
+}
+
+/// String coercion matching JS `String(x ?? "")` for the shapes that reach
+/// here: a JSON string yields its contents, NOT a quoted literal.
+fn as_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// Evaluate one assertion.
+///
+/// Never panics, never allocates for the unary paths, and returns a named
+/// `unsupported` rather than a bare `false` when it cannot evaluate at all.
+pub fn assert_evaluate(
+    name: &str,
+    actual: &Value,
+    operator: &str,
+    expected: &Value,
+    matcher: Option<&dyn RegexMatcher>,
+) -> AssertionOutcome {
+    let Some(op) = assertion_operator(operator) else {
+        // Rejected BY NAME. Falling back to `eq` would make an assertion
+        // report a verdict on something the author never wrote.
+        return AssertionOutcome {
+            name: name.to_string(),
+            passed: false,
+            unsupported: Some(format!(
+                "unknown assertion operator '{operator}' — supported: {}",
+                ASSERTION_OPERATORS
+                    .iter()
+                    .map(|o| o.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )),
+        };
+    };
+
+    let mut unsupported = None;
+    let passed = match op.name {
+        "eq" => loose_equal(actual, expected),
+        "neq" => !loose_equal(actual, expected),
+        "gt" => numeric_pair(actual, expected).is_some_and(|(a, b)| a > b),
+        "gte" => numeric_pair(actual, expected).is_some_and(|(a, b)| a >= b),
+        "lt" => numeric_pair(actual, expected).is_some_and(|(a, b)| a < b),
+        "lte" => numeric_pair(actual, expected).is_some_and(|(a, b)| a <= b),
+        "in" => match expected {
+            Value::Array(items) => items.iter().any(|i| loose_equal(actual, i)),
+            _ => false,
+        },
+        "notIn" => match expected {
+            Value::Array(items) => !items.iter().any(|i| loose_equal(actual, i)),
+            _ => false,
+        },
+        "contains" => contains_value(actual, expected),
+        "notContains" => !contains_value(actual, expected),
+        "length" => match length_of(actual) {
+            Some(len) => numeric_pair(&Value::from(len), expected).is_some_and(|(a, b)| a == b),
+            None => false,
+        },
+        "matches" | "notMatches" => match matcher {
+            Some(m) => {
+                let hit = m.is_match(&as_string(expected), &as_string(actual));
+                if op.name == "matches" {
+                    hit
+                } else {
+                    !hit
+                }
+            }
+            None => {
+                unsupported = Some(format!(
+                    "'{}' needs a regex matcher and none was supplied — the host \
+                     engine is injected so this crate does not link one (TR-434); \
+                     pass one to assert_evaluate",
+                    op.name
+                ));
+                false
+            }
+        },
+        "startsWith" => as_string(actual).starts_with(&as_string(expected)),
+        "endsWith" => as_string(actual).ends_with(&as_string(expected)),
+        "between" => match expected {
+            Value::Array(range) if range.len() == 2 => {
+                match (
+                    numeric_pair(actual, &range[0]),
+                    numeric_pair(actual, &range[1]),
+                ) {
+                    (Some((a, lo)), Some((_, hi))) => {
+                        // The bounds may be given either way round.
+                        a >= lo.min(hi) && a <= lo.max(hi)
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        },
+        "isEmpty" => is_empty(actual),
+        "isNotEmpty" => !is_empty(actual),
+        "isNull" => actual.is_null(),
+        // JSON has no `undefined`; an absent target resolves to Null, so the
+        // two operators agree here. Both are kept because collections already
+        // contain both spellings.
+        "isUndefined" => actual.is_null(),
+        "isDefined" => !actual.is_null(),
+        "isTruthy" => is_truthy(actual),
+        "isFalsy" => !is_truthy(actual),
+        "isJson" => actual.is_object() || actual.is_array() || try_parse_json(actual).is_some(),
+        "isNumber" => numeric_pair(actual, actual).is_some(),
+        "isString" => actual.is_string(),
+        "isBoolean" => actual.is_boolean(),
+        "isArray" => actual.is_array(),
+        // Unreachable: `assertion_operator` only returns rows from the table
+        // above, and every row is handled. A `_ => false` would silently pass
+        // a newly-added operator as "failed" instead of failing to compile.
+        other => {
+            unsupported = Some(format!(
+                "operator '{other}' is in the table but not evaluated"
+            ));
+            false
+        }
+    };
+
+    AssertionOutcome {
+        name: name.to_string(),
+        passed,
+        unsupported,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,6 +552,210 @@ mod tests {
                 o.name,
                 o.summary
             );
+        }
+    }
+    use serde_json::json;
+
+    fn ev(actual: Value, op: &str, expected: Value) -> AssertionOutcome {
+        assert_evaluate("t", &actual, op, &expected, None)
+    }
+    fn ok(actual: Value, op: &str, expected: Value) -> bool {
+        let o = ev(actual, op, expected);
+        assert!(o.unsupported.is_none(), "{:?}", o.unsupported);
+        o.passed
+    }
+
+    #[test]
+    fn numeric_coercion_crosses_string_and_number_but_not_bool() {
+        // Response headers and YAML scalars are TEXT, so `content-length`
+        // against 1024 must work. Booleans must NOT coerce: `true == "true"`
+        // is false in KnockPort, and quietly making it true would flip
+        // assertions that currently fail.
+        assert!(ok(json!(200), "eq", json!("200")));
+        assert!(ok(json!("200"), "eq", json!(200)));
+        assert!(
+            ok(json!(" 200 "), "eq", json!(200)),
+            "headers carry padding"
+        );
+        assert!(!ok(json!(true), "eq", json!("true")));
+        assert!(ok(json!(true), "eq", json!(true)));
+        assert!(
+            !ok(json!("abc"), "gt", json!(1)),
+            "non-numeric never compares"
+        );
+        assert!(ok(json!("3"), "gt", json!("2")));
+    }
+
+    #[test]
+    fn object_equality_ignores_key_order_and_sees_through_json_strings() {
+        assert!(ok(json!({"a":1,"b":2}), "eq", json!({"b":2,"a":1})));
+        // A response body arrives as a STRING; the expected value is written
+        // as YAML structure. Comparing them must succeed.
+        assert!(ok(json!(r#"{"a":1}"#), "eq", json!({"a":1})));
+        assert!(ok(json!({"a":1}), "eq", json!(r#"{"a":1}"#)));
+        assert!(!ok(json!({"a":1}), "eq", json!({"a":2})));
+        assert!(ok(json!([1, 2]), "eq", json!([1, 2])));
+        assert!(
+            !ok(json!([1, 2]), "eq", json!([2, 1])),
+            "arrays are ordered"
+        );
+    }
+
+    #[test]
+    fn null_never_equals_anything_including_empty() {
+        // `null == ""` being true would make "field is absent" and "field is
+        // blank" indistinguishable, which is exactly the bug an assertion is
+        // meant to catch.
+        assert!(!ok(json!(null), "eq", json!("")));
+        assert!(!ok(json!(null), "eq", json!(0)));
+        assert!(!ok(json!(null), "eq", json!(false)));
+        assert!(ok(json!(null), "isNull", json!(null)));
+        assert!(ok(json!(null), "isEmpty", json!(null)));
+    }
+
+    #[test]
+    fn contains_means_substring_membership_or_key() {
+        assert!(ok(json!("hello world"), "contains", json!("lo wo")));
+        assert!(
+            ok(json!([1, 2, 3]), "contains", json!("2")),
+            "loose membership"
+        );
+        assert!(ok(json!({"a": 1}), "contains", json!("a")), "object = key");
+        assert!(!ok(json!({"a": 1}), "contains", json!(1)), "not by value");
+        assert!(
+            ok(json!(42), "notContains", json!("4")),
+            "numbers contain nothing"
+        );
+    }
+
+    #[test]
+    fn length_counts_chars_items_and_keys() {
+        assert!(ok(json!("abc"), "length", json!(3)));
+        assert!(ok(json!("héllo"), "length", json!(5)), "chars, not bytes");
+        assert!(ok(json!([1, 2]), "length", json!("2")));
+        assert!(ok(json!({"a":1,"b":2}), "length", json!(2)));
+        assert!(
+            !ok(json!(123), "length", json!(3)),
+            "a number has no length"
+        );
+    }
+
+    #[test]
+    fn between_accepts_bounds_in_either_order_and_is_inclusive() {
+        assert!(ok(json!(5), "between", json!([1, 10])));
+        assert!(ok(json!(5), "between", json!([10, 1])), "reversed bounds");
+        assert!(ok(json!(1), "between", json!([1, 10])), "inclusive low");
+        assert!(ok(json!(10), "between", json!([1, 10])), "inclusive high");
+        assert!(!ok(json!(11), "between", json!([1, 10])));
+        assert!(!ok(json!(5), "between", json!([1])), "needs exactly two");
+        assert!(!ok(json!(5), "between", json!(1)), "needs an array");
+    }
+
+    #[test]
+    fn truthiness_follows_js_including_the_surprising_cases() {
+        // An empty array/object is TRUTHY in JS. People expect otherwise, so
+        // pin it — silently "fixing" it would diverge from the TypeScript.
+        assert!(ok(json!([]), "isTruthy", json!(null)));
+        assert!(ok(json!({}), "isTruthy", json!(null)));
+        // …while isEmpty says the opposite about the same value. Both are
+        // correct; they answer different questions.
+        assert!(ok(json!([]), "isEmpty", json!(null)));
+        assert!(ok(json!(0), "isFalsy", json!(null)));
+        assert!(ok(json!(""), "isFalsy", json!(null)));
+        assert!(ok(json!(false), "isFalsy", json!(null)));
+    }
+
+    #[test]
+    fn type_predicates_do_not_coerce() {
+        assert!(ok(json!("5"), "isString", json!(null)));
+        // A numeric STRING is "a number" here, because numeric_pair coerces
+        // it — headers are text. isString is also true; they are not exclusive.
+        assert!(ok(json!("5"), "isNumber", json!(null)));
+        assert!(ok(json!(5), "isNumber", json!(null)));
+        assert!(!ok(json!(5), "isString", json!(null)));
+        assert!(ok(json!(true), "isBoolean", json!(null)));
+        assert!(ok(json!([1]), "isArray", json!(null)));
+        assert!(!ok(json!({"a":1}), "isArray", json!(null)));
+        assert!(ok(json!(r#"{"a":1}"#), "isJson", json!(null)));
+        assert!(!ok(json!("not json"), "isJson", json!(null)));
+    }
+
+    #[test]
+    fn matches_without_a_matcher_is_unsupported_not_a_silent_failure() {
+        // TR-434 removed `regex` from this crate; the host engine is injected.
+        // A caller that forgets must get a NAMED reason, because a bare
+        // `false` reads as "the assertion ran and the body did not match".
+        let o = ev(json!("abc"), "matches", json!("^a"));
+        assert!(!o.passed);
+        let why = o.unsupported.expect("a named reason");
+        assert!(why.contains("regex matcher"), "{why}");
+        assert!(why.contains("TR-434"), "{why}");
+    }
+
+    #[test]
+    fn matches_uses_the_injected_matcher_for_both_polarities() {
+        let m = |pattern: &str, hay: &str| pattern == "^a" && hay.starts_with('a');
+        let hit = assert_evaluate("t", &json!("abc"), "matches", &json!("^a"), Some(&m));
+        assert!(hit.passed && hit.unsupported.is_none());
+        let miss = assert_evaluate("t", &json!("xyz"), "matches", &json!("^a"), Some(&m));
+        assert!(!miss.passed && miss.unsupported.is_none());
+        let neg = assert_evaluate("t", &json!("xyz"), "notMatches", &json!("^a"), Some(&m));
+        assert!(neg.passed, "notMatches inverts the same matcher");
+    }
+
+    #[test]
+    fn an_unknown_operator_is_refused_by_name_and_lists_the_alternatives() {
+        let o = ev(json!(1), "equals", json!(1));
+        assert!(!o.passed);
+        let why = o.unsupported.expect("a named reason");
+        assert!(why.contains("unknown assertion operator 'equals'"), "{why}");
+        assert!(why.contains("eq"), "it lists what IS supported: {why}");
+    }
+
+    #[test]
+    fn the_outcome_carries_the_name_so_a_load_run_can_aggregate_it() {
+        // KnockPort collections will run as load tests, where outcomes are
+        // aggregated like k6 checks — pass/fail counts grouped by assertion
+        // name, not one row per request. Correlating by INDEX instead breaks
+        // the moment a conditional assertion is skipped.
+        let o = assert_evaluate("status is 200", &json!(200), "eq", &json!(200), None);
+        assert_eq!(o.name, "status is 200");
+        assert!(o.passed);
+        let json = serde_json::to_string(&o).expect("outcome serialises");
+        assert!(json.contains(r#""name":"status is 200""#), "{json}");
+        assert!(json.contains(r#""passed":true"#));
+        // `unsupported` is omitted when absent, so the common path stays small
+        // on the wire — this is emitted per assertion per request in a run.
+        assert!(!json.contains("unsupported"), "{json}");
+    }
+
+    #[test]
+    fn every_operator_in_the_table_evaluates_without_panicking() {
+        // The evaluator must never panic: a panic aborts a VU mid-iteration.
+        // Hostile-ish shapes against every operator, both arities.
+        let shapes = [
+            json!(null),
+            json!(0),
+            json!(-1.5),
+            json!(""),
+            json!("x"),
+            json!(true),
+            json!([]),
+            json!([1, "a"]),
+            json!({}),
+            json!({"k": null}),
+        ];
+        for op in ASSERTION_OPERATORS {
+            for a in &shapes {
+                for b in &shapes {
+                    let o = assert_evaluate("t", a, op.name, b, None);
+                    if op.name == "matches" || op.name == "notMatches" {
+                        assert!(o.unsupported.is_some());
+                    } else {
+                        assert!(o.unsupported.is_none(), "{} {:?}", op.name, o.unsupported);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Second slice of **KT-303**. The evaluator behind TR-437's vocabulary — a faithful port of KnockPort's `looseEqual`, `numericPair`, `stableJson`, `containsValue`, `lengthOf`, `isEmpty` and all 28 predicates.

## Designed for both callers, because collections will run as load tests

This is evaluated in two very different places:

| | |
|---|---|
| one Send | in wasm, once, latency irrelevant |
| a load run | natively, **per-VU, per-request, at high RPS** |

So every predicate is synchronous, allocation-light on the common paths, and **cannot panic** — a panic aborts a VU mid-iteration, and a silent `false` is a check reporting a failure it never observed. A test drives all 28 operators over 100 hostile shape pairs asserting no panic.

`AssertionOutcome` carries the assertion **name**, so a load run can aggregate outcomes the way k6 aggregates checks — pass/fail grouped by assertion, not one row per request. Correlating by *index* instead breaks the moment a conditional assertion is skipped. `unsupported` is `skip_serializing_if = None` so the common path stays small on the wire; this is emitted per assertion per request in a run.

## The regex matcher is injected, not linked

`matches`/`notMatches` need a regex. Linking one here would **undo TR-434** — `regex` was 152 KB of the eager wasm tier and removing it halved the artifact.

Linking Rust's `regex` would also be **unfaithful**: KnockPort's operator uses JS `RegExp`, which has backreferences and lookaround that Rust's engine deliberately does not.

So the capability is passed in, exactly as `ExecWasmOptions.transport` passes in network access the wasm cannot have. The browser tier supplies the host `RegExp` (bit-identical to today); the load runtime supplies whatever it already links. Neither pays for the other — and a caller that forgets gets a **named** `unsupported`, not a silent false.

## Semantics pinned

Each of these is easy to get subtly wrong, and a wrong one flips assertions that currently pass:

- numeric coercion crosses string/number (`"200" == 200` — headers are text) but **not** bool (`true != "true"`)
- object equality ignores key order, **and** sees through a JSON-string body compared against YAML structure
- `null` equals nothing, including `""` and `0` — otherwise "absent" and "blank" become indistinguishable, which is the bug an assertion exists to catch
- `between` is inclusive and accepts bounds either way round
- an empty array is **truthy** (JS) while `isEmpty` says empty — both correct, different questions
- `length` counts **chars**, not bytes
- an unknown operator is refused by name and lists the alternatives

## Remaining for KT-303

The target-resolution grammar (`status`, `body.json.path`, `headers.x`, `responseTime`) and the `core-wasm` export. Then KT-304 deletes the 875 TypeScript lines.

19 assertion tests, **71** in the crate, clippy clean.