### PR TITLE
fix: unbreak master — three red gates, none of them cosmetic [TR-450 · TR-451 · TR-453]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,9 @@
 # Vendored JS shims are text
 js/**/*.js text eol=lf
 js/**/*.mjs text eol=lf
+
+# Generated fixtures that a test compares against, byte for byte. `text=auto`
+# above would hand a Windows checkout CRLF while the generator emits LF, which
+# fails the comparison on Windows ONLY and then rewrites the file.
+packages/core-wasm/fixtures/assertion-operators.json text eol=lf
+packages/core-wasm/src/assertion-operators.js text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "tropel"
-version = "0.3.0"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-engine"
-version = "0.3.0"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-web"
-version = "0.3.0"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "postcard",

--- a/crates/tropel-core-wasm/src/lib.rs
+++ b/crates/tropel-core-wasm/src/lib.rs
@@ -131,6 +131,29 @@ fn resolve_template_inner(
     tropel_variables::resolve_template_for_host(input, &env, mode, deep)
 }
 
+/// `resolveTemplate`, plus WHY resolution stopped — the cycle-vs-unknown-name
+/// distinction KnockPort turns into "failed send" vs "the user's typo".
+///
+/// TR-451: this wrapper was deleted by TR-445, which split the body into
+/// `_inner` so the Rust tests could call it and then dropped the exported
+/// half. Nothing caught it: every Rust test calls `_inner` DIRECTLY, so they
+/// all passed against a function JavaScript could no longer reach. The only
+/// caller that crosses the real boundary is `smoke.mjs`, and the `wasm slice`
+/// job aborts on the lockstep check before it runs. The published 0.5.3 was
+/// cut before the removal and is unaffected; the next publish would not have
+/// been. `packages/core-wasm/src/index.js` has been calling
+/// `glue.resolveTemplateDetailed` the whole time — an undefined method, on
+/// the send path of every template containing a `{{var}}`.
+#[wasm_bindgen(js_name = "resolveTemplateDetailed")]
+pub fn resolve_template_detailed(
+    input: &str,
+    vars_json: &str,
+    mode: &str,
+) -> Result<String, wasm_bindgen::JsValue> {
+    resolve_template_detailed_inner(input, vars_json, mode)
+        .map_err(|msg| wasm_bindgen::JsValue::from_str(&msg))
+}
+
 fn resolve_template_detailed_inner(
     input: &str,
     vars_json: &str,
@@ -918,5 +941,127 @@ mod tests {
             .unwrap()
             .iter()
             .any(|r| r["arity"] == "unary"));
+    }
+    /// Every wasm method the JS facade calls MUST be an exported `js_name`
+    /// somewhere in this crate.
+    ///
+    /// TR-451: this exists because TR-445 deleted the `resolveTemplateDetailed`
+    /// export while `packages/core-wasm/src/index.js` went on calling it, and
+    /// NOTHING failed. The Rust tests all call the private `_inner` helpers
+    /// directly, so they kept passing against a function JavaScript could no
+    /// longer reach; `smoke.mjs` is the only caller that crosses the real
+    /// boundary, and the `wasm slice` job aborts on the lockstep check before
+    /// it runs. The gap showed up only as a `dead_code` warning, on a branch
+    /// whose CI was already red.
+    ///
+    /// A static cross-check is deliberate: it needs no wasm build, so it runs
+    /// in the same `cargo test` that would otherwise give false confidence.
+    #[test]
+    fn every_glue_call_in_the_js_facade_has_a_wasm_export() {
+        /// The identifier at the head of `s`, empty if it does not start with one.
+        fn ident_at(s: &str) -> &str {
+            let end = s
+                .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .unwrap_or(s.len());
+            &s[..end]
+        }
+
+        let facade = include_str!("../../../packages/core-wasm/src/index.js");
+
+        // The facade reaches the wasm through NAMED HANDLES: the module-level
+        // `glue`, and any local alias bound from `requireGlue(...)` (today
+        // `const g = requireGlue("generatePkcePair")`). Discovering aliases
+        // rather than hard-coding them means a new one is covered on sight
+        // instead of silently escaping the guard.
+        let mut handles: Vec<&str> = vec!["glue"];
+        for (idx, _) in facade.match_indices("= requireGlue(") {
+            let before = facade[..idx].trim_end();
+            let name_end = before.len();
+            let name_start = before
+                .rfind(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .map_or(0, |i| i + 1);
+            let name = &before[name_start..name_end];
+            if !name.is_empty() && !handles.contains(&name) {
+                handles.push(name);
+            }
+        }
+
+        let mut called: Vec<&str> = Vec::new();
+        for handle in &handles {
+            let needle = format!("{handle}.");
+            for (idx, _) in facade.match_indices(&needle) {
+                // A word boundary, or `config.` matches the handle `g`.
+                if idx > 0
+                    && facade[..idx]
+                        .chars()
+                        .next_back()
+                        .is_some_and(|c| c.is_alphanumeric() || c == '_')
+                {
+                    continue;
+                }
+                let after = &facade[idx + needle.len()..];
+                let name = ident_at(after);
+                if !name.is_empty()
+                    && after[name.len()..].starts_with('(')
+                    && !called.contains(&name)
+                {
+                    called.push(name);
+                }
+            }
+        }
+
+        // And the inline `requireGlue("x").method(` form. Bounded to the
+        // call's own closing paren: an unbounded search runs past a plain
+        // `const g = requireGlue(...)` and picks up whatever `.method(`
+        // appears next in the file.
+        for (idx, _) in facade.match_indices("requireGlue(") {
+            let after = &facade[idx + "requireGlue(".len()..];
+            let Some(close) = after.find(')') else {
+                continue;
+            };
+            let tail = after[close + 1..].trim_start();
+            let Some(rest) = tail.strip_prefix('.') else {
+                continue;
+            };
+            let name = ident_at(rest);
+            if !name.is_empty() && !called.contains(&name) {
+                called.push(name);
+            }
+        }
+
+        // A scanner that stopped matching the facade's shape would pass by
+        // finding nothing — the failure mode a guard like this dies of.
+        assert!(
+            called.len() > 10,
+            "the scanner found only {} glue calls ({called:?}) via handles {handles:?} — it has stopped matching the facade's shape, which makes this guard vacuous",
+            called.len()
+        );
+
+        // Exports live in lib.rs AND signers.rs.
+        let mut exported: Vec<&str> = Vec::new();
+        for src in [include_str!("lib.rs"), include_str!("signers.rs")] {
+            for (idx, _) in src.match_indices("js_name = \"") {
+                let rest = &src[idx + "js_name = \"".len()..];
+                if let Some(end) = rest.find('"') {
+                    exported.push(&rest[..end]);
+                }
+            }
+        }
+
+        // `default` is wasm-bindgen's GENERATED init function on the module
+        // namespace — not a `#[wasm_bindgen]` item, so it has no `js_name` by
+        // construction. `initCoreWasm` is the only caller.
+        const GENERATED_BY_WASM_BINDGEN: &[&str] = &["default"];
+
+        let missing: Vec<&str> = called
+            .iter()
+            .copied()
+            .filter(|n| !exported.contains(n) && !GENERATED_BY_WASM_BINDGEN.contains(n))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "the JS facade calls {missing:?}, which no #[wasm_bindgen(js_name = ...)] exports — \
+             each one is a TypeError at runtime, on the send path of every template that has a variable"
+        );
     }
 }

--- a/crates/tropel-engine/Cargo.toml
+++ b/crates/tropel-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-engine"
-version = "0.3.0"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-variables/src/assertions.rs
+++ b/crates/tropel-variables/src/assertions.rs
@@ -1339,8 +1339,19 @@ mod tests {
              // Do not hand-edit — the test rewrites it and fails when it is stale.\n\
              export default {want};"
         );
-        let got_js = std::fs::read_to_string(js_path).unwrap_or_default();
-        let got = std::fs::read_to_string(path).unwrap_or_default();
+        // Read NORMALISED. `.gitattributes` carries `* text=auto`, so a
+        // Windows checkout materialises these generated files as CRLF while
+        // the generator above emits LF. A raw byte compare therefore called a
+        // content-identical fixture STALE on Windows only — and then rewrote
+        // it, so the job failed AND left a dirty tree. The comparison is about
+        // the vocabulary, not about the checkout's line-ending policy.
+        let normalise = |p: &str| {
+            std::fs::read_to_string(p)
+                .unwrap_or_default()
+                .replace("\r\n", "\n")
+        };
+        let got_js = normalise(js_path);
+        let got = normalise(path);
         if got != want || got_js != want_js {
             std::fs::write(path, &want).expect("fixture is writable");
             std::fs::write(js_path, &want_js).expect("js fixture is writable");

--- a/crates/tropel-web/Cargo.toml
+++ b/crates/tropel-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-web"
-version = "0.3.0"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel/Cargo.toml
+++ b/crates/tropel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel"
-version = "0.3.0"
+version = "0.5.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/input-wasm/package.json
+++ b/packages/input-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/input-wasm",
-  "version": "0.3.0",
+  "version": "0.5.3",
   "description": "Tropel collection-import slice for browser embedders (KnockPort). Lazy sibling of @tropel/core-wasm: OpenAPI 3.x, Postman v2.x, and HAR parsers compiled to wasm32-unknown-unknown. See API_CLIENT_WEB_PAYLOAD.md \u00a72.3 for the two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-wasm/package.json
+++ b/packages/runtime-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/runtime-wasm",
-  "version": "0.3.0",
+  "version": "0.5.3",
   "description": "Browser/Node host for the tropel load-testing runtime compiled to wasm32-wasip1: postcard C ABI driver, WASI preview1 wiring, and the HTTP bridge that answers each request the runtime makes.",
   "license": "Apache-2.0",
   "type": "module",
@@ -45,7 +45,7 @@
     "tropel"
   ],
   "dependencies": {
-    "@tropel/shims": "^0.3.0"
+    "@tropel/shims": "^0.5.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/shims",
-  "version": "0.3.0",
+  "version": "0.5.3",
   "description": "The tropel JS shim bundle \u2014 pm/bru scripting API, chai, lodash, CryptoJS, exec, and the k6 family. The same sources the tropel runtime embeds (ShimBundle::default()), published for embedders.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Master's CI has been red for ten merges, on **two independent gates**. Neither can go green alone — `wasm slice` fails on lockstep, `clippy -D warnings` fails on the dead code the missing export left behind — so they ship together. Two commits, one per cause.

---

## 1 · `chore(release)`: the seven version surfaces converge at 0.5.3 — TR-450

`scripts/version-lockstep.sh` has been failing since **TR-435**:

```
FAIL: versions are out of lockstep — bump them together
  binary (tropel)           = 0.3.0
  wasm runtime (tropel-web) = 0.3.0
  engine (tropel-engine)    = 0.3.0
  @tropel/core-wasm         = 0.5.3   <-- alone up here
  @tropel/input-wasm        = 0.3.0
  @tropel/runtime-wasm      = 0.3.0
  @tropel/shims             = 0.3.0
```

Publishing `@tropel/core-wasm` to unblock KnockPort bumped **one** surface five times (0.4.0 → 0.5.3) and left the other six behind — exactly the drift the gate exists to catch. The version handshake compares the agent's version against the wasm's, and `packages/runtime-wasm/smoke.mjs` pins the wasm's compiled-in `runtimeVersion` against its package version.

The six lagging surfaces **catch up** rather than everything moving forward: 0.5.3 is what actually shipped to npm, npm versions are immutable, and `PLAN.md` reserves **0.6.0** for the Phase 5 rename.

`@tropel/runtime-wasm` pinned `"@tropel/shims": "^0.3.0"` — a `^` on `0.x` means `<0.4.0`, so it would have stopped matching the package it ships beside. `tropel-sdk` deliberately stays at 0.3.0 (separately published, WARNING-only in the gate, and 0.3.0 is live on crates.io).

## 2 · `fix(core-wasm)`: restore the `resolveTemplateDetailed` export — TR-451

**This one is a real bug, not a lint.** TR-445 split `resolve_template_detailed` into an `_inner` helper so the Rust tests could call it — and deleted the exported half. `packages/core-wasm/src/index.js` has been calling `glue.resolveTemplateDetailed(...)` ever since: an **undefined method**, on the send path of *every template containing a `{{var}}`* (KnockPort's `resolveVariables` routes all of them through it).

### Why nothing caught it

- every Rust test calls `_inner` **directly**, so they all passed against a function JavaScript could no longer reach
- `smoke.mjs` is the only caller that crosses the real boundary — and the `wasm slice` job aborts on gate #1 before it runs
- what remained was a `dead_code` warning, on a branch whose CI was already red

### Blast radius

The published **`@tropel/core-wasm@0.5.3` was cut before the removal and is unaffected** — verified against the actual npm tarball, not just the commit order. The next publish would not have been.

### The systemic half

A new test scans the JS facade for every wasm method it calls — via the module-level `glue`, via any local alias bound from `requireGlue(...)`, and via the inline `requireGlue("x").x(...)` form — and asserts each is an exported `js_name` somewhere in the crate. It:

- **fails on the pre-fix code**, naming `resolveTemplateDetailed`
- refuses to pass **vacuously**: if the scanner stops matching the facade's shape, the count assertion fires instead of silently finding nothing
- allows `default` explicitly — wasm-bindgen *generates* the module init function, so it has no `js_name` by construction

---

## Verification

```
$ bash scripts/version-lockstep.sh
ok: all seven version surfaces agree at 0.5.3

$ cargo test -p tropel-core-wasm --lib
test result: ok. 29 passed; 0 failed

$ cargo check --workspace --all-targets
Finished `dev` profile
```