### PR TITLE
chore(shims): 0.5.5 — the fixtures export reaches the registry  [TR-466]

### DIFF
--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tropel/shims",
-  "version": "0.5.4",
-  "description": "The tropel JS shim bundle \u2014 pm/bru scripting API, chai, lodash, CryptoJS, exec, and the k6 family. The same sources the tropel runtime embeds (ShimBundle::default()), published for embedders.",
+  "version": "0.5.5",
+  "description": "The tropel JS shim bundle — pm/bru scripting API, chai, lodash, CryptoJS, exec, and the k6 family. The same sources the tropel runtime embeds (ShimBundle::default()), published for embedders.",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
TR-466 added `./fixtures/script-realm-corpus.json` to the exports map — but **0.5.4 was already published without it**. The registry served `exports: ["."]`, so the corpus was unreachable from any consumer and kp#96 (the knockport half of the shared corpus) could not merge.

Published as **0.5.5** and verified *at the registry*, not locally — the local package looked correct for 0.5.4 too, which is exactly how it shipped wrong:

```
latest:  0.5.5
exports: ['.', './fixtures/script-realm-corpus.json']
```

`npm version` also rewrote the description's `—` escape as a literal em dash. Kept — same string either way, and it matches the bytes actually published.

### Known and accepted

`version-lockstep.sh` now fails in `ci.yml` and `release.yml`: shims is `0.5.5` against `0.5.4` across the binary, `tropel-web`, `tropel-engine`, `tropel-sdk`, `core-wasm`, `input-wasm` and `runtime-wasm`.

Bumping those too would mean publishing three more npm packages to keep knockport's pins resolvable. That belongs to a real release, not to unblocking a corpus test.