### PR TITLE
chore(release): 0.5.4 — the seven surfaces move together [TR-460]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "tropel"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-engine"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-web"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "postcard",

--- a/crates/tropel-engine/Cargo.toml
+++ b/crates/tropel-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-engine"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-web/Cargo.toml
+++ b/crates/tropel-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-web"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel/Cargo.toml
+++ b/crates/tropel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/input-wasm/package.json
+++ b/packages/input-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/input-wasm",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Tropel collection-import slice for browser embedders (KnockPort). Lazy sibling of @tropel/core-wasm: OpenAPI 3.x, Postman v2.x, and HAR parsers compiled to wasm32-unknown-unknown. See API_CLIENT_WEB_PAYLOAD.md \u00a72.3 for the two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-wasm/package.json
+++ b/packages/runtime-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/runtime-wasm",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Browser/Node host for the tropel load-testing runtime compiled to wasm32-wasip1: postcard C ABI driver, WASI preview1 wiring, and the HTTP bridge that answers each request the runtime makes.",
   "license": "Apache-2.0",
   "type": "module",
@@ -45,7 +45,7 @@
     "tropel"
   ],
   "dependencies": {
-    "@tropel/shims": "^0.5.3"
+    "@tropel/shims": "^0.5.4"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/shims",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The tropel JS shim bundle \u2014 pm/bru scripting API, chai, lodash, CryptoJS, exec, and the k6 family. The same sources the tropel runtime embeds (ShimBundle::default()), published for embedders.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Everything merged since 0.5.3 is **unreachable to consumers** until this bump, because npm versions are immutable and 0.5.3 is already live.

## Why a bump is required, not just a publish

`@tropel/core-wasm@0.5.3` was published *before* TR-449, TR-451, TR-452 and TR-455 landed. The registry holds an artifact that predates:

| | |
|---|---|
| **TR-451** | the restored `resolveTemplateDetailed` export — an undefined method on the send path of every template with a `{{var}}` |
| **TR-455** | Unicode header folding |
| **TR-449** | `hitCap`/`unresolved` on batch resolve |
| **TR-452** | `/variables/dynamic[/batch]` and `/constants` |

And `@tropel/input-wasm` is still at **0.3.0**, so the `.bru` text parser (TR-458) has never reached a consumer at all — which is exactly what blocks KnockPort from deleting its 683-line stopgap (KT-306).

`release.sh` already anticipates this: its skip check prints the publish *date* precisely because *"if that date is old, the published artifact predates the fixes being released and the version must be BUMPED for them to reach consumers."*

## 0.5.4, not 0.6.0

`PLAN.md` reserves **0.6.0** for the Phase 5 package rename. This is a content release, not a renaming one.

`tropel-sdk` deliberately stays at 0.3.0 — separately published, WARNING-only in the lockstep gate, and 0.3.0 is what's live on crates.io.

## Verified

```
$ bash scripts/version-lockstep.sh
ok: all seven version surfaces agree at 0.5.4

$ cargo check --workspace
Finished — Checking tropel v0.5.4

$ bash packages/core-wasm/scripts/build.sh
(README Size line unchanged — nothing stale for the size gate to fail on)
```