### PR TITLE
fix(shims): `.not` on the response chain, and jsonSchema [TR-441]

### DIFF
--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -2590,4 +2590,127 @@ mod tests {
              ({phases_total}) on the failure path — that identity is the whole of TR-202"
         );
     }
+    /// TR-441 (F14 / KT-308, KT-309): `.not` on the response chain, and
+    /// `jsonSchema`. Both threw "unknown assertion property" before this.
+    #[tokio::test]
+    async fn postman_response_chain_negation_and_json_schema() {
+        let mut ctx = JsContext::new(None, None)
+            .await
+            .expect("js context should construct");
+        ctx.eval(include_str!("../../../js/shared/deep-equal.js"))
+            .await
+            .expect("deep-equal evals");
+        ctx.eval(concat!(
+            include_str!("../../../js/shared/k6-core.js"),
+            "\n",
+            include_str!("../../../js/scripting-api/pm.js")
+        ))
+        .await
+        .expect("pm shim evals");
+        // A minimal response the chain can read.
+        // The chain reads the response through bridge functions, so stub
+        // those rather than assigning to `pm.response.*` (which is a getter).
+        ctx.eval(
+            r#"
+            globalThis.__tropel_trp_response_code = function () { return 200; };
+            globalThis.__tropel_trp_response_json = function () {
+                return JSON.stringify({ id: 7, name: "x", tags: ["a"] });
+            };
+            "#,
+        )
+        .await
+        .expect("response stub evals");
+
+        // `probe(expr)` -> "PASS" when it does not throw, else the message.
+        let probe = |code: &str| {
+            format!(
+                r#"(function () {{ try {{ {code}; return "PASS"; }} catch (e) {{ return "THROW:" + (e && e.message); }} }})()"#
+            )
+        };
+
+        // ── KT-308 · negation ──
+        for (code, want_pass) in [
+            ("pm.response.to.not.have.status(500)", true),
+            ("pm.response.to.not.have.status(200)", false),
+            ("pm.response.to.not.be.notFound", true),
+            ("pm.response.to.not.be.ok", false),
+            // The positive forms must be untouched.
+            ("pm.response.to.have.status(200)", true),
+            ("pm.response.to.be.ok", true),
+        ] {
+            let got = ctx.eval(&probe(code)).await.expect("probe evals");
+            if want_pass {
+                assert_eq!(got, "PASS", "{code}");
+            } else {
+                assert!(got.starts_with("THROW:"), "{code} -> {got}");
+            }
+        }
+        // An unknown name under `.not` must still throw, not silently pass —
+        // the guard the whole chain depends on.
+        let got = ctx
+            .eval(&probe("pm.response.to.not.have.nonsense(1)"))
+            .await
+            .unwrap();
+        assert!(got.contains("unknown assertion property"), "{got}");
+
+        // ── KT-309 · jsonSchema ──
+        for (code, want_pass) in [
+            (r#"pm.response.to.have.jsonSchema({type:"object"})"#, true),
+            (
+                r#"pm.response.to.have.jsonSchema({type:"object",required:["id","name"]})"#,
+                true,
+            ),
+            (
+                r#"pm.response.to.have.jsonSchema({type:"object",required:["missing"]})"#,
+                false,
+            ),
+            (
+                r#"pm.response.to.have.jsonSchema({properties:{id:{type:"integer",minimum:10}}})"#,
+                false,
+            ),
+            (
+                r#"pm.response.to.have.jsonSchema({properties:{name:{type:"string",pattern:"^x$"}}})"#,
+                true,
+            ),
+            (r#"pm.response.to.have.jsonSchema({type:"array"})"#, false),
+        ] {
+            let got = ctx.eval(&probe(code)).await.expect("probe evals");
+            if want_pass {
+                assert_eq!(got, "PASS", "{code}");
+            } else {
+                assert!(got.starts_with("THROW:"), "{code} -> {got}");
+            }
+        }
+
+        // The CANONICAL binding must get both features too. pm.js is a
+        // factory parameterised by namespace, so `trp.*` is a peer view over
+        // the same state — but "should share" is not evidence, and an
+        // addition hung off the wrong object would give Postman users a
+        // feature Tropel-native users silently lack.
+        for (code, want_pass) in [
+            ("trp.response.to.not.have.status(500)", true),
+            ("trp.response.to.not.have.status(200)", false),
+            (r#"trp.response.to.have.jsonSchema({type:"object"})"#, true),
+            (r#"trp.response.to.have.jsonSchema({type:"array"})"#, false),
+        ] {
+            let got = ctx.eval(&probe(code)).await.expect("probe evals");
+            if want_pass {
+                assert_eq!(got, "PASS", "{code}");
+            } else {
+                assert!(got.starts_with("THROW:"), "{code} -> {got}");
+            }
+        }
+
+        // An UNSUPPORTED keyword is refused BY NAME, not ignored. Ignoring it
+        // would report PASS on data the author's schema rejects — a green
+        // assertion that checked less than it says.
+        let got = ctx
+            .eval(&probe(
+                r#"pm.response.to.have.jsonSchema({type:"object",allOf:[]})"#,
+            ))
+            .await
+            .unwrap();
+        assert!(got.contains("allOf"), "{got}");
+        assert!(got.contains("not supported"), "{got}");
+    }
 }

--- a/js/scripting-api/pm.js
+++ b/js/scripting-api/pm.js
@@ -370,12 +370,12 @@ function assertStatusCode(code, label) {
     }
 }
 
-pm.response.to = guardChain({
+var __pmResponseToRaw = {
     // Backlog line 41: be/have are nested objects, so wrap them in guardChain
     // explicitly — an unknown assertion name must throw, not silently pass.
     // (Master's guardChain deliberately does not recurse: the AssertChain hot
     // path hands back `this`, so recursion would add a proxy per nested read.)
-    be: guardChain({
+    be: {
         get success() { assertStatusClass(2, 'success'); },
         get ok() { assertStatusClass(2, 'ok'); },
         get redirection() { assertStatusClass(3, 'redirection'); },
@@ -438,8 +438,18 @@ pm.response.to = guardChain({
             }
             return function () {};
         }
-    }),
-    have: guardChain({
+    },
+    have: {
+        // TR-441 (KT-309): Postman's schema assertion. Unknown keywords are
+        // REFUSED, not ignored — see validateJsonSchema.
+        jsonSchema: function (schema) {
+            var body = pm.response.json();
+            var errors = [];
+            validateJsonSchema(body, schema, '$', errors);
+            if (errors.length > 0) {
+                throw new Error('response body does not match the JSON schema: ' + errors.join('; '));
+            }
+        },
         status: function (code) {
             // Backlog line 143: pm.response.code is a VALUE now.
             // TR-114: accept BOTH a numeric code AND a reason-phrase string.
@@ -512,8 +522,195 @@ pm.response.to = guardChain({
                 throw new Error('expected response JSON body to match');
             }
         }
-    })
+    }
+};
+
+// ── TR-441 · `.not` on the response chain (KT-308, F14) ─────────────────────
+//
+// `pm.response.to.not.have.status(500)` threw "unknown assertion property
+// 'not'". Plain-value negation already worked (`pm.expect(1).to.not.eql(2)`),
+// so this read as a PARTIAL implementation — and "assert it is not a 500" is
+// a common smoke test that surfaced as a SCRIPT ERROR rather than a red
+// assertion, which is worse than either passing or failing.
+//
+// Every assertion in the chain signals failure by THROWING, so negation is
+// mechanical: run the original, and throw only if it did NOT. Building it by
+// mirroring the raw literals means a new assertion added above is negatable
+// for free — a hand-written `not` table would silently omit it.
+function negateChainMember(name, run) {
+    return function () {
+        var threw = false;
+        try {
+            run.apply(this, arguments);
+        } catch (e) {
+            threw = true;
+        }
+        if (!threw) {
+            throw new Error('expected response NOT to satisfy ' + name + ', but it did');
+        }
+    };
+}
+
+function negateChainObject(source, prefix) {
+    var out = {};
+    var names = Object.getOwnPropertyNames(source);
+    for (var i = 0; i < names.length; i++) {
+        (function (key) {
+            var d = Object.getOwnPropertyDescriptor(source, key);
+            var label = prefix + '.' + key;
+            if (typeof d.get === 'function') {
+                // A property assertion (`.ok`, `.notFound`): negate the getter,
+                // keeping it a GETTER so `pm.response.to.not.be.ok` works
+                // without parentheses, exactly as the positive form does.
+                Object.defineProperty(out, key, {
+                    get: negateChainMember(label, d.get),
+                    enumerable: true
+                });
+            } else if (typeof d.value === 'function') {
+                out[key] = negateChainMember(label, d.value);
+            }
+        })(names[i]);
+    }
+    return guardChain(out);
+}
+
+// ── TR-441 · jsonSchema (KT-309, F14) ───────────────────────────────────────
+//
+// `pm.response.to.have.jsonSchema(schema)` threw "unknown assertion property",
+// so any imported collection using it errored out.
+//
+// A BOUNDED subset of JSON Schema, and unknown keywords are REFUSED BY NAME
+// rather than ignored. That choice is the whole point: ajv implements the full
+// spec, and a partial validator that silently skips what it does not
+// understand reports PASS on data the author's schema rejects — a green
+// assertion that checked less than it says. Refusing names the gap instead.
+var JSON_SCHEMA_SUPPORTED = [
+    'type', 'properties', 'required', 'items', 'enum', 'const',
+    'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum',
+    'minLength', 'maxLength', 'minItems', 'maxItems', 'pattern',
+    'additionalProperties', 'nullable', '$schema', 'title', 'description'
+];
+
+function jsonSchemaTypeOf(value) {
+    if (value === null) { return 'null'; }
+    if (Array.isArray(value)) { return 'array'; }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'integer' : 'number';
+    }
+    return typeof value;
+}
+
+function validateJsonSchema(value, schema, path, errors) {
+    if (schema === null || typeof schema !== 'object') {
+        errors.push(path + ': schema must be an object');
+        return;
+    }
+    var keys = Object.keys(schema);
+    for (var k = 0; k < keys.length; k++) {
+        if (JSON_SCHEMA_SUPPORTED.indexOf(keys[k]) === -1) {
+            errors.push(
+                path + ": schema keyword '" + keys[k] + "' is not supported by this " +
+                'validator (supported: ' + JSON_SCHEMA_SUPPORTED.join(', ') + ')'
+            );
+        }
+    }
+    var actual = jsonSchemaTypeOf(value);
+    if (schema.type !== undefined) {
+        var allowed = Array.isArray(schema.type) ? schema.type : [schema.type];
+        // `integer` satisfies `number`, per the spec.
+        var typeOk = allowed.some(function (t) {
+            return t === actual || (t === 'number' && actual === 'integer');
+        });
+        if (!typeOk && !(schema.nullable === true && value === null)) {
+            errors.push(path + ': expected type ' + allowed.join('|') + ', got ' + actual);
+            return;
+        }
+    }
+    if (schema.enum !== undefined && !schema.enum.some(function (e) { return deepEqual(e, value); })) {
+        errors.push(path + ': value is not in enum');
+    }
+    if (schema.const !== undefined && !deepEqual(schema.const, value)) {
+        errors.push(path + ': value does not equal const');
+    }
+    if (typeof value === 'number') {
+        if (schema.minimum !== undefined && value < schema.minimum) {
+            errors.push(path + ': ' + value + ' < minimum ' + schema.minimum);
+        }
+        if (schema.maximum !== undefined && value > schema.maximum) {
+            errors.push(path + ': ' + value + ' > maximum ' + schema.maximum);
+        }
+        if (schema.exclusiveMinimum !== undefined && value <= schema.exclusiveMinimum) {
+            errors.push(path + ': ' + value + ' <= exclusiveMinimum');
+        }
+        if (schema.exclusiveMaximum !== undefined && value >= schema.exclusiveMaximum) {
+            errors.push(path + ': ' + value + ' >= exclusiveMaximum');
+        }
+    }
+    if (typeof value === 'string') {
+        if (schema.minLength !== undefined && value.length < schema.minLength) {
+            errors.push(path + ': shorter than minLength ' + schema.minLength);
+        }
+        if (schema.maxLength !== undefined && value.length > schema.maxLength) {
+            errors.push(path + ': longer than maxLength ' + schema.maxLength);
+        }
+        if (schema.pattern !== undefined) {
+            var re;
+            try {
+                re = new RegExp(schema.pattern);
+            } catch (e) {
+                errors.push(path + ": pattern '" + schema.pattern + "' is not a valid regex");
+                re = null;
+            }
+            if (re && !re.test(value)) {
+                errors.push(path + ': does not match pattern ' + schema.pattern);
+            }
+        }
+    }
+    if (Array.isArray(value)) {
+        if (schema.minItems !== undefined && value.length < schema.minItems) {
+            errors.push(path + ': fewer than minItems ' + schema.minItems);
+        }
+        if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+            errors.push(path + ': more than maxItems ' + schema.maxItems);
+        }
+        if (schema.items !== undefined) {
+            for (var i = 0; i < value.length; i++) {
+                validateJsonSchema(value[i], schema.items, path + '[' + i + ']', errors);
+            }
+        }
+    }
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        if (Array.isArray(schema.required)) {
+            for (var r = 0; r < schema.required.length; r++) {
+                if (!Object.prototype.hasOwnProperty.call(value, schema.required[r])) {
+                    errors.push(path + ": missing required property '" + schema.required[r] + "'");
+                }
+            }
+        }
+        var props = schema.properties || {};
+        var names = Object.keys(value);
+        for (var n = 0; n < names.length; n++) {
+            var name = names[n];
+            if (Object.prototype.hasOwnProperty.call(props, name)) {
+                validateJsonSchema(value[name], props[name], path + '.' + name, errors);
+            } else if (schema.additionalProperties === false) {
+                errors.push(path + ": additional property '" + name + "' is not allowed");
+            }
+        }
+    }
+}
+
+__pmResponseToRaw.not = guardChain({
+    be: negateChainObject(__pmResponseToRaw.be, 'be'),
+    have: negateChainObject(__pmResponseToRaw.have, 'have')
 });
+
+// Wrap the raw literals only AFTER `not` has mirrored them: guardChain returns
+// a Proxy that throws on unknown reads, and Object.getOwnPropertyNames on a
+// Proxy would trip that trap.
+__pmResponseToRaw.be = guardChain(__pmResponseToRaw.be);
+__pmResponseToRaw.have = guardChain(__pmResponseToRaw.have);
+pm.response.to = guardChain(__pmResponseToRaw);
 
 // ── pm.test ──
 // Backlog line 84: an async body (fn returning a Promise) used to record


### PR DESCRIPTION
## What

The two Postman assertion gaps found by running `chai-postman`'s real surface against ours (**F14**). Both threw `unknown assertion property`, so an imported collection using either **errored out** — a *script error* rather than a red assertion, which is worse than passing or failing.

## KT-308 · `.not` on the response chain

`pm.response.to.not.have.status(500)`. Plain-value negation already worked (`pm.expect(1).to.not.eql(2)`), so this read as a **partial** implementation — and "assert it is not a 500" is a common smoke test.

Built by **mirroring** the raw `be`/`have` literals rather than hand-writing a `not` table. Every assertion signals failure by throwing, so negation is mechanical: run the original, throw only if it did *not*. Mirroring means an assertion added later is negatable for free; a hand-written table would silently omit it.

Order is load-bearing — `not` is built from the **raw** objects *before* they are wrapped in `guardChain`, because `getOwnPropertyNames` on a Proxy would trip the unknown-property trap. The guard still holds through the negated view: `to.not.have.nonsense(1)` throws rather than silently passing.

## KT-309 · jsonSchema

A bounded subset: `type`, `properties`, `required`, `items`, `enum`, `const`, `minimum`/`maximum` (+ exclusive), `minLength`/`maxLength`, `minItems`/`maxItems`, `pattern`, `additionalProperties`, `nullable`.

**Unknown keywords are refused by name, not ignored.** That is the whole point — Postman uses ajv, which implements the full spec, and a partial validator that silently skips what it doesn't understand reports **PASS on data the author's schema rejects**: a green assertion that checked less than it claims. `{type:"object", allOf:[]}` now errors naming `allOf`.

## Both reach every namespace

`pm.js` is a factory — `__tropel_build_binding(namespace)` — so `pm`, `postman` and the canonical `trp` are peer views over one implementation.

The test asserts this against `trp` **explicitly** rather than assuming it: an addition hung off the wrong object would give Postman users a feature Tropel-native users silently lack.

`bru.*` is deliberately untouched. Bruno's surface is `bru.assert(expr, msg)` plus plain chai on `res`, with no `.to` response chain — and plain chai negation already works there.

## Verified by running, not grepping

Grepping `chai-shim.js` for these names reported **12 of 14 missing** — and was wrong; they live in `pm.js`. 17 probes in a real QuickJS realm across both namespaces, covering positive forms (unchanged), negated forms both ways, the unknown-name guard, six schema shapes, and the unsupported-keyword refusal.

`tropel-runtime` 63, `tropel-engine` 10, clippy clean.

## Reaching knockport

These live in tropel's `js/scripting-api/pm.js`, which knockport consumes as the **`@tropel/shims`** npm package — so this needs a shims release before it lands there.