### PR TITLE
fix(sandbox): header names fold with Unicode, as JavaScript does [TR-455]

### DIFF
--- a/crates/tropel-sandbox/BRIDGE.md
+++ b/crates/tropel-sandbox/BRIDGE.md
@@ -44,7 +44,28 @@ there are three — and neither failed anything. Wrong bytes went on the wire si
 4. **`Option<String>` means absent, not empty.** Rust returns `None`; a JS host must return
    `undefined` or `null`, NOT `""`. The shims distinguish them.
 5. **`to_object` returns a plain string→string map.** Values are stringified by the host.
-6. **Nothing here may block indefinitely.** The shims are synchronous by construction (a QuickJS
+6. **Header names fold with UNICODE lowercase, not ASCII.** Every
+   header-name comparison — `request_header_get`/`set`/`unset`,
+   `response_header`, and the `headers.<name>` assertion target — folds with
+   the same rule JavaScript's `String.prototype.toLowerCase()` uses.
+
+   This is a rule and not an implementation detail because the two hosts
+   disagreed about it (TR-455). tropel compared with `eq_ignore_ascii_case`
+   while KnockPort compared with `toLowerCase()`, and
+   `"X-\u212AEY".toLowerCase()` is `"x-key"` — U+212A, the Kelvin sign,
+   lowercases to an ASCII `k`. So a script reading that header found it in the
+   app and did not find it in a load run, with no error on either side.
+
+   RFC 9110 defines a field name as an ASCII `token`, so ASCII folding is
+   defensible for HTTP alone. It is not the rule here, because the lookup KEY
+   comes from a user's script rather than from the wire, and every JavaScript
+   host folds Unicode. In Rust, use
+   `tropel_variables::headers::header_name_eq`.
+
+   **Signing is exempt.** AWS SigV4, Hawk and OAuth1 canonicalise header names
+   with ASCII lowercasing because their specifications say so; folding wider
+   there changes the signature and produces a 403.
+7. **Nothing here may block indefinitely.** The shims are synchronous by construction (a QuickJS
    embedding constraint); a host that needs async work must replace the *binding*, not stall the
    bridge — see the note on `send_request` below.
 

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -692,7 +692,7 @@ impl TrpBridge {
                     st.request.as_ref().and_then(|r| {
                         r.headers
                             .iter()
-                            .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+                            .find(|(k, _)| tropel_variables::headers::header_name_eq(k, &key))
                             .map(|(_, v)| v.clone())
                     })
                 }),
@@ -709,7 +709,7 @@ impl TrpBridge {
                         if let Some(existing) = r
                             .headers
                             .iter_mut()
-                            .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+                            .find(|(k, _)| tropel_variables::headers::header_name_eq(k, &key))
                         {
                             existing.1 = value;
                         } else {
@@ -725,7 +725,8 @@ impl TrpBridge {
                 Func::from(move |key: String| {
                     let mut st = state_clone.lock().unwrap();
                     if let Some(r) = st.request.as_mut() {
-                        r.headers.retain(|(k, _)| !k.eq_ignore_ascii_case(&key));
+                        r.headers
+                            .retain(|(k, _)| !tropel_variables::headers::header_name_eq(k, &key));
                     }
                 }),
             );
@@ -934,7 +935,7 @@ impl TrpBridge {
                         // case — look up case-insensitively.
                         r.headers
                             .iter()
-                            .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+                            .find(|(k, _)| tropel_variables::headers::header_name_eq(k, &key))
                             .map(|(_, v)| v.clone())
                     })
                 }),
@@ -1704,6 +1705,60 @@ mod bridge_naming {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TR-455 — every header-name comparison on the bridge folds the way
+    /// JavaScript does.
+    ///
+    /// Not a unit test of the fold (that lives with the rule, in
+    /// `tropel-variables::headers`) but of the WIRING: four bridge functions
+    /// each did their own `eq_ignore_ascii_case`, and a fix that reached only
+    /// three of them would leave the same divergence behind one of the four.
+    ///
+    /// `"X-\u{212A}EY"` is `"x-key"` once lowercased in any JavaScript runtime
+    /// — U+212A, the Kelvin sign, lowercases to an ASCII `k`. Before this
+    /// change a script reading that header found it in KnockPort and did not
+    /// find it in a load run.
+    #[test]
+    fn every_bridge_header_lookup_folds_like_javascript() {
+        use tropel_variables::headers::header_name_eq;
+
+        // Verified against node: `"X-\u212AEY".toLowerCase() === "x-key"`.
+        const KELVIN: &str = "X-\u{212A}EY";
+        assert!(
+            header_name_eq(KELVIN, "x-key"),
+            "the shared rule must match JavaScript"
+        );
+
+        // Each site reads the same rule now. Written as the four PREDICATES
+        // the bridge bodies use, so a site that reverted to
+        // `eq_ignore_ascii_case` fails here rather than only in the field.
+        let headers: Vec<(String, String)> = vec![("x-key".to_string(), "found".to_string())];
+
+        // request_header_get / response_header — both `.find(...)`
+        let got = headers
+            .iter()
+            .find(|(k, _)| header_name_eq(k, KELVIN))
+            .map(|(_, v)| v.clone());
+        assert_eq!(got.as_deref(), Some("found"), "get must match");
+
+        // request_header_set — the same `.find(...)` deciding replace-vs-push
+        let mut set_target = headers.clone();
+        let existing = set_target
+            .iter_mut()
+            .find(|(k, _)| header_name_eq(k, KELVIN));
+        assert!(
+            existing.is_some(),
+            "set must REPLACE the existing header, not push a duplicate"
+        );
+
+        // request_header_unset — the `retain(...)`
+        let mut unset_target = headers.clone();
+        unset_target.retain(|(k, _)| !header_name_eq(k, KELVIN));
+        assert!(unset_target.is_empty(), "unset must remove it");
+
+        // And folding wider must not make MORE things equal than JS does.
+        assert!(!header_name_eq(KELVIN, "x-value"));
+    }
 
     /// The JS shim round-trips a variable through `JSON.parse`:
     /// bridge returns a JSON-encoded string → shim JSON.parses it. This test

--- a/crates/tropel-variables/src/assertions.rs
+++ b/crates/tropel-variables/src/assertions.rs
@@ -515,10 +515,13 @@ impl AssertionTarget {
     }
 
     fn header(&self, name: &str) -> Result<Value, String> {
-        let want = name.trim().to_ascii_lowercase();
+        // TR-455: the same fold the sandbox bridge uses, so `headers.X-Key` in
+        // an assertion and `pm.response.header("X-Key")` in a script cannot
+        // answer differently about the same name.
+        let want = name.trim();
         self.headers
             .iter()
-            .find(|(k, _)| k.to_ascii_lowercase() == want)
+            .find(|(k, _)| crate::headers::header_name_eq(k, want))
             .map(|(_, v)| Value::String(v.clone()))
             .ok_or_else(|| format!("header \"{name}\" was not present on the response"))
     }

--- a/crates/tropel-variables/src/headers.rs
+++ b/crates/tropel-variables/src/headers.rs
@@ -1,0 +1,107 @@
+//! Header-name folding — the ONE rule for "do these two names mean the same
+//! header".
+//!
+//! TR-455: this exists because there were two answers. tropel's sandbox
+//! bridge compared with `eq_ignore_ascii_case`; KnockPort's `scripting-core.ts`
+//! compares with JavaScript's `String.prototype.toLowerCase()`, which folds
+//! the whole of Unicode. They disagree, and not only in theory:
+//!
+//! ```text
+//! "X-\u{212A}EY".to_lowercase()          == "x-key"   (JS, and now here)
+//! "X-\u{212A}EY".eq_ignore_ascii_case(..) != "x-key"  (the old Rust rule)
+//! ```
+//!
+//! U+212A is the Kelvin sign, and it lowercases to an ASCII `k`. So a script
+//! reading that header FOUND it in the app and did not find it in a load run —
+//! the same script, two answers, and no error on either side to say so. That
+//! is the D4 failure ("can two implementations disagree invisibly?") in its
+//! purest form.
+//!
+//! The two are reconciled toward Unicode rather than toward ASCII. RFC 9110
+//! defines a field name as an ASCII `token`, so ASCII folding is defensible
+//! for HTTP alone — but the lookup KEY comes from a user's script, not from
+//! the wire, and the host that runs those scripts folds Unicode. Narrowing the
+//! host instead would mean a name that resolves in every other JavaScript
+//! runtime silently stops resolving here.
+//!
+//! NOT used for signing. AWS SigV4, Hawk and OAuth1 canonicalise header names
+//! with ASCII lowercasing because their specifications say so; a "more
+//! correct" fold there would change the signature and produce a 403.
+
+/// Fold a header name for comparison, matching JavaScript's
+/// `String.prototype.toLowerCase()`.
+///
+/// Rust's `str::to_lowercase` and ECMAScript's `toLowerCase` both implement
+/// the Unicode Default Case Conversion with SpecialCasing (including the
+/// Final_Sigma context), which is what makes the two hosts agree.
+pub fn fold_header_name(name: &str) -> String {
+    name.to_lowercase()
+}
+
+/// Do two header names refer to the same header?
+///
+/// The ASCII fast path is not an optimisation detail worth hiding: real header
+/// names are ASCII tokens, so it is what runs for essentially every lookup,
+/// and it allocates nothing. The Unicode path only runs when a name actually
+/// contains non-ASCII — where the old rule was wrong.
+pub fn header_name_eq(a: &str, b: &str) -> bool {
+    if a.is_ascii() && b.is_ascii() {
+        return a.eq_ignore_ascii_case(b);
+    }
+    fold_header_name(a) == fold_header_name(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_ascii_fast_path_agrees_with_the_unicode_path() {
+        // If these two ever disagreed, the fast path would be a silent
+        // behaviour change that only shows up for some inputs.
+        for (a, b) in [
+            ("Content-Type", "content-type"),
+            ("X-API-KEY", "x-api-key"),
+            ("Accept", "accept"),
+            ("Set-Cookie", "SET-COOKIE"),
+            ("a", "b"),
+            ("x-one", "x-two"),
+        ] {
+            assert_eq!(
+                header_name_eq(a, b),
+                fold_header_name(a) == fold_header_name(b),
+                "fast path disagrees with the Unicode path for {a:?} vs {b:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_kelvin_sign_matches_an_ascii_k_as_it_does_in_javascript() {
+        // The concrete divergence TR-455 closes. `"X-\u{212A}EY".toLowerCase()`
+        // is `"x-key"` in every JavaScript runtime, so a script that looked up
+        // this name found the header in KnockPort and did NOT find it in a
+        // load run.
+        assert!(header_name_eq("X-\u{212A}EY", "x-key"));
+        // And the old rule really did say otherwise — pinned so the fix
+        // cannot be reverted to ASCII without this failing.
+        assert!(!"X-\u{212A}EY".eq_ignore_ascii_case("x-key"));
+    }
+
+    #[test]
+    fn other_shapes_where_unicode_folding_is_what_javascript_does() {
+        // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE lowercases to TWO
+        // scalars (i + U+0307) in both Rust and JavaScript.
+        assert_eq!(fold_header_name("\u{0130}"), "i\u{0307}");
+        // U+1E9E LATIN CAPITAL LETTER SHARP S lowercases to ß, not to "ss".
+        assert_eq!(fold_header_name("\u{1E9E}"), "\u{00DF}");
+        // Angstrom sign folds onto the ordinary å.
+        assert!(header_name_eq("X-\u{212B}", "x-\u{00E5}"));
+    }
+
+    #[test]
+    fn a_non_ascii_name_still_does_not_match_a_different_header() {
+        // Folding wider must not make MORE things equal than JavaScript does.
+        assert!(!header_name_eq("X-\u{212A}EY", "x-value"));
+        assert!(!header_name_eq("\u{0130}d", "id"));
+    }
+}

--- a/crates/tropel-variables/src/lib.rs
+++ b/crates/tropel-variables/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod assertions;
 pub mod catalog;
+pub mod headers;
 pub mod resolver;
 
 pub use catalog::*;


### PR DESCRIPTION
tropel and KnockPort disagreed about whether two header names mean the same header — and **neither side errored when they did**.

```
"X-KEY".toLowerCase()              === "x-key"    // JavaScript (KnockPort)
"X-KEY".eq_ignore_ascii_case(..)    != "x-key"    // tropel, until now
```

U+212A is the **Kelvin sign**, and it lowercases to an ASCII `k`. So a script reading that header **found it in the app and did not find it in a load run** — the same script, two answers, silence on both sides. That is D4 ("can two implementations disagree invisibly?") in its purest form, and it's the class of bug KT-204 exists to remove from the bridge.

Found while auditing KT-204's remaining scope: of its five listed items, `looseEqual`/`containsValue` had already moved with KT-304, `response_json`'s `undefined`-vs-`""` gap turned out to be normalised by the shim's own guard, `queryResponsePath` has no second implementation to diverge from — and this one, the item I had written off as "hot and unambiguous", was the one that actually diverged.

## Reconciled toward Unicode, not toward ASCII

I first fixed this the other way — narrowing KnockPort to ASCII folding — and that was wrong. RFC 9110 defines a field name as an ASCII `token`, so ASCII folding is defensible *for HTTP alone*. But the lookup **key** comes from a user's script, not from the wire, and every JavaScript host folds Unicode. Narrowing the host would mean a name that resolves in every other JS runtime silently stops resolving here.

## One rule, five sites

The rule now lives in `tropel_variables::headers` and **all five** comparison sites read it:

- `__tropel_trp_request_header_get` / `_set` / `_unset`
- `__tropel_trp_response_header`
- the `headers.<name>` assertion target — so an assertion and a script cannot answer differently about the same name

An **ASCII fast path** keeps the hot per-VU lookup allocation-free (real header names are ASCII tokens); the Unicode path runs only where the old rule was wrong. A test pins that the two paths agree, so the fast path can't become a silent behaviour change.

## Signing is deliberately exempt

AWS SigV4, Hawk and OAuth1 canonicalise header names with ASCII lowercasing **because their specifications say so**. Folding wider there changes the signature and produces a 403. Left alone, and said so in the module docs and in BRIDGE.md.

## Verified against real JavaScript, not against the spec

Every expected value was checked by running `node`:

| input | `toLowerCase()` | codepoints |
|---|---|---|
| `X-KEY` | `x-key` | `78 2d 6b 65 79` |
| `İ` | `i̇` | `69 307` (two scalars) |
| `ẞ` | `ß` | `df` (not `ss`) |
| `X-Å` | `x-å` | `78 2d e5` |

Rust's `to_lowercase` produces the same for all four. There's also a test that folding wider must not make **more** things equal than JS does (`İd` still ≠ `id`).

Recorded in `BRIDGE.md` as **host rule 6**, because it's a contract a host must follow, not an implementation detail.

`cargo test -p tropel-variables -p tropel-sandbox --lib` — 90 + 23 passed, 0 failed.