### PR TITLE
feat(variables): failure messages on assertion outcomes — 0.5.2 [TR-443]

### DIFF
--- a/crates/tropel-core-wasm/src/lib.rs
+++ b/crates/tropel-core-wasm/src/lib.rs
@@ -510,6 +510,8 @@ fn assert_evaluate_batch_inner(
                     name,
                     passed: false,
                     unsupported: Some(why),
+                    // An unresolvable target has no comparison to describe.
+                    message: None,
                 },
             }
         })

--- a/crates/tropel-variables/src/assertions.rs
+++ b/crates/tropel-variables/src/assertions.rs
@@ -172,6 +172,30 @@ pub struct AssertionOutcome {
     /// `passed: false`, which means the predicate ran and said no.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unsupported: Option<String>,
+    /// Why it failed, worded for a human. Present only on a FAILING row — a
+    /// passing assertion needs no explanation, and this is emitted per
+    /// assertion per request in a load run.
+    ///
+    /// TR-443: built HERE, not by the caller. The caller does not have the
+    /// resolved `actual` value — only this function does — and the app and a
+    /// load report must word the same failure the same way. Two formatters
+    /// would drift.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// A short, safe rendering of a value for a failure message.
+///
+/// Long strings are truncated: a failed assertion against a 2 MB body must not
+/// put 2 MB into every result row of a load run.
+fn preview(value: &Value) -> String {
+    match value {
+        Value::String(s) if s.chars().count() > 120 => {
+            let head: String = s.chars().take(117).collect();
+            Value::String(format!("{head}...")).to_string()
+        }
+        other => other.to_string(),
+    }
 }
 
 /// Numeric coercion: both sides must be numbers, or numeric strings.
@@ -316,6 +340,7 @@ pub fn assert_evaluate(
         return AssertionOutcome {
             name: name.to_string(),
             passed: false,
+            message: None,
             unsupported: Some(format!(
                 "unknown assertion operator '{operator}' — supported: {}",
                 ASSERTION_OPERATORS
@@ -411,10 +436,30 @@ pub fn assert_evaluate(
         }
     };
 
+    // The wording matches what KnockPort's TypeScript evaluator produced, so
+    // migrating does not silently reword every existing failure.
+    let message = if passed || unsupported.is_some() {
+        None
+    } else if op.arity == AssertionArity::Unary {
+        Some(format!(
+            "expected target {name} {}; actual {}",
+            op.summary,
+            preview(actual)
+        ))
+    } else {
+        Some(format!(
+            "expected target {name} {} {}; actual {}",
+            op.summary,
+            preview(expected),
+            preview(actual)
+        ))
+    };
+
     AssertionOutcome {
         name: name.to_string(),
         passed,
         unsupported,
+        message,
     }
 }
 
@@ -1266,5 +1311,48 @@ mod tests {
                  editor WITHOUT the wasm, so this file is a real interface, not a cache."
             );
         }
+    }
+    #[test]
+    fn a_failing_assertion_carries_a_human_message_and_a_passing_one_does_not() {
+        // TR-443: the TypeScript evaluator produced this wording, and the
+        // panel renders it. Keeping it byte-compatible means migrating does
+        // not silently reword every existing failure.
+        let fail = assert_evaluate("status", &json!(200), "eq", &json!(500), None);
+        assert!(!fail.passed);
+        assert_eq!(
+            fail.message.as_deref(),
+            Some("expected target status equals 500; actual 200")
+        );
+
+        // A unary operator has no expected value to name.
+        let unary = assert_evaluate("body", &json!("x"), "isEmpty", &json!(null), None);
+        assert!(!unary.passed);
+        assert_eq!(
+            unary.message.as_deref(),
+            Some("expected target body is empty; actual \"x\"")
+        );
+
+        // A PASSING row carries none — it is emitted per assertion per
+        // request in a load run, and "why did it pass" is not a question.
+        let pass = assert_evaluate("status", &json!(200), "eq", &json!(200), None);
+        assert!(pass.passed && pass.message.is_none());
+        let json = serde_json::to_string(&pass).expect("serialises");
+        assert!(!json.contains("message"), "{json}");
+
+        // `unsupported` and `message` do not both appear: an assertion that
+        // could not run has no comparison to describe.
+        let unknown = assert_evaluate("x", &json!(1), "nope", &json!(1), None);
+        assert!(unknown.unsupported.is_some() && unknown.message.is_none());
+    }
+
+    #[test]
+    fn a_failure_message_truncates_a_huge_actual_value() {
+        // A failed assertion against a 2 MB body must not put 2 MB into every
+        // result row of a load run.
+        let big = json!("y".repeat(5000));
+        let out = assert_evaluate("body", &big, "eq", &json!("x"), None);
+        let msg = out.message.expect("a failing row has a message");
+        assert!(msg.len() < 300, "message was {} bytes", msg.len());
+        assert!(msg.contains("..."), "{msg}");
     }
 }

--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core-wasm/smoke.mjs
+++ b/packages/core-wasm/smoke.mjs
@@ -420,6 +420,16 @@ const [bad] = assertEvaluate(assertResponse, [
   { target: 'header("X-Nope")', operator: "eq", expected: "x" },
 ]);
 if (bad.passed || !bad.unsupported) throw new Error(`unresolvable target: ${JSON.stringify(bad)}`);
+// TR-443: a FAILING row explains itself; a passing one carries no message.
+const [failing] = assertEvaluate(assertResponse, [
+  { name: "status", target: "status", operator: "eq", expected: 500 },
+]);
+if (failing.passed || failing.message !== "expected target status equals 500; actual 200") {
+  throw new Error(`failure message: ${JSON.stringify(failing)}`);
+}
+if (outcomes.some((o) => o.message !== undefined)) {
+  throw new Error("a passing assertion must carry no message");
+}
 // The host RegExp is injected; without it `matches` says so by name.
 const [noMatcher] = assertEvaluate(assertResponse, [
   { target: "body", operator: "matches", expected: "^\\{" },

--- a/packages/core-wasm/src/index.d.ts
+++ b/packages/core-wasm/src/index.d.ts
@@ -335,6 +335,10 @@ export interface AssertionOutcome {
    *  unresolvable target, or `matches` with no matcher. Distinct from
    *  `passed: false`, which means the predicate ran and said no. */
   unsupported?: string;
+  /** Why it failed, worded for a human — present only on a FAILING row.
+   *  Built in Rust so the app and a load report word the same failure the
+   *  same way. */
+  message?: string;
 }
 
 export interface AssertionResponse {

--- a/packages/core-wasm/src/index.js
+++ b/packages/core-wasm/src/index.js
@@ -418,8 +418,9 @@ export function oauth1SignatureMethods() {
  *   rather than linked because a Rust regex would put back the 152 KB TR-434
  *   removed from this tier, AND would be unfaithful — JS RegExp has
  *   backreferences and lookaround that Rust's engine deliberately lacks.
- * @returns {Array<{name:string, passed:boolean, unsupported?:string}>} one
- *   outcome per assertion, in order. `unsupported` means it could not be
+ * @returns {Array<{name:string, passed:boolean, message?:string, unsupported?:string}>}
+ *   one outcome per assertion, in order. `message` explains a FAILING row and
+ *   is absent on a passing one. `unsupported` means it could not be
  *   evaluated at all (unknown operator, unresolvable target, missing matcher)
  *   — distinct from `passed:false`, which means the predicate ran and said no.
  */


### PR DESCRIPTION
## What

A failing assertion returned `passed: false` and nothing else, so KnockPort lost the explanation its TypeScript evaluator gave — `expected target status equals 500; actual 200` became a bare red row.

Found as a **KT-304 test failure**, not a design review. That's the point of porting against the existing suite.

## Built in Rust, not by the caller

Two reasons:

- the caller **does not have the resolved `actual` value** — only the evaluator does, and re-resolving the target in TypeScript to word a message would re-create the second implementation KT-303 removed
- collections run as **load tests**, so the app and a load report must word the same failure identically; two formatters drift

The wording is byte-compatible with the TypeScript it replaces, so migrating does not silently reword every existing failure.

## Only on failing rows

`message` is `skip_serializing_if = None`. A passing assertion needs no explanation, and this is emitted **per assertion per request** in a run.

`unsupported` and `message` never both appear — an assertion that could not run has no comparison to describe.

`preview` truncates at 120 chars: a failed assertion against a 2 MB body must not put 2 MB into every result row of a load run.

## Tests

- exact wording, binary (`expected target status equals 500; actual 200`) and unary (`expected target body is empty; actual "x"`)
- absence on a passing row — asserted on the **serialised JSON**, not just the struct, since that's what crosses the wire
- mutual exclusion with `unsupported`
- truncation of a 5,000-char actual

83 `tropel-variables` + 28 `core-wasm` tests, workspace clippy clean, smoke green.

## Publishing

```bash
cd packages/core-wasm && npm publish --access public
```