### PR TITLE
feat(shims): bru.getTestResults answers; getAssertionResults refuses by name  [KT-404 / TR-478]

### DIFF
--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -3507,6 +3507,75 @@ mod tests {
         );
     }
 
+    /// TR-478: `bru.getTestResults` answers; `getAssertionResults` refuses.
+    ///
+    /// Both lived only in the API client's own prelude, so a script calling
+    /// either worked in the app and died on a bare ReferenceError here — the
+    /// same one-script-two-answers split `fetch` had before TR-475.
+    ///
+    /// Only ONE of them can live here, and the asymmetry is the point:
+    /// `getTestResults` reports what THIS realm recorded, which is ours to
+    /// answer. `getAssertionResults` evaluates the caller's declarative
+    /// assertion grammar through its operator table — a vocabulary this
+    /// runtime does not have, and re-implementing it would be a second
+    /// semantics for one language.
+    ///
+    /// So the second REFUSES BY NAME. An empty array would be an answer —
+    /// "nothing failed" — and would be a lie.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_results_answer_and_assertion_results_refuse() {
+        let out = run_script_once(
+            "kp.test('first', function () {});\
+             kp.test('second', function () { throw new Error('no'); });\
+             var r = bru.getTestResults();\
+             kp.environment.set('count', String(r.length));\
+             kp.environment.set('shape', r.map(function (x) { return x.name + ':' + x.passed; }).join(','));",
+            ScriptScopes::default(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig {
+                namespace: "kp".into(),
+                aliases: Vec::new(),
+            },
+            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+        )
+        .await
+        .expect("the realm runs");
+
+        let env = out.get("environment").expect("environment comes back");
+        assert_eq!(
+            env.get("count").and_then(|v| v.as_str()),
+            Some("2"),
+            "both checks must be reported, not just the passing one: {out}"
+        );
+        assert_eq!(
+            env.get("shape").and_then(|v| v.as_str()),
+            Some("first:true,second:false"),
+            "each result must carry its own name AND outcome — a count alone \
+             cannot tell a passing suite from a failing one: {out}"
+        );
+
+        let refused = run_script_once(
+            "bru.getAssertionResults();",
+            ScriptScopes::default(),
+            None,
+            None,
+            tropel_sandbox::config::SandboxConfig::default(),
+            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+        )
+        .await
+        .expect("the realm runs");
+        let err = refused
+            .get("scriptError")
+            .and_then(|e| e.as_str())
+            .unwrap_or("");
+        assert!(
+            err.contains("not available here"),
+            "it must refuse by NAME rather than return an empty list, which would \
+             read as \"no assertions failed\": {refused}"
+        );
+    }
+
     /// TR-476: the cookie jar round-trips, and refuses when absent.
     ///
     /// Three properties in one, because they only mean anything together:

--- a/crates/tropel-sandbox/src/bindings/trp.rs
+++ b/crates/tropel-sandbox/src/bindings/trp.rs
@@ -1000,6 +1000,40 @@ impl TrpBridge {
                 }),
             );
 
+            // ── Test results (TR-478) ──
+            //
+            // The checks THIS realm has recorded so far, as JSON. Lives here
+            // rather than in the agent so a LOAD RUN answers it too: the API
+            // client's prelude had `bru.getTestResults`, so a script calling
+            // it worked in the app and died on a bare ReferenceError
+            // everywhere else — the same split `fetch` had.
+            //
+            // Read at CALL time from the sample stream, which is the same
+            // place the run's own reporting reads them from. Keeping a second
+            // list in step with that one is the drift invariant 3 forbids.
+            let state_for_results = state.clone();
+            set_global!(
+                "__tropel_trp_get_test_results",
+                Func::from(move || -> String {
+                    let st = match state_for_results.lock() {
+                        Ok(g) => g,
+                        Err(e) => e.into_inner(),
+                    };
+                    let rows: Vec<serde_json::Value> = st
+                        .samples
+                        .iter()
+                        .filter(|s| s.metric == "checks")
+                        .map(|s| {
+                            serde_json::json!({
+                                "name": s.tags.get("check").unwrap_or_default(),
+                                "passed": s.value != 0.0,
+                            })
+                        })
+                        .collect();
+                    serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+                }),
+            );
+
             // ── Test ──
             let state_clone = state.clone();
             set_global!(

--- a/js/scripting-api/bru.js
+++ b/js/scripting-api/bru.js
@@ -256,6 +256,52 @@
         }
     };
 
+    // ── bru.getTestResults / bru.getAssertionResults (TR-478) ───────────────
+    //
+    // These existed only in the API client's own prelude, so a script calling
+    // either worked in the app and died on a bare ReferenceError under a load
+    // run and on the agent tier — the same one-script-two-answers split
+    // `fetch` had before TR-475.
+    //
+    // They are NOT the same kind of thing, and only one of them can live here:
+    //
+    //   getTestResults      — the checks THIS realm recorded. Ours to answer.
+    //   getAssertionResults — evaluates the caller's DECLARATIVE assertion
+    //                         grammar (`status eq 200`, `jsonpath(...) exists`)
+    //                         through its operator table. That table is the
+    //                         API client's vocabulary and does not exist here;
+    //                         re-implementing it would be a second semantics
+    //                         for one language, which is the drift invariant 3
+    //                         forbids.
+    //
+    // So the second REFUSES BY NAME rather than returning an empty array. An
+    // empty array is an answer — "no assertions failed" — and would be a lie.
+    bru.getTestResults = function () {
+        if (typeof __tropel_trp_get_test_results !== 'function') {
+            throw new Error(
+                'bru.getTestResults is not available here: this realm records no test ' +
+                'results (tropel TR-478).'
+            );
+        }
+        var raw = __tropel_trp_get_test_results();
+        try {
+            return JSON.parse(raw) || [];
+        } catch (e) {
+            throw new Error('bru.getTestResults: the host answered with invalid JSON: ' + raw);
+        }
+    };
+
+    bru.getAssertionResults = function () {
+        throw new Error(
+            'bru.getAssertionResults is not available here. It evaluates the API ' +
+            'client\'s declarative assertion grammar through its operator table, which ' +
+            'this runtime does not have — and implementing a second copy of that ' +
+            'grammar is exactly the drift it exists to avoid. Use bru.getTestResults() ' +
+            'for the checks this realm recorded, or run the assertions on the caller ' +
+            'side (tropel TR-478).'
+        );
+    };
+
     // ── bru.cookies (TR-476) ────────────────────────────────────────────────
     //
     // The cookie jar surface. This shim shipped WITHOUT one for a long time —


### PR DESCRIPTION
Both existed **only in the API client's own prelude**, so a script calling either worked in the app and died on a bare `ReferenceError` on the agent tier — the same one-script-two-answers split `fetch` had before #572.

### Only one of them can live here, and the asymmetry is the point

**`getTestResults`** reports the checks *this* realm recorded. That's ours to answer, so it does — read at call time from the sample stream, the same place the run's own reporting reads them from. A second list kept "in step" with that one is the drift invariant 3 forbids.

**`getAssertionResults`** evaluates the caller's **declarative assertion grammar** (`status eq 200`, `jsonpath(...) exists`) through its operator table. That table is the API client's vocabulary and doesn't exist here. Implementing a copy would be a second semantics for one language — the exact failure this review has spent its time removing.

So it **refuses by name** and says where the capability lives. An empty array would have been an *answer* — "nothing failed" — and a lie.

The binding sits in `TrpBridge` rather than the agent, so it's reachable wherever `bru` is, not only over the socket.

### Verified on the agent, not inferred

```
kp.test('first',  …)          -> passes
kp.test('second', …) throws   -> fails
bru.getTestResults()          -> "first:true,second:false"
```

Each result carries its own name **and** outcome, because a count alone can't tell a passing suite from a failing one.

### Not verified in a load run — stating that plainly

A Postman collection has no `bru` at all (its bundle excludes it deliberately: *"a Postman collection has no syntax that produces it"*), and my `.bru` fixture ran its 18 requests but never executed its `tests` block. That path proved nothing, so I'm not claiming it.

89 tests pass; clippy clean; the shims cross-check passes.