### PR TITLE
feat(shims): fetch in the script realm, on the same client as pm.sendRequest  [KT-404 / TR-475]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -3133,6 +3133,54 @@ mod tests {
         );
     }
 
+    /// TR-475: `fetch` exists in the realm and rides the SAME client.
+    ///
+    /// QuickJS ships none, so a script written the way every modern one is
+    /// written — `await fetch(...)` — died on a bare ReferenceError, while
+    /// the identical call through `pm.sendRequest` worked. Two spellings of
+    /// one capability, one of which was a crash.
+    ///
+    /// Hermetic, like the send-request test: it fetches a port nothing
+    /// listens on, so the call MUST fail, and asserts WHICH failure. A
+    /// connection error proves the binding reached the client; "not
+    /// available here" proves it did not.
+    #[tokio::test]
+    async fn fetch_is_bound_to_the_same_host_client() {
+        let out = run_script_once(
+            "(async function () {\
+               try {\
+                 var r = await fetch('http://127.0.0.1:1/');\
+                 kp.environment.set('status', String(r.status));\
+               } catch (e) {\
+                 kp.environment.set('err', String(e && e.message));\
+               }\
+             })();",
+            ScriptScopes::default(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig {
+                namespace: "kp".into(),
+                aliases: Vec::new(),
+            },
+            test_http_client(),
+            None,
+        )
+        .await
+        .expect("the realm runs");
+
+        let env = out.get("environment").expect("environment comes back");
+        let err = env.get("err").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            !err.contains("not available here"),
+            "fetch must be bound to a real client, not refuse for lack of one: {out}"
+        );
+        assert!(
+            !err.is_empty() || env.get("status").is_some(),
+            "the call must have gone somewhere — neither a result nor an error \
+             means `fetch` never ran: {out}"
+        );
+    }
+
     /// TR-473: all FOUR scopes reach the realm and come back.
     ///
     /// `/script` carried only `environment`. The realm has always had four
@@ -3273,16 +3321,25 @@ mod tests {
         // Host capabilities a script must not be able to name. Read back
         // through the environment rather than asserted on a throw, so a probe
         // that never ran cannot be mistaken for a probe that found nothing.
+        // TR-475 removed `fetch` from this list, deliberately. It is now a
+        // BOUND capability — the same audited host client `pm.sendRequest`
+        // already rode — not an ambient one the realm happened to expose.
+        // The realm was never network-isolated; `pm.sendRequest` predates
+        // this test. Keeping `fetch` here would have asserted an isolation
+        // the realm did not have, which is worse than not asserting it.
+        //
+        // What remains is the set that would reach the HOST PROCESS: the
+        // module loader, `process`, and the Function-constructor route to a
+        // global. Those are the escape; a guarded HTTP call is not.
         let probe = "kp.environment.set('process', typeof process);\
                      kp.environment.set('require', typeof require);\
-                     kp.environment.set('fetch', typeof fetch);\
                      kp.environment.set('module', typeof module);\
                      kp.environment.set('viaFn', typeof Function('return this')().process);";
         let out = run_script_once(probe, ScriptScopes::default(), None, None, kp(), test_http_client(), None)
             .await
             .expect("the realm runs");
         let env = out.get("environment").expect("the environment comes back");
-        for name in ["process", "require", "fetch", "module", "viaFn"] {
+        for name in ["process", "require", "module", "viaFn"] {
             assert_eq!(
                 env.get(name).and_then(|v| v.as_str()),
                 Some("undefined"),

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -85,6 +85,11 @@ pub enum Shim {
     Exec,
     /// `bru`, `req`, `res` — the Bruno scripting API.
     Bru,
+    /// `fetch` — the same HTTP client `pm.sendRequest` rides, wearing the
+    /// interface every modern script is written against (TR-475). QuickJS
+    /// ships none, so a script using one got a bare ReferenceError. Last in
+    /// the bundle: it defines a global and depends on no other shim.
+    Fetch,
 }
 
 impl Shim {
@@ -93,7 +98,7 @@ impl Shim {
     /// [`Shim::DeepEqual`] MUST stay first: pm, chai and lodash all call
     /// `globalThis.__tropelDeepEqual`. The remaining order is preserved from
     /// the pre-TR-501 bundle so no behaviour moves with this refactor.
-    pub const ALL: [Shim; 8] = [
+    pub const ALL: [Shim; 9] = [
         Shim::DeepEqual,
         Shim::K6Core,
         Shim::Pm,
@@ -102,6 +107,7 @@ impl Shim {
         Shim::CryptoJs,
         Shim::Exec,
         Shim::Bru,
+        Shim::Fetch,
     ];
 
     /// The section-header name this shim is rendered under.
@@ -115,6 +121,7 @@ impl Shim {
             Shim::CryptoJs => "cryptojs-shim",
             Shim::Exec => "exec-shim",
             Shim::Bru => "bru-shim",
+            Shim::Fetch => "fetch-shim",
         }
     }
 
@@ -129,6 +136,7 @@ impl Shim {
             Shim::CryptoJs => include_str!("../../../js/cryptojs-shim/cryptojs.js"),
             Shim::Exec => include_str!("../../../js/exec/exec.js"),
             Shim::Bru => include_str!("../../../js/scripting-api/bru.js"),
+            Shim::Fetch => include_str!("../../../js/scripting-api/fetch.js"),
         }
     }
 }
@@ -769,7 +777,8 @@ mod tests {
                 "lodash-shim",
                 "cryptojs-shim",
                 "exec-shim",
-                "bru-shim"
+                "bru-shim",
+                "fetch-shim"
             ],
             "the default bundle is Shim::ALL, in canonical order"
         );

--- a/js/scripting-api/fetch.js
+++ b/js/scripting-api/fetch.js
@@ -1,0 +1,125 @@
+/**
+ * `fetch` for the tropel script realm (TR-475).
+ *
+ * QuickJS ships no `fetch`, so a script that used one — the shape every
+ * modern API-client script is written in — got a bare ReferenceError. The
+ * realm already has an HTTP client behind `__tropel_trp_send_request`
+ * (TR-472); this is that binding wearing the interface people expect.
+ *
+ * NOT a new transport. It is the SAME client `pm.sendRequest` uses, so a
+ * script's fetch inherits the same posture, and there is one network path
+ * out of the realm rather than two that can disagree.
+ *
+ * The binding is checked at CALL time, never at eval time: the shim bundle
+ * is evaluated BEFORE the bridge is installed, so an eval-time
+ * `typeof __tropel_trp_send_request` is always "undefined" and would leave
+ * `fetch` permanently unset. pm.js defers the same check for the same
+ * reason.
+ */
+(function () {
+    var g = typeof globalThis !== 'undefined' ? globalThis : this;
+
+    // Never shadow a real one. A host that already provides `fetch` (a
+    // browser, or a future runtime that grows one) keeps its own — this shim
+    // exists only where there is none.
+    if (typeof g.fetch === 'function') {
+        return;
+    }
+
+    function headerPairs(headers) {
+        var out = {};
+        if (!headers) return out;
+        if (typeof headers.forEach === 'function' && typeof headers.get === 'function') {
+            headers.forEach(function (v, k) { out[k] = String(v); });
+            return out;
+        }
+        if (Object.prototype.toString.call(headers) === '[object Array]') {
+            for (var i = 0; i < headers.length; i++) {
+                var pair = headers[i];
+                if (pair && pair.length >= 2) out[String(pair[0])] = String(pair[1]);
+            }
+            return out;
+        }
+        for (var k in headers) {
+            if (Object.prototype.hasOwnProperty.call(headers, k)) out[k] = String(headers[k]);
+        }
+        return out;
+    }
+
+    /** A minimal Response. `text()`/`json()` return promises, as the real one
+     *  does — a script that awaits them must not get a raw value back. */
+    function responseOf(raw) {
+        var parsed;
+        try {
+            parsed = JSON.parse(raw);
+        } catch (e) {
+            throw new Error('fetch: the host answered with invalid JSON: ' + raw);
+        }
+        // The bridge reports transport failures in-band; surface them as a
+        // rejected fetch rather than a 0-status response a script would read
+        // as "the server answered" (invariant 8).
+        if (parsed && parsed.error && !parsed.code) {
+            throw new Error('fetch: ' + parsed.error);
+        }
+        var status = parsed.code || 0;
+        var headers = parsed.headers || {};
+        var lower = {};
+        for (var k in headers) {
+            if (Object.prototype.hasOwnProperty.call(headers, k)) {
+                lower[String(k).toLowerCase()] = String(headers[k]);
+            }
+        }
+        return {
+            status: status,
+            ok: status >= 200 && status < 300,
+            statusText: parsed.statusText || '',
+            url: parsed.url || '',
+            headers: {
+                get: function (name) {
+                    var v = lower[String(name).toLowerCase()];
+                    return v === undefined ? null : v;
+                },
+                has: function (name) {
+                    return Object.prototype.hasOwnProperty.call(lower, String(name).toLowerCase());
+                }
+            },
+            text: function () { return Promise.resolve(parsed.body || ''); },
+            json: function () {
+                return new Promise(function (resolve, reject) {
+                    try {
+                        resolve(JSON.parse(parsed.body || ''));
+                    } catch (e) {
+                        reject(new Error('fetch: response body is not JSON'));
+                    }
+                });
+            }
+        };
+    }
+
+    g.fetch = function (input, init) {
+        return new Promise(function (resolve, reject) {
+            try {
+                if (typeof __tropel_trp_send_request !== 'function') {
+                    throw new Error(
+                        'fetch is not available here: this realm was built without an HTTP ' +
+                        'client, so there is nothing to send on (tropel TR-472).'
+                    );
+                }
+                var opts = init || {};
+                var url = typeof input === 'string' ? input : (input && input.url) || '';
+                if (!url) throw new Error('fetch: a URL is required');
+                var method = String(opts.method || (input && input.method) || 'GET').toUpperCase();
+                var headers = headerPairs(opts.headers || (input && input.headers));
+                var body = opts.body === undefined || opts.body === null ? '' : String(opts.body);
+                var timeout = typeof opts.timeout === 'number' ? opts.timeout : 0;
+
+                var raw = __tropel_trp_send_request(
+                    method, String(url), JSON.stringify(headers), body, timeout, 'text'
+                );
+                resolve(responseOf(raw));
+            } catch (e) {
+                reject(e);
+            }
+        });
+    };
+})();

--- a/packages/shims/fixtures/script-realm-corpus.json
+++ b/packages/shims/fixtures/script-realm-corpus.json
@@ -1,40 +1,156 @@
 {
-  "$comment": "TR-465 / KT-404 — what a user script can rely on in each realm. MEASURED, not asserted from documentation: every value here came from running the probe in that realm and recording the answer. The point is that the divergence between KnockPort's host-JS realm (new Function + eval, the browser and the web app) and tropel's QuickJS realm (load runs, and desktop from KT-404 on) becomes a committed table instead of folklore. A probe whose answer changes fails the test in BOTH repos until this file is updated, so the surface cannot drift silently.",
+  "$comment": "TR-465 / KT-404 \u2014 what a user script can rely on in each realm. MEASURED, not asserted from documentation: every value here came from running the probe in that realm and recording the answer. The point is that the divergence between KnockPort's host-JS realm (new Function + eval, the browser and the web app) and tropel's QuickJS realm (load runs, and desktop from KT-404 on) becomes a committed table instead of folklore. A probe whose answer changes fails the test in BOTH repos until this file is updated, so the surface cannot drift silently.",
   "$realms": {
-    "hostJs": "KnockPort's scripting realm — `createRealmWithHost` in packages/engine/src/scripting-core.ts. The page's own engine.",
-    "quickJs": "tropel's script realm — the shim bundle over tropel-js, used by every load run and by POST /script."
+    "hostJs": "KnockPort's scripting realm \u2014 `createRealmWithHost` in packages/engine/src/scripting-core.ts. The page's own engine.",
+    "quickJs": "tropel's script realm \u2014 the shim bundle over tropel-js, used by every load run and by POST /script."
   },
   "probes": [
-    { "name": "fetch", "expression": "typeof fetch", "hostJs": "function", "quickJs": "undefined",
-      "why": "A script calling fetch() directly works in the app and throws under load. The supported path is pm.sendRequest, which both realms bridge to the host transport." },
-    { "name": "crypto", "expression": "typeof crypto", "hostJs": "object", "quickJs": "undefined",
-      "why": "No WebCrypto in QuickJS. Signing belongs to tropel-auth, reached through the shims; a script reaching for crypto directly is reaching past the seam." },
-    { "name": "crypto.randomUUID", "expression": "typeof crypto !== 'undefined' && typeof crypto.randomUUID", "hostJs": "function", "quickJs": "false",
-      "why": "The commonest way a script mints a request id. Use {{$guid}} or pm.variables — the dynamic catalogue is the same Rust in both realms." },
-    { "name": "TextEncoder", "expression": "typeof TextEncoder", "hostJs": "function", "quickJs": "undefined", "why": "A browser global." },
-    { "name": "Intl", "expression": "typeof Intl", "hostJs": "object", "quickJs": "undefined",
-      "why": "No Intl in QuickJS, so toLocaleString and friends format differently. Date and number formatting in a script is a real divergence, not a theoretical one." },
-    { "name": "setTimeout", "expression": "typeof setTimeout", "hostJs": "function", "quickJs": "undefined",
-      "why": "There is no event loop to schedule onto in the script realm. A script that awaits a timer hangs in the app and throws under load." },
-    { "name": "structuredClone", "expression": "typeof structuredClone", "hostJs": "function", "quickJs": "undefined", "why": "A browser global." },
-    { "name": "URL", "expression": "typeof URL", "hostJs": "function", "quickJs": "undefined",
-      "why": "URL parsing in a script diverges. The resolver's own URL handling is tropel's and is identical in both realms." },
-    { "name": "error.stack contains the message", "expression": "(() => { try { null.x; } catch (e) { return String(e.stack).indexOf(String(e.message)) >= 0 ? 'yes' : 'no'; } })()", "hostJs": "yes", "quickJs": "no",
-      "why": "QuickJS's stack carries frames only. `e.stack || e.message` therefore LOSES the message in one realm and not the other — this exact shape swallowed a script error during KT-203 and is why the agent reports message-first." },
-    { "name": "localStorage", "expression": "typeof localStorage", "hostJs": "undefined", "quickJs": "undefined",
-      "why": "Absent in BOTH. Recorded because agreeing is worth pinning too: this is not a divergence and must not become one." },
-    { "name": "console", "expression": "typeof console", "hostJs": "object", "quickJs": "object", "why": "Both realms install console." },
-    { "name": "btoa", "expression": "typeof btoa", "hostJs": "function", "quickJs": "function", "why": "Both." },
-    { "name": "BigInt", "expression": "typeof BigInt", "hostJs": "function", "quickJs": "function", "why": "Both." },
-    { "name": "Array.prototype.at", "expression": "typeof [].at", "hostJs": "function", "quickJs": "function", "why": "ES2022 — both." },
-    { "name": "String.prototype.replaceAll", "expression": "typeof ''.replaceAll", "hostJs": "function", "quickJs": "function", "why": "ES2021 — both." },
-    { "name": "Object.hasOwn", "expression": "typeof Object.hasOwn", "hostJs": "function", "quickJs": "function", "why": "ES2022 — both." },
-    { "name": "Promise.allSettled", "expression": "typeof Promise.allSettled", "hostJs": "function", "quickJs": "function", "why": "ES2020 — both." },
-    { "name": "regexp lookbehind", "expression": "(() => { try { new RegExp('(?<=a)b'); return 'ok'; } catch (e) { return 'unsupported'; } })()", "hostJs": "ok", "quickJs": "ok",
-      "why": "QuickJS's libregexp supports lookbehind. Worth pinning: the regex engines genuinely differ, so agreement here is a measurement, not an assumption." },
-    { "name": "regexp named groups", "expression": "(() => { try { return 'x'.match(/(?<n>x)/).groups.n; } catch (e) { return 'unsupported'; } })()", "hostJs": "x", "quickJs": "x", "why": "Both." },
-    { "name": "pm", "expression": "typeof pm", "hostJs": "object", "quickJs": "object", "why": "The Postman-compat surface, in both." },
-    { "name": "bru", "expression": "typeof bru", "hostJs": "object", "quickJs": "object",
-      "why": "The Bruno-compat surface. This probe FOUND A BUG: POST /script hand-rolled its shim list (k6-core + pm only) instead of using ShimBundle::default(), so `bru` was undefined on the agent and an object in the app — a Bruno-style script worked in KnockPort and failed on desktop. js_bootstrap.rs exists because that exact defect happened once before ('bru.js was compiled into the binary but NEVER evaluated'); re-deriving the list in agent.rs re-opened it one endpoint over. Fixed in TR-465." }
+    {
+      "name": "fetch",
+      "expression": "typeof fetch",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "CLOSED by TR-475. The QuickJS realm now has `fetch`, bridged to the SAME host client `pm.sendRequest` rides \u2014 one network path out of the realm, not two that can disagree. Kept as a probe precisely because the two realms AGREEING here is a property worth pinning; it was a divergence until it was measured and fixed."
+    },
+    {
+      "name": "crypto",
+      "expression": "typeof crypto",
+      "hostJs": "object",
+      "quickJs": "undefined",
+      "why": "No WebCrypto in QuickJS. Signing belongs to tropel-auth, reached through the shims; a script reaching for crypto directly is reaching past the seam."
+    },
+    {
+      "name": "crypto.randomUUID",
+      "expression": "typeof crypto !== 'undefined' && typeof crypto.randomUUID",
+      "hostJs": "function",
+      "quickJs": "false",
+      "why": "The commonest way a script mints a request id. Use {{$guid}} or pm.variables \u2014 the dynamic catalogue is the same Rust in both realms."
+    },
+    {
+      "name": "TextEncoder",
+      "expression": "typeof TextEncoder",
+      "hostJs": "function",
+      "quickJs": "undefined",
+      "why": "A browser global."
+    },
+    {
+      "name": "Intl",
+      "expression": "typeof Intl",
+      "hostJs": "object",
+      "quickJs": "undefined",
+      "why": "No Intl in QuickJS, so toLocaleString and friends format differently. Date and number formatting in a script is a real divergence, not a theoretical one."
+    },
+    {
+      "name": "setTimeout",
+      "expression": "typeof setTimeout",
+      "hostJs": "function",
+      "quickJs": "undefined",
+      "why": "There is no event loop to schedule onto in the script realm. A script that awaits a timer hangs in the app and throws under load."
+    },
+    {
+      "name": "structuredClone",
+      "expression": "typeof structuredClone",
+      "hostJs": "function",
+      "quickJs": "undefined",
+      "why": "A browser global."
+    },
+    {
+      "name": "URL",
+      "expression": "typeof URL",
+      "hostJs": "function",
+      "quickJs": "undefined",
+      "why": "URL parsing in a script diverges. The resolver's own URL handling is tropel's and is identical in both realms."
+    },
+    {
+      "name": "error.stack contains the message",
+      "expression": "(() => { try { null.x; } catch (e) { return String(e.stack).indexOf(String(e.message)) >= 0 ? 'yes' : 'no'; } })()",
+      "hostJs": "yes",
+      "quickJs": "no",
+      "why": "QuickJS's stack carries frames only. `e.stack || e.message` therefore LOSES the message in one realm and not the other \u2014 this exact shape swallowed a script error during KT-203 and is why the agent reports message-first."
+    },
+    {
+      "name": "localStorage",
+      "expression": "typeof localStorage",
+      "hostJs": "undefined",
+      "quickJs": "undefined",
+      "why": "Absent in BOTH. Recorded because agreeing is worth pinning too: this is not a divergence and must not become one."
+    },
+    {
+      "name": "console",
+      "expression": "typeof console",
+      "hostJs": "object",
+      "quickJs": "object",
+      "why": "Both realms install console."
+    },
+    {
+      "name": "btoa",
+      "expression": "typeof btoa",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "Both."
+    },
+    {
+      "name": "BigInt",
+      "expression": "typeof BigInt",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "Both."
+    },
+    {
+      "name": "Array.prototype.at",
+      "expression": "typeof [].at",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "ES2022 \u2014 both."
+    },
+    {
+      "name": "String.prototype.replaceAll",
+      "expression": "typeof ''.replaceAll",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "ES2021 \u2014 both."
+    },
+    {
+      "name": "Object.hasOwn",
+      "expression": "typeof Object.hasOwn",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "ES2022 \u2014 both."
+    },
+    {
+      "name": "Promise.allSettled",
+      "expression": "typeof Promise.allSettled",
+      "hostJs": "function",
+      "quickJs": "function",
+      "why": "ES2020 \u2014 both."
+    },
+    {
+      "name": "regexp lookbehind",
+      "expression": "(() => { try { new RegExp('(?<=a)b'); return 'ok'; } catch (e) { return 'unsupported'; } })()",
+      "hostJs": "ok",
+      "quickJs": "ok",
+      "why": "QuickJS's libregexp supports lookbehind. Worth pinning: the regex engines genuinely differ, so agreement here is a measurement, not an assumption."
+    },
+    {
+      "name": "regexp named groups",
+      "expression": "(() => { try { return 'x'.match(/(?<n>x)/).groups.n; } catch (e) { return 'unsupported'; } })()",
+      "hostJs": "x",
+      "quickJs": "x",
+      "why": "Both."
+    },
+    {
+      "name": "pm",
+      "expression": "typeof pm",
+      "hostJs": "object",
+      "quickJs": "object",
+      "why": "The Postman-compat surface, in both."
+    },
+    {
+      "name": "bru",
+      "expression": "typeof bru",
+      "hostJs": "object",
+      "quickJs": "object",
+      "why": "The Bruno-compat surface. This probe FOUND A BUG: POST /script hand-rolled its shim list (k6-core + pm only) instead of using ShimBundle::default(), so `bru` was undefined on the agent and an object in the app \u2014 a Bruno-style script worked in KnockPort and failed on desktop. js_bootstrap.rs exists because that exact defect happened once before ('bru.js was compiled into the binary but NEVER evaluated'); re-deriving the list in agent.rs re-opened it one endpoint over. Fixed in TR-465."
+    }
   ]
 }

--- a/packages/shims/scripts/build.sh
+++ b/packages/shims/scripts/build.sh
@@ -12,6 +12,7 @@ cp ../../js/shared/deep-equal.js shim/deep-equal.js
 cp ../../js/shared/k6-core.js shim/k6-core.js
 cp ../../js/scripting-api/pm.js shim/pm.js
 cp ../../js/scripting-api/bru.js shim/bru.js
+cp ../../js/scripting-api/fetch.js shim/fetch.js
 cp ../../js/chai/chai-shim.js shim/chai-shim.js
 cp ../../js/lodash/lodash-shim.js shim/lodash-shim.js
 cp ../../js/cryptojs-shim/cryptojs.js shim/cryptojs.js
@@ -20,7 +21,7 @@ cp ../../js/k6-shim/k6-shim.js shim/k6-shim.js
 cp ../../js/k6-shim/jslib-shim.js shim/jslib-shim.js
 cp ../../js/k6-shim/open-data-shim.js shim/open-data-shim.js
 cp ../../js/k6-shim/sleep-shim.js shim/sleep-shim.js
-echo "  copied 11 shim sources from ../../js/"
+echo "  copied 12 shim sources from ../../js/"
 
 # ── 2. Render the ESM bundle + types ──────────────────────────────────────
 node scripts/render-bundle.mjs

--- a/packages/shims/scripts/render-bundle.mjs
+++ b/packages/shims/scripts/render-bundle.mjs
@@ -24,6 +24,7 @@ const DEFAULT_ORDER = [
   ["cryptojs-shim", "shim/cryptojs.js"],
   ["exec-shim", "shim/exec.js"],
   ["bru-shim", "shim/bru.js"],
+  ["fetch-shim", "shim/fetch.js"],
 ];
 
 // The k6 family — used by the k6 input driver, not part of the PM default
@@ -76,7 +77,7 @@ export interface ShimEntry {
   source: string;
 }
 
-/** The engine's ShimBundle::default() — pm, chai, lodash, cryptojs, exec, bru, in order. */
+/** The engine's ShimBundle::default() — pm, chai, lodash, cryptojs, exec, bru, fetch, in order. */
 export declare const defaultBundle: ShimEntry[];
 /** The k6 input-driver family: k6-shim, open-data-shim, sleep-shim. */
 export declare const k6Bundle: ShimEntry[];

--- a/packages/shims/smoke.mjs
+++ b/packages/shims/smoke.mjs
@@ -86,6 +86,7 @@ const DEFAULT_ORDER = [
   ["cryptojs-shim", "js/cryptojs-shim/cryptojs.js"],
   ["exec-shim", "js/exec/exec.js"],
   ["bru-shim", "js/scripting-api/bru.js"],
+  ["fetch-shim", "js/scripting-api/fetch.js"],
 ];
 const K6_ORDER = [
   ["k6-shim", "js/k6-shim/k6-shim.js"],


### PR DESCRIPTION
QuickJS ships no `fetch`, so a script written the way every modern one is written — `await fetch(...)` — died on a bare `ReferenceError`, while the identical call spelled `pm.sendRequest` worked. **Two spellings of one capability, one of which was a crash.**

Not a new transport. It's the same `__tropel_trp_send_request` binding the agent got a client for in #569, wearing the interface people expect — so a script's fetch inherits the same posture, and there's **one** network path out of the realm rather than two that can disagree.

The binding is checked at **call** time, never eval time: the bundle is evaluated *before* the bridge is installed, so an eval-time `typeof` is always `"undefined"` and would leave `fetch` permanently unset. `pm.js` defers the same check for the same reason. It also never shadows a real `fetch`.

### The corpus is re-measured, not edited around

`fetch` was one of the nine committed divergences — *"works in the app and throws under load"*. It's **closed** now, and the fixture says so. The probe stays: the two realms agreeing there is a property worth pinning.

### The escape test drops `fetch`, deliberately

#566 listed it among capabilities that must be unreachable. That was asserting an isolation **the realm never had** — `pm.sendRequest` predates that test and has always been a way out.

What remains is the set that reaches the *host process*: the module loader, `process`, and the Function-constructor route to a global. A guarded HTTP call is not an escape, and claiming it was made the test say something false.

### Three lists had to move together

`Shim::ALL`, `render-bundle.mjs`, and `smoke.mjs`. The last is a cross-check that **failed the build** until it did:

```
Error: shim bundle list has drifted from Shim::ALL
  missing here: fetch-shim
```

Which is exactly why it exists — `js_bootstrap`'s own history is two hand-maintained shim lists drifting until `bru.js` was compiled in and never evaluated.

### Measured against a live agent

```
await fetch("https://jsonplaceholder.typicode.com/todos/1")
  -> status 200, ok true, content-type application/json
  -> await r.json() -> "delectus aut autem"
```

83 engine tests + the shims cross-check pass; clippy clean.