### PR TITLE
feat(agent): --exit-with-parent, so a dead supervisor cannot leak a live agent  [KT-404 / TR-471]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -82,6 +82,7 @@ pub async fn run_agent(
     bind: &str,
     token: Option<&str>,
     allowed_origins: &[String],
+    exit_with_parent: bool,
 ) -> tropel_sdk::Result<()> {
     let ip: IpAddr = bind
         .parse()
@@ -90,6 +91,69 @@ pub async fn run_agent(
         return Err(TropelError::Other(format!(
             "refusing to bind {bind}: the agent is a localhost-only execution endpoint (TR-405)"
         )));
+    }
+
+    // TR-471: die with the process that spawned us.
+    //
+    // The desktop shell kills the agent on window-destroy, but that handler
+    // does not run when the shell is SIGKILLed, crashes, or is restarted by a
+    // dev rebuild — and every one of those leaves an agent listening on a
+    // loopback port, holding the collection variables and OAuth client
+    // secrets it was sent, with nothing left to talk to it. Observed twice in
+    // one session: two agents reparented to init while the app was gone.
+    //
+    // A parent-side handler cannot close this on its own (it is precisely the
+    // cases where the parent runs no code), so the agent has to notice. On
+    // Unix an orphan is reparented, so the parent id CHANGING is the signal —
+    // no pid to pass in, and no way to mistake a recycled pid for the parent
+    // still being alive.
+    if exit_with_parent {
+        // Watch stdin for EOF, on a dedicated thread.
+        //
+        // The FIRST attempt at this compared parent process ids — an orphan is
+        // reparented, so a changed parent id looks like a death signal. It
+        // failed its own test: a process can be reparented before it ever
+        // reads its parent id, in which case "changed" never happens and the
+        // watchdog is a no-op that looks armed. That is the wrong failure
+        // direction for something whose whole job is to not leak.
+        //
+        // A pipe cannot be fooled that way. The spawning process hands us a
+        // stdin pipe and simply holds it; when it dies for ANY reason — exit,
+        // crash, or SIGKILL, which runs no cleanup on either side — the OS
+        // closes the write end and this read returns 0. It needs no pid, wins
+        // no race, and works the same on Windows.
+        //
+        // The contract this places on the caller is real and worth stating:
+        // stdin MUST be a pipe the parent keeps open. Handed /dev/null or a
+        // closed descriptor, the read returns 0 at once and the agent exits
+        // immediately — which is why the flag says so, and why the exit says
+        // which of the two happened rather than vanishing silently.
+        std::thread::spawn(|| {
+            use std::io::Read;
+            let mut stdin = std::io::stdin();
+            let mut buf = [0u8; 256];
+            loop {
+                match stdin.read(&mut buf) {
+                    Ok(0) | Err(_) => {
+                        // Deliberately ONE message naming both causes. An
+                        // earlier version tried to tell them apart with a
+                        // "did we ever read a byte" flag, which is wrong: a
+                        // parent that holds the pipe open and never writes to
+                        // it — the normal case — looks identical to a parent
+                        // that never gave us a pipe at all. A diagnostic that
+                        // confidently names the wrong cause is worse than one
+                        // that names both.
+                        tracing::info!(
+                            "tropel agent exiting: stdin reached EOF — either the process that \
+                             spawned it is gone, or stdin was not a pipe held open by it \
+                             (--exit-with-parent requires one)"
+                        );
+                        std::process::exit(0);
+                    }
+                    Ok(_) => {}
+                }
+            }
+        });
     }
 
     let addr = format!("{bind}:{port}");

--- a/crates/tropel-engine/src/cli.rs
+++ b/crates/tropel-engine/src/cli.rs
@@ -290,6 +290,18 @@ pub enum Commands {
         #[arg(long = "bind", default_value = "127.0.0.1")]
         bind: String,
 
+        /// Exit as soon as the process that spawned this agent is gone.
+        ///
+        /// TR-471: a supervisor's own cleanup does not run when it is
+        /// SIGKILLed or crashes, and an agent left behind keeps a loopback
+        /// port open with the variables and client secrets it was sent.
+        ///
+        /// Detected by stdin EOF, so the spawning process MUST give the agent
+        /// a stdin pipe and hold it open. With stdin on /dev/null or closed,
+        /// the agent exits immediately (and says so).
+        #[arg(long = "exit-with-parent")]
+        exit_with_parent: bool,
+
         /// Browser origin allowed to reach this agent, e.g.
         /// `--allow-origin https://app.knockport.dev`. Repeatable.
         ///
@@ -392,7 +404,17 @@ pub async fn run_cli() -> Result<()> {
             token,
             bind,
             allow_origin,
-        } => crate::agent::run_agent(port, bind.as_str(), token.as_deref(), &allow_origin).await,
+            exit_with_parent,
+        } => {
+            crate::agent::run_agent(
+                port,
+                bind.as_str(),
+                token.as_deref(),
+                &allow_origin,
+                exit_with_parent,
+            )
+            .await
+        }
     }
 }
 


### PR DESCRIPTION
An agent outlived the desktop shell **twice in one session** — both reparented to `init`, both still listening on a loopback port, each holding the collection variables and OAuth client secrets it had been sent, with nothing left to talk to it.

A parent-side handler cannot close this. The cases that leak are precisely the cases where the parent runs no code: `SIGKILL`, a panic, or a dev rebuild replacing the process. The agent has to notice by itself.

### How

It watches **stdin for EOF**. The spawning process hands it a pipe and simply holds it; when that process dies for any reason, the OS closes the write end and the read returns 0. No pid to pass, no race to lose, and identical behaviour on Windows.

### Two wrong versions, kept in the commentary

**Comparing parent process ids.** An orphan is reparented, so a changed parent id looks like a death signal. It *failed its own test*: a child can be reparented before it ever reads its parent id, and then "changed" never happens. The watchdog was a no-op that looked armed — the wrong failure direction for something whose only job is to not leak.

**A "did we ever read a byte" flag**, to tell "parent died" from "stdin was never a pipe". Also wrong: a parent that holds the pipe and never writes to it — the normal case — is indistinguishable from one that never gave us a pipe. The exit now names one cause covering both possibilities, because a diagnostic that confidently names the wrong cause is worse than one that names both.

### Measured, not assumed

- **With the parent alive, the agent serves** — `/constants` answers over the socket 2s in, so the watchdog is demonstrably not killing a working agent.
- The moment the parent dies, it is gone.
- With stdin on `/dev/null` it exits at once **and says why**, rather than appearing to run with a watchdog that can never fire.

The flag documents the contract it places on the caller: stdin must be a pipe the parent holds open.

78 tests pass; clippy clean on both changed crates.