### PR TITLE
ci: run core-wasm's smoke — the real wasm boundary was never exercised [KT-205 / TR-456]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,6 +680,28 @@ jobs:
           git diff --exit-code -- packages/core-wasm/README.md || { echo "FAIL: packages/core-wasm/README.md Size line is stale — run 'bash packages/core-wasm/scripts/build.sh' locally and commit the generated Size line (TR-404: generated, not typed)" >&2; exit 1; }
           echo "ok: core-wasm 700 KB gate + README generation check passed"
 
+      # KT-205: run @tropel/core-wasm's OWN smoke — the only thing in CI that
+      # calls the eager tier through the REAL wasm boundary.
+      #
+      # It was never wired. The job above builds `pkg/` for the size gate and
+      # stopped there, so nothing executed a single wasm export; the other two
+      # `node smoke.mjs` steps in this job belong to @tropel/shims and
+      # @tropel/runtime-wasm, which are different packages. That gap is how
+      # TR-445 deleted the `resolveTemplateDetailed` export and shipped: every
+      # Rust test called the private `_inner` helper directly, and the one
+      # caller that crossed the boundary never ran.
+      #
+      # It is also the SECOND leg of the resolution corpus (KT-202) — the one
+      # that stands in for KnockPort's browser tier. The native leg runs in
+      # `cargo test` and the agent leg runs in `cargo test -p tropel-engine`;
+      # with this, all three are merge gates.
+      #
+      # No extra toolchain: `pkg/` already exists from the step above.
+      - name: KT-205 core-wasm smoke (the real wasm boundary + corpus leg)
+        run: |
+          cd packages/core-wasm
+          node smoke.mjs
+
       # TR-407: the SDK inversion (contract at the bottom of the graph) rots
       # if adapters start depending on tropel-core, or if the SDK needs a full
       # checkout to use. Guard 1 asserts no in-tree adapter pulls tropel-core;

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -1702,6 +1702,142 @@ mod tests {
         );
     }
 
+    /// KT-202 — the THIRD differential leg: the same corpus, over the socket.
+    ///
+    /// `packages/core-wasm/fixtures/resolve-corpus.json` already runs through
+    /// two paths: native Rust (`tropel-core-wasm`'s `conformance_corpus`) and
+    /// the real wasm (`packages/core-wasm/smoke.mjs`). Those are the two tiers
+    /// a BROWSER host can be served by. The agent is the third, and since
+    /// KP-209 it is the one KnockPort's DESKTOP tier actually runs on — so an
+    /// agent that resolved `{{base-url}}` differently would put literal text
+    /// on the wire for desktop users only, which is the single divergence
+    /// this corpus was written to catch in the first place.
+    ///
+    /// It reads the SAME bytes rather than restating the cases. A copied
+    /// corpus drifts exactly the way the two resolvers did.
+    ///
+    /// This deviates from KT-202's literal wording ("run the corpus through
+    /// the TypeScript host"): driving KnockPort's TypeScript from a Rust test
+    /// would need Node and a second checkout inside tropel's CI. The agent leg
+    /// covers what that was for — the desktop tier's rules — with no
+    /// cross-repo dependency, and the browser tier is already covered by
+    /// smoke.mjs, which IS the TypeScript leg.
+    #[tokio::test]
+    async fn the_resolution_corpus_agrees_over_the_socket() {
+        const CORPUS: &str =
+            include_str!("../../../packages/core-wasm/fixtures/resolve-corpus.json");
+
+        /// Mirrors `tropel-core-wasm`'s `generated_vars` — same kind, same
+        /// construction from the SAME constant, so the two legs cannot drift
+        /// into testing different chains.
+        fn generated_vars(kind: &str) -> serde_json::Value {
+            match kind {
+                "chain_longer_than_cap" => {
+                    let cap = tropel_variables::MAX_VARIABLE_RESOLUTION_PASSES;
+                    let mut m = serde_json::Map::new();
+                    for i in 0..=cap {
+                        m.insert(
+                            format!("v{i}"),
+                            serde_json::json!(format!("{{{{v{}}}}}", i + 1)),
+                        );
+                    }
+                    m.insert(format!("v{}", cap + 1), serde_json::json!("end"));
+                    serde_json::Value::Object(m)
+                }
+                other => panic!("unknown vars_generated kind: {other}"),
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let state = Arc::new(AgentState {
+            token: None,
+            client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
+                .expect("http client"),
+        });
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                let st = state.clone();
+                tokio::spawn(async move {
+                    let _ = handle_connection(&mut sock, st).await;
+                });
+            }
+        });
+
+        let doc: serde_json::Value = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
+        let cases = doc["cases"].as_array().expect("cases array");
+        assert!(!cases.is_empty(), "an empty corpus asserts nothing");
+
+        for case in cases {
+            let name = case["name"].as_str().expect("every case is named");
+            let template = case["template"].as_str().expect("template");
+            let mode = case["mode"].as_str().expect("mode");
+            let vars = match case.get("vars_generated") {
+                Some(kind) => generated_vars(kind.as_str().unwrap()),
+                None => case["vars"].clone(),
+            };
+
+            // Through /resolve/batch, because that is the endpoint the desktop
+            // tier actually calls — a leg that exercised a different route
+            // would not be testing the path users get.
+            let body = serde_json::json!({
+                "variables": vars,
+                "items": [{"template": template, "mode": mode}],
+            })
+            .to_string();
+            let mut s = TcpStream::connect(("127.0.0.1", port))
+                .await
+                .expect("connect");
+            let req = format!(
+                "POST /resolve/batch HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            s.write_all(req.as_bytes()).await.expect("write");
+            let mut out = Vec::new();
+            s.read_to_end(&mut out).await.expect("read");
+            let raw = String::from_utf8_lossy(&out).to_string();
+            let reply = raw.split("\r\n\r\n").nth(1).unwrap_or_default().to_string();
+            let parsed: serde_json::Value =
+                serde_json::from_str(&reply).unwrap_or_else(|e| panic!("{name}: {e} — {reply}"));
+            let item = &parsed["items"][0];
+            assert!(
+                item["error"].is_null(),
+                "{name}: the agent refused a corpus case: {item}"
+            );
+            let value = item["value"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{name}: no value"));
+
+            // The same assertions the native leg makes, in the same order.
+            if let Some(expected) = case.get("expect").and_then(|v| v.as_str()) {
+                assert_eq!(value, expected, "{name}");
+            }
+            if case.get("parses_as_json").and_then(|v| v.as_bool()) == Some(true) {
+                serde_json::from_str::<serde_json::Value>(value).unwrap_or_else(|e| {
+                    panic!("{name}: result must stay parseable JSON: {e} — {value}")
+                });
+            }
+            if let Some(expected) = case.get("expect_hit_cap").and_then(|v| v.as_bool()) {
+                assert_eq!(item["hitCap"], expected, "{name}: hitCap");
+            }
+            if let Some(expected) = case.get("expect_unresolved") {
+                assert_eq!(&item["unresolved"], expected, "{name}: unresolved");
+            }
+            if let Some(required) = case
+                .get("expect_unresolved_contains")
+                .and_then(|v| v.as_array())
+            {
+                let got = item["unresolved"].as_array().unwrap();
+                for n in required {
+                    assert!(
+                        got.contains(n),
+                        "{name}: unresolved must contain {n} — got {got:?}"
+                    );
+                }
+            }
+        }
+    }
+
     /// TR-445: `/auth/sign`, over the socket.
     ///
     /// This is the endpoint that lets knockport's DESKTOP tier stop throwing

--- a/crates/tropel-web/tests/native_vs_wasm_divergences.md
+++ b/crates/tropel-web/tests/native_vs_wasm_divergences.md
@@ -34,3 +34,29 @@ If a future divergence appears, add it here with the reason it is unavoidable
 timestamp) AND mark the corresponding corpus item `#[ignore]` with a link to
 this file. A divergence that is NOT listed here is a bug in the one-engine
 claim and must be fixed, not waived.
+
+## The resolution corpus, and its third leg (KT-202)
+
+`packages/core-wasm/fixtures/resolve-corpus.json` is a separate, narrower
+differential: the 16 cases that motivated moving the `{{var}}` resolver into
+Rust in the first place. It now runs through **three** paths, all reading the
+same bytes rather than restating the cases:
+
+| leg | where | serves |
+|---|---|---|
+| native Rust | `tropel-core-wasm`'s `conformance_corpus` | the engine |
+| real wasm | `packages/core-wasm/smoke.mjs` | KnockPort's **browser** tier |
+| the agent, over a socket | `tropel-engine`'s `the_resolution_corpus_agrees_over_the_socket` | KnockPort's **desktop** tier (KP-209) |
+
+The third leg exists because since KP-209 the desktop tier resolves through
+the agent, so an agent that handled `{{base-url}}` differently would put
+literal text on the wire **for desktop users only** — the exact divergence
+this corpus was written to catch, in the one tier it was not yet checked in.
+
+It deviates from KT-202's literal wording ("run the corpus through the
+TypeScript host"). Driving KnockPort's TypeScript from a Rust test would need
+Node and a second checkout inside tropel's CI; the agent leg covers what that
+was for with no cross-repo dependency, and `smoke.mjs` already **is** the
+TypeScript leg for the browser tier.
+
+Current state: **no divergences.** All 16 cases agree across all three.


### PR DESCRIPTION
`packages/core-wasm/smoke.mjs` **has never run in CI.**

The `wasm` job builds `pkg/` for the 700 KB size gate and stops there, so nothing executed a single wasm export. The two `node smoke.mjs` steps already in that job belong to `@tropel/shims` and `@tropel/runtime-wasm` — different packages.

## This is how TR-445 shipped a deleted export

Every Rust test calls the private `_inner` helper **directly**, so they all passed against a function JavaScript could no longer reach — and the one caller that crosses the real boundary wasn't wired to anything.

**Correction to what I said in #545:** I wrote that the wasm job "aborts on the lockstep check before it runs [smoke.mjs]". That was wrong — it wouldn't have run either way, because it was never a step. The static export guard added in that PR is what actually closes the hole; this PR closes the one behind it.

## KT-205's second leg

The resolution corpus (KT-202) now runs in three places, and with this all three are **merge gates**:

| leg | command | job | stands in for |
|---|---|---|---|
| native Rust | `cargo test -p tropel-core-wasm` | `test` | the engine |
| **the real wasm** | `packages/core-wasm/smoke.mjs` | `wasm` | **KnockPort's browser tier** ← this PR |
| the agent | `cargo test -p tropel-engine` | `test` | KnockPort's desktop tier |

## Cost

None. `pkg/` already exists from the size-gate step directly above, and `wasm` is already in `ci-ok`'s `needs`.

## Verification

Run against a **fresh build from current source**, not the stale `pkg/` that was sitting on disk (which predated the TR-445 removal and would have passed misleadingly):

```
$ bash packages/core-wasm/scripts/build.sh
$ grep -c resolveTemplateDetailed packages/core-wasm/pkg/tropel_core_wasm.js
3
$ node smoke.mjs
core-wasm smoke OK — catalog: 38 variables · oauth2 flows verified · 5 signers verified ·
assertions verified (28 ops) · resolveTemplate verified (grammar, 3 escape modes, chains,
pass cap 20) · corpus 16/16 cases
```

The README `Size` line did not change, so the gate's generated output is unaffected.