### PR TITLE
feat(agent): /execute carries the whole request [TR-463]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -1293,6 +1293,13 @@ fn sign_with_scheme(
     }
 }
 
+/// Base64 encode, beside the decoder — the same engine, so a round trip
+/// through the agent cannot disagree with itself.
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
 /// Base64 decode without pulling a new dependency into this crate.
 fn base64_decode(s: &str) -> Result<Vec<u8>, String> {
     use base64::Engine as _;
@@ -1600,11 +1607,30 @@ async fn execute_single(state: &AgentState, req: &serde_json::Value) -> serde_js
                 .as_ref()
                 .map(|t| t.receiving.as_millis() as f64)
                 .unwrap_or(0.0);
+            // TR-462: a response body that is not valid UTF-8 comes back as
+            // base64, and says so.
+            //
+            // This used to be `String::from_utf8_lossy`, which replaces every
+            // invalid byte with U+FFFD and reports nothing. A PNG, a protobuf
+            // or a gzip payload fetched through the agent arrived CORRUPTED,
+            // and no field on the reply said so — the silent data loss
+            // invariant #7 forbids, on the single-request path a desktop or
+            // website transport uses for every send.
+            //
+            // `bodyEncoding` is always present so a caller never has to guess,
+            // and a caller that ignores it now sees obvious base64 rather than
+            // subtle mojibake — a failure that is visible instead of one that
+            // looks like a server bug.
+            let (body, body_encoding) = match std::str::from_utf8(&resp.body) {
+                Ok(text) => (text.to_string(), "utf8"),
+                Err(_) => (base64_encode(&resp.body), "base64"),
+            };
             serde_json::json!({
                 "status": resp.status_code,
                 "status_text": resp.status_text,
                 "headers": resp.headers,
-                "body": String::from_utf8_lossy(&resp.body),
+                "body": body,
+                "bodyEncoding": body_encoding,
                 "timings": {
                     "blocked": 0.0, "dns": 0.0, "connecting": 0.0, "tls_handshaking": 0.0,
                     "sending": 0.0, "waiting": waiting, "receiving": receiving,
@@ -2213,6 +2239,69 @@ mod tests {
         s.read_to_end(&mut out).await.expect("read");
         let raw = String::from_utf8_lossy(&out).to_string();
         assert!(raw.starts_with("HTTP/1.1 401"), "{raw}");
+    }
+
+    /// TR-462 — a non-UTF-8 response body survives, and says how.
+    ///
+    /// Not a socket test: `/execute` needs a live upstream, and what is under
+    /// test is the ENCODING DECISION, not the HTTP plumbing. Driving the same
+    /// bytes through the same branch is the honest way to pin it — and the
+    /// round trip through `base64_decode` proves the two halves of this file
+    /// agree, which is the property that actually matters to a caller.
+    #[test]
+    fn a_binary_response_body_is_base64_not_mojibake() {
+        // A PNG header: valid bytes, invalid UTF-8. `from_utf8_lossy` turns
+        // every one of the high bytes into U+FFFD and reports nothing, so the
+        // caller receives a corrupted image that looks like a server bug.
+        //
+        // Built through a function rather than as a literal: clippy
+        // const-folds `from_utf8` on a literal and warns that it "always
+        // returns an error", which is the very property under test.
+        fn png_header() -> Vec<u8> {
+            vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0xD8]
+        }
+        let png = png_header();
+        assert!(
+            std::str::from_utf8(&png).is_err(),
+            "the fixture must actually be invalid UTF-8 or this test proves nothing"
+        );
+
+        let (body, encoding) = match std::str::from_utf8(&png) {
+            Ok(text) => (text.to_string(), "utf8"),
+            Err(_) => (base64_encode(&png), "base64"),
+        };
+        assert_eq!(encoding, "base64");
+        assert_eq!(
+            base64_decode(&body).expect("round trips"),
+            png,
+            "the bytes must come back EXACTLY — lossy is the bug"
+        );
+
+        // What the old code did, pinned so the difference is visible rather
+        // than asserted: every high byte became the replacement character.
+        let lossy = String::from_utf8_lossy(&png);
+        assert!(
+            lossy.contains('\u{FFFD}'),
+            "the old path really did corrupt these bytes: {lossy:?}"
+        );
+        assert_ne!(
+            lossy.as_bytes(),
+            png,
+            "and the corruption was unrecoverable — no field said so"
+        );
+
+        // Text is untouched: the common case must not start arriving as
+        // base64, which would break every existing caller.
+        fn json_body() -> Vec<u8> {
+            br#"{"ok":true}"#.to_vec()
+        }
+        let text = json_body();
+        let (body, encoding) = match std::str::from_utf8(&text) {
+            Ok(t) => (t.to_string(), "utf8"),
+            Err(_) => (base64_encode(&text), "base64"),
+        };
+        assert_eq!(encoding, "utf8");
+        assert_eq!(body, "{\"ok\":true}");
     }
 
     /// TR-445: `/auth/sign`, over the socket.

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -1534,14 +1534,65 @@ async fn execute_single(state: &AgentState, req: &serde_json::Value) -> serde_js
         .and_then(|f| f.as_bool())
         .unwrap_or(true);
 
-    let headers: Vec<(String, String)> = req
-        .get("headers")
-        .and_then(|h| h.as_object())
-        .map(|o| {
-            o.iter()
-                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
-                .collect()
-        })
+    // TR-463: headers arrive as an ARRAY of pairs, with the old object form
+    // still accepted.
+    //
+    // A JSON object cannot hold two entries with the same key, so the object
+    // form silently collapsed duplicate header names — one of two `Set-Cookie`
+    // or `Accept` rows reached the wire and nothing reported the other. That
+    // is the same silent-loss class as TR-462's mangled bodies, refusing to
+    // send data the caller asked for rather than corrupting what came back.
+    //
+    // The relay has always used a pair list for exactly this reason
+    // (`duplicateNames: true` in its capability descriptor); /execute now
+    // matches, so a transport built on it can declare the same.
+    let headers: Vec<(String, String)> = match req.get("headers") {
+        Some(serde_json::Value::Array(rows)) => rows
+            .iter()
+            .filter_map(|row| match row {
+                // ["Name", "value"]
+                serde_json::Value::Array(pair) if pair.len() == 2 => Some((
+                    pair[0].as_str()?.to_string(),
+                    pair[1].as_str().unwrap_or("").to_string(),
+                )),
+                // {"name": "...", "value": "..."}
+                serde_json::Value::Object(o) => Some((
+                    o.get("name")?.as_str()?.to_string(),
+                    o.get("value")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                )),
+                _ => None,
+            })
+            .collect(),
+        Some(serde_json::Value::Object(o)) => o
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    // TR-463: the fields the engine has always supported and the wire format
+    // dropped on the floor. Each was hard-coded to its empty value, so a
+    // client asking for a client certificate, a Host override, a cookie or a
+    // timeout was ignored WITHOUT being told — the request went out missing
+    // what it asked for. `tropel_sdk::Request` carries every one of them.
+    let certificate: Option<tropel_sdk::types::CertificateConfig> = req
+        .get("certificate")
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let host: Option<String> = req.get("host").and_then(|h| h.as_str()).map(str::to_string);
+    let cookies: Vec<tropel_sdk::types::RequestCookie> = req
+        .get("cookies")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    let timeout = req
+        .get("timeout_ms")
+        .and_then(|t| t.as_u64())
+        .map(std::time::Duration::from_millis);
+    let query_params: HashMap<String, String> = req
+        .get("query_params")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default();
 
     let method_parsed = Method::parse(method).unwrap_or(Method::GET);
@@ -1555,17 +1606,17 @@ async fn execute_single(state: &AgentState, req: &serde_json::Value) -> serde_js
         url: url.to_string(),
         method: method_parsed,
         headers,
-        query_params: HashMap::new(),
+        query_params,
         body: req
             .get("body")
             .and_then(|b| b.as_str())
             .map(|s| Body::Raw(s.to_string())),
         auth: auth.clone(),
-        certificate: None,
+        certificate,
         follow_redirects: follow,
-        host: None,
-        cookies: Vec::new(),
-        timeout: None,
+        host,
+        cookies,
+        timeout,
         response_type: ResponseType::Text,
     };
 
@@ -2239,6 +2290,83 @@ mod tests {
         s.read_to_end(&mut out).await.expect("read");
         let raw = String::from_utf8_lossy(&out).to_string();
         assert!(raw.starts_with("HTTP/1.1 401"), "{raw}");
+    }
+
+    /// TR-463 — duplicate header names survive `/execute`.
+    ///
+    /// The object form cannot hold two entries with the same key, so
+    /// `{"Accept": "a", "Accept": "b"}` is not even expressible — one row is
+    /// gone before the agent sees it. Two `Set-Cookie` rows, or the `Accept`
+    /// pair an API needs, arrived as one and nothing reported the other.
+    ///
+    /// Pins the ARRAY form carrying both, and the object form still working,
+    /// because breaking the old shape would break every existing caller.
+    #[test]
+    fn duplicate_header_names_survive_the_execute_wire_format() {
+        // Exactly the parsing branch `execute_single` runs.
+        fn parse(v: &serde_json::Value) -> Vec<(String, String)> {
+            match v.get("headers") {
+                Some(serde_json::Value::Array(rows)) => rows
+                    .iter()
+                    .filter_map(|row| match row {
+                        serde_json::Value::Array(pair) if pair.len() == 2 => Some((
+                            pair[0].as_str()?.to_string(),
+                            pair[1].as_str().unwrap_or("").to_string(),
+                        )),
+                        serde_json::Value::Object(o) => Some((
+                            o.get("name")?.as_str()?.to_string(),
+                            o.get("value")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                        )),
+                        _ => None,
+                    })
+                    .collect(),
+                Some(serde_json::Value::Object(o)) => o
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                    .collect(),
+                _ => Vec::new(),
+            }
+        }
+
+        // Pair form: BOTH rows survive, in order.
+        let pairs = parse(&serde_json::json!({
+            "headers": [["Accept", "application/json"], ["Accept", "text/plain"]]
+        }));
+        assert_eq!(
+            pairs,
+            vec![
+                ("Accept".to_string(), "application/json".to_string()),
+                ("Accept".to_string(), "text/plain".to_string()),
+            ],
+            "a duplicate header name must reach the wire twice"
+        );
+
+        // Object form: still accepted, so existing callers keep working.
+        let obj = parse(&serde_json::json!({"headers": {"Accept": "application/json"}}));
+        assert_eq!(
+            obj,
+            vec![("Accept".to_string(), "application/json".to_string())]
+        );
+
+        // The {name, value} row shape too — what a KnockPort KeyValuePair
+        // serialises to, so a caller does not have to reshape it first.
+        let named = parse(&serde_json::json!({
+            "headers": [{"name": "X-A", "value": "1"}, {"name": "X-A", "value": "2"}]
+        }));
+        assert_eq!(named.len(), 2, "{named:?}");
+
+        // And the loss the object form CANNOT avoid, pinned so the reason
+        // this changed is visible: serde keeps the last of two equal keys.
+        let collapsed: serde_json::Value =
+            serde_json::from_str(r#"{"headers":{"Accept":"a","Accept":"b"}}"#).unwrap();
+        assert_eq!(
+            parse(&collapsed).len(),
+            1,
+            "the object form loses one row before the agent ever sees it"
+        );
     }
 
     /// TR-462 — a non-UTF-8 response body survives, and says how.


### PR DESCRIPTION
Five fields the engine has always supported and the wire format threw away. `tropel_sdk::Request` carries every one; `execute_single` hard-coded them to empty and told nobody:

| field | was | effect |
|---|---|---|
| `certificate` | `None` | no client certificate, ever |
| `host` | `None` | no Host override |
| `cookies` | `Vec::new()` | per-request cookies dropped |
| `timeout` | `None` | the caller's timeout ignored |
| `query_params` | `HashMap::new()` | dropped |

A client asking for a client certificate got a request sent **without** one. Not refused, not reported — sent, and it fails at the far end as an auth error that looks like the server's fault.

## Headers are the worse half

They were read from a JSON **object**, and an object cannot hold two entries with the same key:

```json
{"Accept": "a", "Accept": "b"}    →    one row. The other is gone
                                        before the agent ever sees it.
```

Two `Set-Cookie` rows, or the `Accept` pair an API needs, arrived as one. The relay has used a pair list from the start for exactly this reason (`duplicateNames: true` in its capability descriptor) — `/execute` now matches, so **a transport built on it can declare the same thing truthfully**.

Three shapes accepted:

- `[["Name", "value"]]` — the pair array
- `[{"name": "...", "value": "..."}]` — what a KnockPort `KeyValuePair` serialises to, so a caller needn't reshape it
- `{"Name": "value"}` — the old object form, because breaking it would break every existing caller. There's an assertion for that.

## The test pins the loss, not just the fix

It asserts that the object form **collapses two equal keys to one**, so the reason this changed stays visible instead of becoming folklore.

## How it was found

Grounding a capability descriptor for the website's agent transport (KT-402) in what `/execute` *actually* forwards rather than what the engine can do. #557 fixed the one gap that **corrupted** data; these five **refused** it silently instead.

`cargo test -p tropel-engine --lib` — 73 passed. Clippy clean.