### PR TITLE
fix(agent): make the loopback agent reachable, and give its realm the embedder's namespace  [KT-404 / TR-469]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -637,7 +637,49 @@ async fn handle_connection(sock: &mut TcpStream, state: Arc<AgentState>) -> trop
                 )
                 .await;
             };
-            let code = payload.get("code").and_then(|c| c.as_str()).unwrap_or("");
+            // TR-469: a MISSING or non-string `code` is a caller bug, not an
+            // empty script. `.unwrap_or("")` ran nothing and answered 200 with
+            // a success-shaped body, so a client that misspelled the field saw
+            // "the script ran and did nothing" — the silent success invariant 8
+            // forbids. An empty STRING stays legal (a stage with no script).
+            let Some(code) = payload.get("code").and_then(|c| c.as_str()) else {
+                return respond_raw_cors(
+                    sock,
+                    cors.as_deref(),
+                    400,
+                    r#"{"error":"`code` is required and must be a string"}"#,
+                )
+                .await;
+            };
+            // TR-469: the embedder's canonical namespace. pm.js installs the
+            // name named here (P4b `__tropel_sandbox_config`); absent a config
+            // the stock install applies, whose canonical name is `trp`.
+            //
+            // The API client's realm is built with namespace "kp", so WITHOUT
+            // this the agent realm had no `kp` at all: a `kp.test(...)` script
+            // passed in the app and died with "kp is not defined" on desktop —
+            // two realms for one script, disagreeing invisibly. tropel stays
+            // product-neutral; the client declares its own namespace and sends
+            // the SAME value it builds its local realm from.
+            let sandbox_cfg = payload
+                .get("sandbox")
+                .map(|v| tropel_sandbox::config::SandboxConfig {
+                    namespace: v
+                        .get("namespace")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("trp")
+                        .to_string(),
+                    aliases: v
+                        .get("aliases")
+                        .and_then(|a| a.as_array())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|x| x.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                })
+                .unwrap_or_default();
             let environment: HashMap<String, String> = payload
                 .get("environment")
                 .and_then(|e| serde_json::from_value(e.clone()).ok())
@@ -651,7 +693,9 @@ async fn handle_connection(sock: &mut TcpStream, state: Arc<AgentState>) -> trop
             let script_response: Option<tropel_sdk::types::Response> = payload
                 .get("response")
                 .and_then(|v| serde_json::from_value(v.clone()).ok());
-            match run_script_once(code, environment, script_request, script_response).await {
+            match run_script_once(code, environment, script_request, script_response, sandbox_cfg)
+                .await
+            {
                 Ok(out) => respond_raw_cors(sock, cors.as_deref(), 200, &out.to_string()).await,
                 Err(why) => respond_raw_cors(sock, cors.as_deref(), 500, &error_body(&why)).await,
             }
@@ -1338,10 +1382,19 @@ async fn run_script_once(
     environment: HashMap<String, String>,
     request: Option<TropelRequest>,
     response: Option<tropel_sdk::types::Response>,
+    sandbox: tropel_sandbox::config::SandboxConfig,
 ) -> Result<serde_json::Value, String> {
     let mut ctx = tropel_js::JsContext::new(None, Some(std::time::Duration::from_secs(10)))
         .await
         .map_err(|e| format!("js context: {e:?}"))?;
+
+    // TR-469: BEFORE the bundle — pm.js's install tail reads this global to
+    // decide the canonical binding name and its aliases, so a preamble
+    // evaluated afterwards would be read too late and silently leave the
+    // stock `trp` install in place.
+    ctx.eval(&sandbox.render_js_preamble())
+        .await
+        .map_err(|e| format!("sandbox config preamble: {e:?}"))?;
 
     ctx.eval(include_str!("../../../js/shared/deep-equal.js"))
         .await
@@ -2366,6 +2419,7 @@ mod tests {
             HashMap::new(),
             None,
             Some(response),
+            tropel_sandbox::config::SandboxConfig::default(),
         )
         .await
         .expect("the realm runs");
@@ -2418,6 +2472,7 @@ mod tests {
             HashMap::new(),
             Some(request),
             None,
+            tropel_sandbox::config::SandboxConfig::default(),
         )
         .await
         .expect("the realm runs");
@@ -2441,6 +2496,69 @@ mod tests {
         assert!(
             rendered.contains("Accept"),
             "the original headers must survive too: {rendered}"
+        );
+    }
+
+    /// TR-469: the embedder's canonical namespace reaches the realm.
+    ///
+    /// The API client builds its LOCAL realm with namespace `kp`, but the
+    /// agent applied tropel's stock install (canonical `trp`, no aliases)
+    /// because `/script` never rendered a `SandboxConfig` preamble. So the
+    /// very same script passed in the app and died with "kp is not defined"
+    /// on the desktop tier — two realms for one script, disagreeing where
+    /// nothing looked. The D4 question ("can two implementations disagree
+    /// invisibly?") answered yes, and no test asked it.
+    ///
+    /// Both halves are asserted deliberately: that the configured name works,
+    /// AND that the stock install genuinely lacks it. Without the second, a
+    /// future default of `kp` everywhere would make this test vacuous while
+    /// still passing.
+    #[tokio::test]
+    async fn the_embedder_namespace_reaches_the_script_realm() {
+        let code = "kp.environment.set('viaKp', '2');";
+
+        let configured = run_script_once(
+            code,
+            HashMap::new(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig {
+                namespace: "kp".into(),
+                aliases: Vec::new(),
+            },
+        )
+        .await
+        .expect("the realm runs");
+        assert!(
+            configured.get("scriptError").map(|e| e.is_null()).unwrap_or(false),
+            "a kp.* script must run when the caller declares the kp namespace: {configured}"
+        );
+        assert_eq!(
+            configured
+                .get("environment")
+                .and_then(|e| e.get("viaKp"))
+                .and_then(|v| v.as_str()),
+            Some("2"),
+            "the effect must come back, not just the absence of an error: {configured}"
+        );
+
+        let stock = run_script_once(
+            code,
+            HashMap::new(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig::default(),
+        )
+        .await
+        .expect("the realm runs");
+        let err = stock
+            .get("scriptError")
+            .and_then(|e| e.as_str())
+            .unwrap_or("");
+        assert!(
+            err.contains("kp is not defined"),
+            "the stock install must NOT bind kp — if it does, this test no \
+             longer proves the preamble is what carries the namespace: {stock}"
         );
     }
 
@@ -2477,7 +2595,13 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let out = run_script_once(&script, HashMap::new(), None, None)
+        let out = run_script_once(
+            &script,
+            HashMap::new(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig::default(),
+        )
             .await
             .expect("the realm runs");
 

--- a/crates/tropel/src/main.rs
+++ b/crates/tropel/src/main.rs
@@ -36,13 +36,43 @@ fn outer_worker_threads() -> usize {
 }
 
 fn main() -> tropel_sdk::Result<()> {
-    // `tropel agent` — the API client's process boundary (P6). Dispatched here
+    // `tropel worker` — the distributed load-test worker (P6). Dispatched here
     // (the binary crate) rather than in tropel-engine's CLI because
     // tropel-distributed depends on tropel-engine; a CLI-level reference would
-    // be a dependency cycle. The client repo carries zero Rust — it spawns
-    // `tropel agent` and talks to it over the controller protocol.
-    if std::env::args().nth(1).as_deref() == Some("agent") {
-        return agent_command();
+    // be a dependency cycle.
+    //
+    // TR-467: this answered to `tropel agent` until that was found to SHADOW
+    // `Commands::Agent` in tropel-engine's CLI — the loopback HTTP agent
+    // (`agent.rs`, TR-405) that the API client actually spawns. Two unrelated
+    // features, one name, and this one won because it is matched before
+    // run_cli() ever sees argv: `tropel agent --port 9876` died on
+    // "unexpected argument '--port'", so the loopback agent had NO reachable
+    // entry point from this binary at all.
+    //
+    // `agent` now belongs to the loopback agent — the meaning every knockport
+    // doc, error message and `agent.rs` startup line already assumed. The
+    // worker answers to `tropel worker` and to the standalone `tropel-agent`
+    // binary, which is unchanged. (`tropel-cloud-run agent` is a different
+    // binary and is unaffected.)
+    match std::env::args().nth(1).as_deref() {
+        Some("worker") => return worker_command(),
+        // Invariant 8: an unsupported invocation names its reason. Without this
+        // arm, the old worker command line would die on clap's "unexpected
+        // argument '--controller'", which does not say that the subcommand was
+        // renamed or where it went. Any OTHER `agent` invocation falls through
+        // to run_cli() -> Commands::Agent, the loopback agent.
+        Some("agent")
+            if std::env::args().any(|a| a == "--controller" || a == "-C" || a == "--token-file") =>
+        {
+            eprintln!(
+                "tropel: `agent` is the loopback HTTP agent \
+                 (--port/--bind/--token/--allow-origin).\n\
+                 The distributed worker moved to `tropel worker` (same flags); \
+                 the standalone `tropel-agent` binary is unchanged."
+            );
+            std::process::exit(2);
+        }
+        _ => {}
     }
 
     let workers = outer_worker_threads();
@@ -54,20 +84,20 @@ fn main() -> tropel_sdk::Result<()> {
     rt.block_on(tropel_engine::cli::run_cli())
 }
 
-/// `tropel agent [--controller HOST:PORT] [--token TOKEN] [--token-file FILE]`
+/// `tropel worker [--controller HOST:PORT] [--token TOKEN] [--token-file FILE]`
 ///
 /// Connect to a `tropel-controller` and run this worker's segment of the job.
 /// Same contract as the standalone `tropel-agent` binary, surfaced as a
-/// subcommand of the main binary so the API client needs nothing but `tropel`.
-fn agent_command() -> tropel_sdk::Result<()> {
+/// subcommand of the main binary so a worker image needs nothing but `tropel`.
+fn worker_command() -> tropel_sdk::Result<()> {
     use clap::Parser;
     use std::path::PathBuf;
 
     #[derive(Parser, Debug)]
     #[command(
-        name = "tropel agent",
-        about = "Distributed load-test worker (API client process boundary)",
-        // P6 version handshake: `tropel agent --version` prints the binary's
+        name = "tropel worker",
+        about = "Distributed load-test worker (runs one segment of a job for a controller)",
+        // P6 version handshake: `tropel worker --version` prints the binary's
         // version so the API client can feed it to checkVersionParity against
         // the loaded wasm's runtimeVersion. clap wires this from
         // CARGO_PKG_VERSION automatically.
@@ -85,20 +115,20 @@ fn agent_command() -> tropel_sdk::Result<()> {
         token_file: Option<PathBuf>,
     }
 
-    // run_cli() initializes tracing for the main commands; the agent path
+    // run_cli() initializes tracing for the main commands; the worker path
     // bypasses it, so initialize here (mirrors the standalone `tropel-agent`
     // bin) or run_agent's tracing::info! calls would be silent no-ops.
     tracing_subscriber::fmt::init();
 
-    // clap::parse() would treat the leading "agent" as an unknown positional;
+    // clap::parse() would treat the leading "worker" as an unknown positional;
     // parse_from over args[2..] scopes the subcommand's own argv correctly.
     //
     // IMPORTANT: parse_from treats its FIRST element as argv[0] (the program
-    // name), so a lone `tropel agent --version` would have "--version" eaten
+    // name), so a lone `tropel worker --version` would have "--version" eaten
     // as the binary name and fall through to the auth check. Prepend a dummy
     // name so real flags (--version/--help included) land at argv[1..].
     let args = AgentArgs::parse_from(
-        std::iter::once("tropel agent".to_string()).chain(std::env::args().skip(2)),
+        std::iter::once("tropel worker".to_string()).chain(std::env::args().skip(2)),
     );
 
     if args.controller.is_empty() {


### PR DESCRIPTION
Three defects on the `/script` path, each of which made a working-looking path do nothing.

### 1. `tropel agent` was unreachable

`main.rs` matched `agent` on `argv[1]` and routed it to the **distributed worker** before `run_cli()` ever saw it. So `tropel-engine`'s `Commands::Agent` — the loopback HTTP agent the API client spawns, and the thing KP-207/209/215 and KT-402/404 are all built on — could not be invoked from this binary at all:

```
$ tropel agent --port 9876
error: unexpected argument '--port' found
```

Two unrelated features shared one name, and the wrong one won.

- The worker moves to **`tropel worker`**.
- The standalone **`tropel-agent` binary is unchanged**, and `tropel-cloud-run agent` is a different binary and unaffected.
- The old worker command line exits 2 with a message naming where it went, rather than dying on clap's "unexpected argument" (invariant 8).

Every other `tropel agent` reference in the tree — `agent.rs`'s own startup line, `tropel-web`, `packages/README.md` — already meant the loopback agent. They become true rather than aspirational.

### 2. `/script` ran a different realm from the one the API client builds

The client builds its realm with namespace `kp`. The agent rendered no `SandboxConfig` preamble, so `pm.js` applied its **stock install** (canonical `trp`, no aliases) and bound no `kp` at all. Same script, two answers:

```
# with the caller's config          -> {"environment":{"viaKp":"2","viaPm":"1"}}
# without it (previous behaviour)   -> {"scriptError":"kp is not defined"}
```

`/script` now accepts the caller's `sandbox` config and evaluates the preamble **before** the shim bundle — after it, `pm.js` has already installed and the name is lost. tropel stays product-neutral: the client declares its own namespace.

### 3. A misspelled `code` field reported success

`payload.get("code").unwrap_or("")` ran an empty script and answered **200 with a success-shaped body**, so a client that sent the wrong field name saw "the script ran and did nothing" — the silent success invariant 8 forbids. It is a 400 now; an empty *string* stays legal (a stage with no script).

### How these were found

By probing a live agent, not by reading it. The realm's own global list is what showed `kp` missing; a deliberately throwing script returning `scriptError: null` is what showed the empty-code path reporting success.

### Tests

`the_embedder_namespace_reaches_the_script_realm` asserts **both** halves — that the configured namespace works, and that the stock install genuinely lacks it — so a future default of `kp` cannot make it vacuous while still passing.

`cargo test -p tropel-engine --lib` → 77 passed, 0 failed. Clippy clean on both changed crates.