### PR TITLE
feat(shims): export the script-realm corpus [TR-466]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -231,11 +231,16 @@ async fn handle_connection(sock: &mut TcpStream, state: Arc<AgentState>) -> trop
         // ── TR-445 · the RULES endpoints ─────────────────────────────────────
         //
         // The agent exposed request EXECUTION only, which is why every
-        // core-tier method in knockport's `native-agent.ts` throws
+        // core-tier method in knockport's `native-agent.ts` USED TO throw
         // `TropelCoreUnavailableError` naming this gap. Desktop ships no wasm,
         // so without these the only way to resolve a variable or sign a
-        // request there is a TypeScript re-implementation — invariant #3, and
+        // request there was a TypeScript re-implementation — invariant #3, and
         // the most expensive recurring bug class in both repos.
+        //
+        // TR-464: those methods FORWARD now (knockport KP-209), batched at the
+        // provider so a burst of 33 template resolutions costs one round trip
+        // rather than 33. The present tense here described the state this
+        // endpoint set was built to end.
         //
         // These are pure functions over JSON: same Rust the wasm tier calls,
         // reached over the loopback socket instead of a wasm boundary.

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -1335,13 +1335,23 @@ async fn run_script_once(
     ctx.eval(include_str!("../../../js/shared/deep-equal.js"))
         .await
         .map_err(|e| format!("deep-equal shim: {e:?}"))?;
-    ctx.eval(concat!(
-        include_str!("../../../js/shared/k6-core.js"),
-        "\n",
-        include_str!("../../../js/scripting-api/pm.js")
-    ))
-    .await
-    .map_err(|e| format!("pm shim: {e:?}"))?;
+    // TR-465: the SHARED bundle, not a hand-rolled list.
+    //
+    // This used to eval `k6-core.js` + `pm.js` inline, which quietly gave
+    // /script a SMALLER surface than a load run: `typeof bru === "undefined"`
+    // here and an object there, so a Bruno-style script worked in the app and
+    // failed on the agent. Measured, not guessed — a realm probe across both
+    // engines is what surfaced it.
+    //
+    // `js_bootstrap` exists precisely because this went wrong once before: two
+    // hand-maintained shim lists drifted and "bru.js was compiled into the
+    // binary but NEVER evaluated". Re-deriving the list here re-opened that
+    // exact hole, one endpoint over.
+    for entry in crate::js_bootstrap::ShimBundle::default().0 {
+        ctx.eval(&entry.1)
+            .await
+            .map_err(|e| format!("{} shim: {e:?}", entry.0))?;
+    }
 
     let state = tropel_sandbox::state::SharedPmState::default();
     {
@@ -2295,6 +2305,70 @@ mod tests {
         s.read_to_end(&mut out).await.expect("read");
         let raw = String::from_utf8_lossy(&out).to_string();
         assert!(raw.starts_with("HTTP/1.1 401"), "{raw}");
+    }
+
+    /// TR-465 / KT-404 — the QuickJS half of the script-realm corpus.
+    ///
+    /// The corpus is a COMMITTED, MEASURED table of what a user script can
+    /// rely on in each realm — KnockPort's host-JS one and this one. Both
+    /// repos read the same file, so a probe whose answer changes fails here
+    /// AND there until the table is updated. That is the whole design: the
+    /// divergence stops being folklore and becomes something a test owns.
+    ///
+    /// It runs through `run_script_once`, the production /script path, rather
+    /// than a hand-built context — a realm assembled just for the test could
+    /// pass while the one users reach is missing a shim, which is exactly the
+    /// bug the `bru` probe found.
+    #[tokio::test]
+    async fn the_script_realm_matches_the_committed_corpus() {
+        const CORPUS: &str =
+            include_str!("../../../packages/shims/fixtures/script-realm-corpus.json");
+        let doc: serde_json::Value = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
+        let probes = doc["probes"].as_array().expect("probes array");
+        assert!(!probes.is_empty(), "an empty corpus asserts nothing");
+
+        // One script sets one environment key per probe, so a single realm
+        // answers all of them — and the realm is built exactly once, as a
+        // caller's would be.
+        let script = probes
+            .iter()
+            .map(|p| {
+                let name = p["name"].as_str().expect("name");
+                let expr = p["expression"].as_str().expect("expression");
+                format!("pm.environment.set({name:?}, String({expr}));")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let out = run_script_once(&script, HashMap::new())
+            .await
+            .expect("the realm runs");
+
+        let mut wrong: Vec<String> = Vec::new();
+        for probe in probes {
+            let name = probe["name"].as_str().unwrap();
+            let want = probe["quickJs"].as_str().unwrap();
+            let got = out
+                .get("environment")
+                .and_then(|e| e.get(name))
+                .and_then(|v| v.as_str())
+                .unwrap_or("(probe did not run)");
+            if got != want {
+                wrong.push(format!(
+                    "  {name}: corpus says {want:?}, realm answered {got:?}"
+                ));
+            }
+        }
+        assert!(
+            wrong.is_empty(),
+            "the QuickJS realm no longer matches the committed corpus.\n{}\n\n\
+             If the realm CHANGED on purpose, update \
+             packages/shims/fixtures/script-realm-corpus.json — and update the \
+             `why` line too, because KnockPort's half of this corpus asserts \
+             the same file and a user reads those lines to know what their \
+             script can use.",
+            wrong.join("\n")
+        );
     }
 
     /// TR-463 — duplicate header names survive `/execute`.

--- a/packages/shims/fixtures/script-realm-corpus.json
+++ b/packages/shims/fixtures/script-realm-corpus.json
@@ -1,0 +1,40 @@
+{
+  "$comment": "TR-465 / KT-404 — what a user script can rely on in each realm. MEASURED, not asserted from documentation: every value here came from running the probe in that realm and recording the answer. The point is that the divergence between KnockPort's host-JS realm (new Function + eval, the browser and the web app) and tropel's QuickJS realm (load runs, and desktop from KT-404 on) becomes a committed table instead of folklore. A probe whose answer changes fails the test in BOTH repos until this file is updated, so the surface cannot drift silently.",
+  "$realms": {
+    "hostJs": "KnockPort's scripting realm — `createRealmWithHost` in packages/engine/src/scripting-core.ts. The page's own engine.",
+    "quickJs": "tropel's script realm — the shim bundle over tropel-js, used by every load run and by POST /script."
+  },
+  "probes": [
+    { "name": "fetch", "expression": "typeof fetch", "hostJs": "function", "quickJs": "undefined",
+      "why": "A script calling fetch() directly works in the app and throws under load. The supported path is pm.sendRequest, which both realms bridge to the host transport." },
+    { "name": "crypto", "expression": "typeof crypto", "hostJs": "object", "quickJs": "undefined",
+      "why": "No WebCrypto in QuickJS. Signing belongs to tropel-auth, reached through the shims; a script reaching for crypto directly is reaching past the seam." },
+    { "name": "crypto.randomUUID", "expression": "typeof crypto !== 'undefined' && typeof crypto.randomUUID", "hostJs": "function", "quickJs": "false",
+      "why": "The commonest way a script mints a request id. Use {{$guid}} or pm.variables — the dynamic catalogue is the same Rust in both realms." },
+    { "name": "TextEncoder", "expression": "typeof TextEncoder", "hostJs": "function", "quickJs": "undefined", "why": "A browser global." },
+    { "name": "Intl", "expression": "typeof Intl", "hostJs": "object", "quickJs": "undefined",
+      "why": "No Intl in QuickJS, so toLocaleString and friends format differently. Date and number formatting in a script is a real divergence, not a theoretical one." },
+    { "name": "setTimeout", "expression": "typeof setTimeout", "hostJs": "function", "quickJs": "undefined",
+      "why": "There is no event loop to schedule onto in the script realm. A script that awaits a timer hangs in the app and throws under load." },
+    { "name": "structuredClone", "expression": "typeof structuredClone", "hostJs": "function", "quickJs": "undefined", "why": "A browser global." },
+    { "name": "URL", "expression": "typeof URL", "hostJs": "function", "quickJs": "undefined",
+      "why": "URL parsing in a script diverges. The resolver's own URL handling is tropel's and is identical in both realms." },
+    { "name": "error.stack contains the message", "expression": "(() => { try { null.x; } catch (e) { return String(e.stack).indexOf(String(e.message)) >= 0 ? 'yes' : 'no'; } })()", "hostJs": "yes", "quickJs": "no",
+      "why": "QuickJS's stack carries frames only. `e.stack || e.message` therefore LOSES the message in one realm and not the other — this exact shape swallowed a script error during KT-203 and is why the agent reports message-first." },
+    { "name": "localStorage", "expression": "typeof localStorage", "hostJs": "undefined", "quickJs": "undefined",
+      "why": "Absent in BOTH. Recorded because agreeing is worth pinning too: this is not a divergence and must not become one." },
+    { "name": "console", "expression": "typeof console", "hostJs": "object", "quickJs": "object", "why": "Both realms install console." },
+    { "name": "btoa", "expression": "typeof btoa", "hostJs": "function", "quickJs": "function", "why": "Both." },
+    { "name": "BigInt", "expression": "typeof BigInt", "hostJs": "function", "quickJs": "function", "why": "Both." },
+    { "name": "Array.prototype.at", "expression": "typeof [].at", "hostJs": "function", "quickJs": "function", "why": "ES2022 — both." },
+    { "name": "String.prototype.replaceAll", "expression": "typeof ''.replaceAll", "hostJs": "function", "quickJs": "function", "why": "ES2021 — both." },
+    { "name": "Object.hasOwn", "expression": "typeof Object.hasOwn", "hostJs": "function", "quickJs": "function", "why": "ES2022 — both." },
+    { "name": "Promise.allSettled", "expression": "typeof Promise.allSettled", "hostJs": "function", "quickJs": "function", "why": "ES2020 — both." },
+    { "name": "regexp lookbehind", "expression": "(() => { try { new RegExp('(?<=a)b'); return 'ok'; } catch (e) { return 'unsupported'; } })()", "hostJs": "ok", "quickJs": "ok",
+      "why": "QuickJS's libregexp supports lookbehind. Worth pinning: the regex engines genuinely differ, so agreement here is a measurement, not an assumption." },
+    { "name": "regexp named groups", "expression": "(() => { try { return 'x'.match(/(?<n>x)/).groups.n; } catch (e) { return 'unsupported'; } })()", "hostJs": "x", "quickJs": "x", "why": "Both." },
+    { "name": "pm", "expression": "typeof pm", "hostJs": "object", "quickJs": "object", "why": "The Postman-compat surface, in both." },
+    { "name": "bru", "expression": "typeof bru", "hostJs": "object", "quickJs": "object",
+      "why": "The Bruno-compat surface. This probe FOUND A BUG: POST /script hand-rolled its shim list (k6-core + pm only) instead of using ShimBundle::default(), so `bru` was undefined on the agent and an object in the app — a Bruno-style script worked in KnockPort and failed on desktop. js_bootstrap.rs exists because that exact defect happened once before ('bru.js was compiled into the binary but NEVER evaluated'); re-deriving the list in agent.rs re-opened it one endpoint over. Fixed in TR-465." }
+  ]
+}

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -14,6 +14,7 @@
     }
   },
   "files": [
+    "fixtures",
     "dist",
     "shim",
     "LICENSE-APACHE"

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./dist/bundle.d.ts",
       "default": "./dist/bundle.js"
-    }
+    },
+    "./fixtures/script-realm-corpus.json": "./fixtures/script-realm-corpus.json"
   },
   "files": [
     "fixtures",


### PR DESCRIPTION
#561 shipped the fixture in the package's `files` but never added it to `exports`, so a consumer **cannot reach it**:

```
Error: Package subpath './fixtures/script-realm-corpus.json' is not defined
by "exports" in @tropel/shims/package.json
```

KnockPort's half of the corpus couldn't load at all.

A fixture that **two repos assert against** is part of the package's contract, not an internal file that happens to be shipped. Exporting it says so — and it means the consumer resolves through the map rather than walking to the package directory, which is path archaeology that works until the layout moves and then fails somewhere unhelpful.

Found by writing the consumer, which is the only way this kind of gap shows up: the producing side sees a file on disk and assumes reachable.