### PR TITLE
fix(http): a public-suffix Domain cannot scope a cookie across sites [TR-457]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
  "tracing",
  "tropel-auth",
  "tropel-sdk",
+ "tropel-variables",
 ]
 
 [[package]]

--- a/crates/tropel-http/Cargo.toml
+++ b/crates/tropel-http/Cargo.toml
@@ -14,6 +14,9 @@ description = "HTTP protocol implementation for Tropel: reqwest client, connecti
 [dependencies]
 tropel-sdk.workspace = true
 tropel-auth = { workspace = true, features = ["reqwest"] }
+# TR-457: the cookie-scope rule (public-suffix Domain rejection). A leaf crate
+# with no tropel dependencies and no regex since TR-434, so this is cheap.
+tropel-variables.workspace = true
 serde.workspace = true
 reqwest.workspace = true
 h2.workspace = true

--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -1122,6 +1122,19 @@ impl HttpClient {
             if let Some(jar) = jar {
                 for v in response.headers().get_all(reqwest::header::SET_COOKIE) {
                     if let Ok(s) = v.to_str() {
+                        // TR-457: reject a `Domain` that is a public suffix.
+                        // reqwest's jar does not (`publicsuffix` is in the
+                        // graph via cookie_store but `Jar::default()` never
+                        // consults it), so `Domain=com` from one host was
+                        // stored and replayed to every other `.com` host in
+                        // the jar. Filtered HERE because this is the only
+                        // place Set-Cookie enters the jar on the request path.
+                        if !tropel_variables::cookies::set_cookie_is_acceptable(
+                            s,
+                            hop_url.host_str().unwrap_or_default(),
+                        ) {
+                            continue;
+                        }
                         jar.add_cookie_str(s, &hop_url);
                     }
                 }

--- a/crates/tropel-http/src/vu_jar.rs
+++ b/crates/tropel-http/src/vu_jar.rs
@@ -153,7 +153,26 @@ pub fn set_cookie(
     opts: &K6CookieOptions,
 ) -> Result<()> {
     let parsed = parse_url(url)?;
-    jar.add_cookie_str(&build_set_cookie(name, value, opts)?, &parsed);
+    let line = build_set_cookie(name, value, opts)?;
+    // TR-457: the same public-suffix rule the response path applies. A script
+    // calling `jar.set(url, name, value, {domain: "com"})` must not be able to
+    // put a cookie in the jar that a Set-Cookie header could not — the two
+    // doors into the jar have to agree, or the rule is only half a rule.
+    //
+    // A REFUSAL, not a silent drop: the script asked for something specific
+    // and getting no error back would read as "stored" (invariant #8).
+    if !tropel_variables::cookies::set_cookie_is_acceptable(
+        &line,
+        parsed.host_str().unwrap_or_default(),
+    ) {
+        return Err(TropelError::Other(format!(
+            "cookie {name:?} was refused: Domain is a public suffix, so the cookie would be \
+             scoped across every site under it (RFC 6265 5.3 step 5). Drop the domain option to \
+             scope it to {:?}.",
+            parsed.host_str().unwrap_or_default()
+        )));
+    }
+    jar.add_cookie_str(&line, &parsed);
     Ok(())
 }
 
@@ -485,6 +504,77 @@ mod tests {
                 .is_empty(),
             "a past Expires must evict the cookie, not store a dead one"
         );
+    }
+
+    /// TR-457 — a public-suffix `Domain` must not put a cookie in the jar.
+    ///
+    /// Through the REAL jar, because that is where the bug was: the rule's own
+    /// unit tests live in `tropel-variables::cookies`, and they would have
+    /// passed just as happily while nothing called them. Before this change
+    /// the probe below printed `Some("sid=leaked")` for bank.com.
+    #[test]
+    fn a_public_suffix_domain_cannot_scope_a_cookie_across_sites() {
+        let jar = Jar::default();
+        // The k6 `jar.set()` door: REFUSED by name, not silently dropped —
+        // the script asked for something specific and silence reads as
+        // "stored".
+        let err = set_cookie(
+            &jar,
+            "https://evil.com/",
+            "sid",
+            "leaked",
+            &K6CookieOptions {
+                domain: Some("com".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("public suffix") && msg.contains("sid"),
+            "the refusal must name the reason AND the cookie: {msg}"
+        );
+        assert!(
+            cookies_for_url(&jar, "https://bank.com/account")
+                .unwrap()
+                .is_empty(),
+            "nothing may have reached the jar"
+        );
+
+        // The control: an ordinary parent domain still works through the same
+        // door. A fix that broke this would be worse than the bug.
+        set_cookie(
+            &jar,
+            "https://api.example.com/",
+            "ok",
+            "1",
+            &K6CookieOptions {
+                domain: Some("example.com".into()),
+                ..Default::default()
+            },
+        )
+        .expect("parent-domain scoping must keep working");
+        assert_eq!(
+            cookies_for_url(&jar, "https://www.example.com/")
+                .unwrap()
+                .get("ok")
+                .map(|v| v.as_slice()),
+            Some(&["1".to_string()][..]),
+        );
+
+        // And `Domain=localhost` on localhost survives, or every local dev
+        // server stops keeping its session.
+        set_cookie(
+            &jar,
+            "http://localhost:3000/",
+            "dev",
+            "1",
+            &K6CookieOptions {
+                domain: Some("localhost".into()),
+                ..Default::default()
+            },
+        )
+        .expect("Domain=localhost on localhost is identical-to-host, not a rejection");
     }
 
     #[test]

--- a/crates/tropel-variables/src/cookies.rs
+++ b/crates/tropel-variables/src/cookies.rs
@@ -1,0 +1,129 @@
+//! Cookie-scope rules — the ones that decide whether a `Set-Cookie` is stored
+//! at all.
+//!
+//! TR-457: this exists because the jar accepted `Domain=com`. A server on
+//! `evil.com` sending that had the cookie stored with domain `com` and
+//! replayed to `bank.com` — verified through the real jar, not theorised:
+//!
+//! ```text
+//! Domain=com         -> bank.com          : Some("sid=leaked")
+//! Domain=example.com -> www.example.com   : Some("ok=1")    (the control)
+//! ```
+//!
+//! `publicsuffix` IS in the dependency graph, via `cookie_store` — but
+//! reqwest's `Jar::default()` does not enforce it, so nothing rejected the
+//! cookie. Every browser does (RFC 6265 §5.3 step 5).
+//!
+//! The rule lives in this crate rather than in `tropel-http` for two reasons:
+//! it is a RULE and this crate is where rules live, and it is wasm-safe, so
+//! `core-wasm` can export it whenever KnockPort should read it here instead of
+//! keeping its own copy. KnockPort implements the same single-label test today
+//! (KP-213) — a duplication worth naming: a one-line predicate is low-risk to
+//! duplicate, and exporting it would cost a publish cycle for one boolean, so
+//! this is a deliberate trade rather than an oversight.
+
+/// Is this domain a public suffix — a registry under which anyone can
+/// register a name?
+///
+/// A SINGLE-LABEL test, not the full Public Suffix List, and the gap is worth
+/// stating rather than burying: it rejects `com`, `net`, `org` and
+/// `localhost`, and it does NOT reject `co.uk` or `github.io`. Embedding the
+/// PSL means ~250 KB of data that needs updating forever after, in a crate the
+/// wasm tier links. The single-label case is the one reachable from any `.com`
+/// server, which is the one that matters.
+pub fn is_likely_public_suffix(domain: &str) -> bool {
+    !domain.trim_start_matches('.').contains('.')
+}
+
+/// Should this `Set-Cookie` line be stored at all, given the host it came from?
+///
+/// RFC 6265 §5.3 step 5: a `Domain` attribute that is a public suffix is
+/// REJECTED unless it is identical to the request host — in which case the
+/// cookie becomes host-only, which is what keeps `Domain=localhost` working on
+/// `localhost`.
+///
+/// Rejected, never "downgraded to host-only": storing it host-only would keep
+/// a cookie the sender asked to scope differently, and it would still go back
+/// to the sender on every request.
+pub fn set_cookie_is_acceptable(set_cookie: &str, request_host: &str) -> bool {
+    let Some(domain) = domain_attribute(set_cookie) else {
+        // No Domain attribute at all: host-only, always fine.
+        return true;
+    };
+    let domain = domain.trim().trim_start_matches('.').to_lowercase();
+    if domain.is_empty() {
+        return true;
+    }
+    if !is_likely_public_suffix(&domain) {
+        return true;
+    }
+    domain == request_host.trim().to_lowercase()
+}
+
+/// The `Domain=` attribute value, if the line carries one.
+///
+/// Attribute names are case-insensitive per RFC 6265 §5.2, and splitting on
+/// `;` is enough here because a Domain value cannot contain one.
+fn domain_attribute(set_cookie: &str) -> Option<&str> {
+    set_cookie.split(';').skip(1).find_map(|part| {
+        let (name, value) = part.split_once('=')?;
+        name.trim().eq_ignore_ascii_case("domain").then_some(value)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_public_suffix_domain_is_rejected() {
+        // The exact leak: evil.com scoping a cookie to every `.com` host.
+        assert!(!set_cookie_is_acceptable(
+            "sid=leaked; Domain=com; Path=/",
+            "evil.com"
+        ));
+        assert!(!set_cookie_is_acceptable("a=1; Domain=net", "evil.net"));
+        // A leading dot is the same attribute (RFC 6265 §5.2.3).
+        assert!(!set_cookie_is_acceptable("a=1; Domain=.com", "evil.com"));
+    }
+
+    #[test]
+    fn identical_to_the_host_survives_so_localhost_keeps_working() {
+        // `localhost` is single-label, so the test above catches it. It must
+        // survive by the identical-to-host branch or every local dev server
+        // stops keeping its session.
+        assert!(set_cookie_is_acceptable(
+            "sid=dev; Domain=localhost; Path=/",
+            "localhost"
+        ));
+        assert!(set_cookie_is_acceptable("a=1; Domain=com", "com"));
+    }
+
+    #[test]
+    fn ordinary_scoping_is_untouched() {
+        // The control. A fix that also broke parent-domain scoping would be
+        // worse than the bug it closes.
+        assert!(set_cookie_is_acceptable(
+            "sid=ok; Domain=example.com; Path=/",
+            "api.example.com"
+        ));
+        assert!(set_cookie_is_acceptable(
+            "sid=ok; Path=/",
+            "api.example.com"
+        ));
+        assert!(set_cookie_is_acceptable("sid=ok", "api.example.com"));
+    }
+
+    #[test]
+    fn the_attribute_is_found_however_it_is_written() {
+        // Case-insensitive, whitespace-tolerant, and never confused by a
+        // COOKIE called "domain" — that is the name=value pair, not an
+        // attribute, so it is skipped.
+        assert!(!set_cookie_is_acceptable("a=1; DOMAIN=com", "evil.com"));
+        assert!(!set_cookie_is_acceptable(
+            "a=1;   domain  =  com  ",
+            "evil.com"
+        ));
+        assert!(set_cookie_is_acceptable("domain=com; Path=/", "evil.com"));
+    }
+}

--- a/crates/tropel-variables/src/lib.rs
+++ b/crates/tropel-variables/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod assertions;
 pub mod catalog;
+pub mod cookies;
 pub mod headers;
 pub mod resolver;
 


### PR DESCRIPTION
The jar accepted `Domain=com`. Verified through the real jar before the fix, not theorised:

```
Domain=com         -> bank.com         : Some("sid=leaked")   ← the leak
Domain=example.com -> www.example.com  : Some("ok=1")         ← the control passes
```

A server on `evil.com` sending `Domain=com` had that cookie stored with domain `com` and replayed to **every `.com` host in the jar**.

I expected reqwest to reject it — `publicsuffix` *is* in the dependency graph, via `cookie_store`. `Jar::default()` never consults it. Every browser does (RFC 6265 §5.3 step 5).

## Both doors, not one

A rule enforced on one entrance is half a rule:

| door | behaviour |
|---|---|
| the response path (`client.rs`) — the only place `Set-Cookie` enters the jar during a run | filtered |
| the k6 `jar.set(url, name, value, {domain})` verb | **refused by name** |

The k6 verb refuses rather than dropping silently: the script asked for something specific, and silence reads as "stored" (invariant #8).

## The test drives the jar, not the predicate

The predicate has its own unit tests — and they'd have passed just as happily while nothing called them. That is *exactly* how the missing `resolveTemplateDetailed` export shipped in TR-445, so this one goes through `set_cookie` / `cookies_for_url` end to end.

## The single-label limit, stated rather than buried

| rejected | not rejected |
|---|---|
| `com`, `net`, `org`, `localhost` | `co.uk`, `github.io` |

Embedding the real PSL means ~250 KB of data needing updates forever, in a crate the wasm tier links. The single-label case is the one reachable from any `.com` server.

## What must keep working — both pinned

- `Domain=localhost` on `localhost` (identical-to-host branch) — or every local dev server stops keeping its session
- `Domain=example.com` from `api.example.com` — a fix that broke parent-domain scoping would be worse than the bug

## Where the rule lives

`tropel-variables::cookies` — a wasm-safe leaf, so `core-wasm` can export it whenever KnockPort should read it instead of keeping its own. KnockPort implements the same single-label test today (kp#92). **That duplication is deliberate**: a one-line predicate is low-risk to duplicate, and exporting it would cost a publish cycle for one boolean. Named in the module docs rather than left for someone to find.

## What this says about KT-305

Found while probing whether the two jars' cookie rules diverge. **They don't** — KnockPort leaked this too. A *shared* bug, not a divergence, which is more evidence against decoupling the jar: the two agree, including where they were both wrong.

`cargo test -p tropel-http --lib` 81 passed · `-p tropel-variables --lib` 94 passed · clippy clean.