### PR TITLE
feat(input-bru): keep the disabled entries, vars, settings and assertions

### DIFF
--- a/crates/inputs/tropel-input-bru/src/lib.rs
+++ b/crates/inputs/tropel-input-bru/src/lib.rs
@@ -18,8 +18,11 @@
 //! | item with `type: "folder"` | nested `ScenarioItem` (folders) |
 //! | item with `type: "http-request"` or `"http"` (export spelling) | `ScenarioItem.request` |
 //! | `request.url` / `request.method` | `request.url` / `request.method` |
-//! | `request.headers` (disabled dropped) | `request.headers` |
-//! | `request.params` (`type: "query"`, disabled dropped) | `request.query_params` |
+//! | `request.headers` (enabled only) | `request.headers` |
+//! | `request.params` (`type: "query"`, enabled only) | `request.query_params` |
+//! | `request.headers` / `params` — ALL of them, disabled included | `ScenarioItem.authoring.headers` / `.query` |
+//! | `vars:pre-request` | `ScenarioItem.authoring.vars` |
+//! | the `settings` block | `ScenarioItem.authoring.settings` |
 //! | `request.auth` | `request.auth` |
 //! | `request.body` (by `mode`) | `request.body` |
 //! | `request.script` pre/post | `ScenarioItem.prerequest` / `test` |
@@ -41,6 +44,7 @@ use std::collections::HashMap;
 use tropel_sdk::{ApiKeyLocation, AuthConfig, Body, FormDataPart, Method, Request};
 use tropel_sdk::{InputAdapter, InputAdapterRegistration};
 use tropel_sdk::{Result, TropelError};
+use tropel_sdk::{AuthoredEntry, AuthoredSettings, RequestAuthoring};
 use tropel_sdk::{Scenario, ScenarioInfo, ScenarioItem};
 
 // ── Bruno collection JSON model (minimal — only what we need) ────
@@ -69,6 +73,11 @@ struct BruItem {
     request: Option<BruRequest>,
     #[serde(default)]
     items: Vec<BruItem>,
+    /// Already-resolved assertion expressions. The `.bru` text path turns
+    /// Bruno's `res.status: eq 200` into one here; Bruno's JSON export has no
+    /// equivalent field, so it stays empty there.
+    #[serde(default)]
+    assertions: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -87,6 +96,15 @@ struct BruRequest {
     body: Option<BruBody>,
     #[serde(default)]
     script: Option<BruScript>,
+    /// `vars:pre-request` — request-local variables. Authoring state: the
+    /// runtime resolves variables from the scenario's own environment, so
+    /// these have no `Request` field and ride on `authoring` instead.
+    #[serde(default)]
+    vars: Vec<BruKeyValue>,
+    /// The `settings` block, as raw strings — Bruno writes `timeout: 3000`
+    /// and `encodeUrl: false` untyped.
+    #[serde(default)]
+    settings: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -325,6 +343,7 @@ fn build_items(items: &[BruItem], notes: &mut Vec<String>) -> Vec<ScenarioItem> 
     for item in items {
         match item.r#type.as_deref() {
             Some("folder") => out.push(ScenarioItem {
+                authoring: None,
                 name: item.name.clone().unwrap_or_else(|| "Folder".into()),
                 id: None,
                 request: None,
@@ -373,6 +392,28 @@ fn build_items(items: &[BruItem], notes: &mut Vec<String>) -> Vec<ScenarioItem> 
 }
 
 /// Map a single Bruno http-request item to a ScenarioItem.
+/// Bruno's `settings` block, which is untyped text, into typed authoring state.
+///
+/// Unparseable values are DROPPED rather than defaulted: `timeout: soon` is a
+/// mistake in the user's file, and inventing `0` for it would silently change
+/// what the request means.
+fn build_settings(raw: &HashMap<String, String>) -> Option<AuthoredSettings> {
+    if raw.is_empty() {
+        return None;
+    }
+    let flag = |k: &str| raw.get(k).and_then(|v| v.parse::<bool>().ok());
+    let settings = AuthoredSettings {
+        timeout: raw.get("timeout").and_then(|v| v.parse::<u64>().ok()),
+        encode_url: flag("encodeUrl"),
+        follow_redirects: flag("followRedirects"),
+        max_redirects: raw.get("maxRedirects").and_then(|v| v.parse::<u32>().ok()),
+    };
+    if settings == AuthoredSettings::default() {
+        return None;
+    }
+    Some(settings)
+}
+
 fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
     let request = item.request.as_ref().ok_or_else(|| {
         TropelError::Parse(format!(
@@ -427,6 +468,86 @@ fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
         }
     }
 
+    // ── What the user WROTE ─────────────────────────────────────────────────
+    //
+    // Everything above builds what gets SENT, and drops what does not: a
+    // `~name:` header, a disabled parameter, a var block with no runtime
+    // meaning. An API client has to be able to show the user that header and
+    // let them switch it back on, so it is carried beside the request rather
+    // than folded into it.
+    //
+    // The URL is left exactly as written. Splitting `?page=2` out of it here
+    // would change what the RUNTIME sends — the HTTP client re-appends
+    // `query_params`, so moving the pair across would only be neutral if every
+    // consumer agreed, and one that did not would silently drop the query.
+    // The authored list carries both the inline pairs and the block's, and the
+    // reader decides how to present them.
+    let mut query: Vec<AuthoredEntry> = Vec::new();
+    if let Some((_, qs)) = request.url.split_once('?') {
+        for pair in qs.split('&').filter(|s| !s.is_empty()) {
+            let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+            query.push(AuthoredEntry {
+                key: k.to_string(),
+                value: v.to_string(),
+                enabled: true,
+            });
+        }
+    }
+    query.extend(
+        request
+            .params
+            .iter()
+            .filter(|p| p.param_type.as_deref() == Some("query"))
+            .filter_map(|p| {
+                Some(AuthoredEntry {
+                    key: p.name.clone()?,
+                    value: p.value.clone().unwrap_or_default(),
+                    enabled: p.enabled.unwrap_or(true),
+                })
+            }),
+    );
+
+    let authored_headers: Vec<AuthoredEntry> = request
+        .headers
+        .iter()
+        .filter_map(|h| {
+            Some(AuthoredEntry {
+                key: h.name.clone()?,
+                value: h.value.clone().unwrap_or_default(),
+                enabled: h.enabled.unwrap_or(true),
+            })
+        })
+        .collect();
+
+    let vars: Vec<AuthoredEntry> = request
+        .vars
+        .iter()
+        .filter_map(|v| {
+            Some(AuthoredEntry {
+                key: v.name.clone()?,
+                value: v.value.clone().unwrap_or_default(),
+                enabled: v.enabled.unwrap_or(true),
+            })
+        })
+        .collect();
+
+    let settings = build_settings(&request.settings);
+
+    let authoring = if authored_headers.is_empty()
+        && query.is_empty()
+        && vars.is_empty()
+        && settings.is_none()
+    {
+        None
+    } else {
+        Some(RequestAuthoring {
+            headers: authored_headers,
+            query,
+            vars,
+            settings,
+        })
+    };
+
     let body = request.body.as_ref().and_then(build_body);
     let auth = request.auth.as_ref().and_then(build_auth);
 
@@ -446,6 +567,7 @@ fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
         .unwrap_or_default();
 
     Ok(ScenarioItem {
+        authoring,
         name: item
             .name
             .clone()
@@ -467,7 +589,7 @@ fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
         }),
         prerequest,
         test,
-        assertions: vec![],
+        assertions: item.assertions.clone(),
         items: vec![],
     })
 }
@@ -1284,16 +1406,50 @@ mod bru_text_format {
     }
 
     #[test]
-    fn dropped_blocks_are_reported_rather_than_silently_lost() {
-        // GET_USER carries an `assert` block and a `docs` block. The Scenario
-        // model has no field for assertions, and "the import worked" must not
-        // look identical to "the import worked and dropped your assertions".
+    fn assertions_are_carried_now_rather_than_reported_as_dropped() {
+        // GET_USER carries an `assert` block. It used to be reported as
+        // dropped, because `Scenario` had no field for it — untrue since the
+        // expressions land on `ScenarioItem.assertions`. A note claiming a
+        // loss that did not happen is its own defect: it teaches the reader to
+        // ignore the notes.
         let s = BruInputAdapter.parse(GET_USER.as_bytes()).expect("parses");
         let notes = format!("{:?}", s.conversion_notes);
         assert!(
-            notes.contains("assertions"),
-            "the dropped assert block must be reported: {notes}"
+            !notes.contains("assertions"),
+            "assert is carried now, so it must not be reported as dropped: {notes}"
         );
+        assert_eq!(
+            s.items[0].assertions,
+            vec!["response.status === 200".to_string()],
+            "res.status: eq 200 → a test-realm expression"
+        );
+    }
+
+    #[test]
+    fn a_disabled_assertion_is_not_imported() {
+        // `~` on an assert pair means "do not run this". Importing it as an
+        // enabled expression would invent a check the user switched off.
+        let doc = "meta {\n  name: A\n}\n\nget {\n  url: https://e.com\n}\n\nassert {\n  ~res.status: eq 200\n  res.body.ok: eq true\n}\n";
+        let s = BruInputAdapter.parse(doc.as_bytes()).expect("parses");
+        assert_eq!(s.items[0].assertions, vec!["response.body.ok === true".to_string()]);
+    }
+
+    #[test]
+    fn an_unknown_assert_operator_fails_the_import() {
+        // Not a skip: an assertion that can never run looks exactly like one
+        // that passes.
+        let doc = "meta {\n  name: A\n}\n\nget {\n  url: https://e.com\n}\n\nassert {\n  res.status: teleports 200\n}\n";
+        let err = BruInputAdapter.parse(doc.as_bytes()).unwrap_err().to_string();
+        assert!(err.contains("teleports"), "{err}");
+    }
+
+    #[test]
+    fn blocks_with_no_home_are_still_reported() {
+        // The channel must keep working for what genuinely has nowhere to go.
+        let doc = "meta {\n  name: A\n}\n\nget {\n  url: https://e.com\n}\n\nvars:post-response {\n  token: res.body.t\n}\n";
+        let s = BruInputAdapter.parse(doc.as_bytes()).expect("parses");
+        let notes = format!("{:?}", s.conversion_notes);
+        assert!(notes.contains("post-response"), "{notes}");
     }
 
     #[test]
@@ -1312,5 +1468,88 @@ mod bru_text_format {
             .unwrap_err()
             .to_string();
         assert!(err.contains("no method block"), "{err}");
+    }
+
+    // ── Authoring fidelity (what the user WROTE) ────────────────────────────
+    //
+    // The runtime `Request` deliberately carries only what gets sent. These
+    // pin the other half: an API client has to show a disabled header and let
+    // the user switch it back on, and before `authoring` existed the importer
+    // recorded these blocks in `conversion_notes` as having nowhere to go.
+
+    fn only_item(src: &str) -> ScenarioItem {
+        let s = BruInputAdapter.parse(src.as_bytes()).unwrap();
+        s.items.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn authoring_keeps_the_disabled_header_the_request_drops() {
+        let item = only_item(GET_USER);
+        let a = item.authoring.as_ref().expect("authoring");
+
+        // What is SENT still excludes it — this is not a behaviour change.
+        let req = item.request.as_ref().unwrap();
+        assert!(
+            !req.headers.iter().any(|(k, _)| k == "x-draft"),
+            "a ~disabled header must never reach the wire: {:?}",
+            req.headers
+        );
+
+        let draft = a.headers.iter().find(|e| e.key == "x-draft").expect("~x-draft");
+        assert_eq!(draft.value, "true");
+        assert!(!draft.enabled, "the ~ prefix means disabled, not absent");
+        let accept = a.headers.iter().find(|e| e.key == "accept").expect("accept");
+        assert!(accept.enabled);
+    }
+
+    #[test]
+    fn authoring_query_carries_the_inline_url_pairs_and_the_block() {
+        let item = only_item(GET_USER);
+        let a = item.authoring.as_ref().expect("authoring");
+
+        // `?page=2` is written inline in the url; `limit` in the query block.
+        // The authored view is BOTH, in that order.
+        let keys: Vec<&str> = a.query.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(keys, vec!["page", "limit"]);
+        assert_eq!(a.query[0].value, "2");
+        assert_eq!(a.query[1].value, "10");
+
+        // The url is left exactly as written: moving the pair out would change
+        // what the runtime sends, because the client re-appends query_params.
+        let req = item.request.as_ref().unwrap();
+        assert!(req.url.ends_with("?page=2"), "{}", req.url);
+    }
+
+    #[test]
+    fn authoring_carries_pre_request_vars_and_settings() {
+        let item = only_item(POST_LOGIN);
+        let a = item.authoring.as_ref().expect("authoring");
+
+        let vars: Vec<(&str, &str)> = a.vars.iter().map(|v| (v.key.as_str(), v.value.as_str())).collect();
+        // The `@` marker is Bruno's "request-local" prefix and is not part of
+        // the name.
+        assert_eq!(vars, vec![("requestId", "req-1"), ("baseUrl", "https://api.example.com")]);
+
+        let st = a.settings.as_ref().expect("settings");
+        assert_eq!(st.timeout, Some(3000));
+        assert_eq!(st.encode_url, Some(false));
+    }
+
+    #[test]
+    fn the_dropped_note_is_gone_for_blocks_that_now_have_a_home() {
+        let s = BruInputAdapter.parse(POST_LOGIN.as_bytes()).unwrap();
+        let notes = s.conversion_notes.join("\n");
+        assert!(
+            !notes.contains("request-local variables") && !notes.contains("request settings"),
+            "these are carried now, so claiming they were dropped is a lie: {notes}"
+        );
+    }
+
+    #[test]
+    fn a_request_with_nothing_authored_carries_no_sidecar() {
+        // Absent, not an empty object: every existing Scenario must serialize
+        // byte-identically to before.
+        let item = only_item("meta {\n  name: Bare\n}\n\nget {\n  url: https://example.com\n}\n");
+        assert!(item.authoring.is_none(), "{:?}", item.authoring);
     }
 }

--- a/crates/inputs/tropel-input-bru/src/text.rs
+++ b/crates/inputs/tropel-input-bru/src/text.rs
@@ -246,6 +246,84 @@ fn find<'a>(blocks: &'a [Block], name: &str) -> Option<&'a Block> {
 }
 
 /// Enabled + disabled pairs as `[{name, value, enabled}]`.
+/// A Bruno `assert` pair → one JS expression, evaluated in the test realm with
+/// `response` in scope.
+///
+/// Bruno writes assertions as `res.status: eq 200` — a path, an operator and an
+/// argument. `ScenarioItem.assertions` carries expressions, so the operator is
+/// resolved HERE rather than by each embedder: an operator table copied into
+/// two languages is the second implementation invariant #3 forbids, and it
+/// would drift silently because both sides would still "work".
+///
+/// An unknown operator is an ERROR, not a skip. Importing an assertion that
+/// can never run looks exactly like importing one that passes.
+fn assertion_expression(key: &str, raw_value: &str) -> Result<String, String> {
+    let expr = match key.strip_prefix("res.") {
+        Some(rest) => format!("response.{rest}"),
+        None => key.to_string(),
+    };
+    let trimmed = raw_value.trim();
+    let (op, arg) = match trimmed.split_once(char::is_whitespace) {
+        Some((o, a)) => (o, a.trim()),
+        None => ("eq", trimmed),
+    };
+    let lit = assertion_literal(arg);
+    let text = serde_json::to_string(arg).unwrap_or_else(|_| format!("{arg:?}"));
+    let list = || {
+        let inner: Vec<String> = arg.split(',').map(assertion_literal).collect();
+        format!("[{}]", inner.join(", "))
+    };
+    Ok(match op {
+        "eq" => format!("{expr} === {lit}"),
+        "neq" => format!("{expr} !== {lit}"),
+        "gt" => format!("{expr} > {lit}"),
+        "gte" => format!("{expr} >= {lit}"),
+        "lt" => format!("{expr} < {lit}"),
+        "lte" => format!("{expr} <= {lit}"),
+        "in" => format!("{}.includes({expr})", list()),
+        "notIn" => format!("!{}.includes({expr})", list()),
+        "contains" => format!("{expr}.includes({text})"),
+        "notContains" => format!("!{expr}.includes({text})"),
+        "startsWith" => format!("{expr}.startsWith({text})"),
+        "endsWith" => format!("{expr}.endsWith({text})"),
+        "matches" => format!("RegExp({text}).test({expr})"),
+        "minLength" => format!("{expr}.length >= {}", arg.trim()),
+        "maxLength" => format!("{expr}.length <= {}", arg.trim()),
+        "length" => format!("{expr}.length === {}", arg.trim()),
+        "isNumber" => format!("typeof {expr} === \"number\""),
+        "isString" => format!("typeof {expr} === \"string\""),
+        "isBoolean" => format!("typeof {expr} === \"boolean\""),
+        "isNull" => format!("{expr} === null"),
+        "isUndefined" => format!("{expr} === undefined"),
+        "isTruthy" => format!("!!{expr}"),
+        "isFalsy" => format!("!{expr}"),
+        "isEmpty" => format!("({expr} == null || String({expr}).length === 0)"),
+        "isNotEmpty" => format!("!({expr} == null || String({expr}).length === 0)"),
+        other => {
+            return Err(format!(
+                ".bru assert operator {other:?} ({key}: {raw_value}) has no Scenario equivalent — the document is not imported rather than silently dropping the assertion"
+            ))
+        }
+    })
+}
+
+/// A bare number, boolean, `null` or `undefined` stays literal; anything else
+/// becomes a JS string, so `eq 200` compares to the number and `eq ok` to the
+/// text.
+fn assertion_literal(value: &str) -> String {
+    let v = value.trim();
+    if !v.is_empty()
+        && v.parse::<f64>().is_ok()
+        && v.chars().all(|c| c.is_ascii_digit() || c == '.' || c == '-')
+    {
+        return v.to_string();
+    }
+    if matches!(v, "true" | "false" | "null" | "undefined") {
+        return v.to_string();
+    }
+    serde_json::to_string(v).unwrap_or_else(|_| format!("{v:?}"))
+}
+
 fn pairs_to_kv(block: &Block) -> Value {
     Value::Array(
         block
@@ -322,6 +400,26 @@ pub fn bru_text_to_json(text: &str, notes: &mut Vec<String>) -> Result<Value, St
         request.insert("body".into(), body);
     }
 
+    // Request-local variables and per-request settings. Both used to be listed
+    // by `note_dropped_blocks` as having "no field for the .bru block" — true
+    // of `Request`, which is what to SEND, and no longer true of
+    // `ScenarioItem.authoring`, which is what the user wrote. Carried in the
+    // export shape so the mapper reads them like any other block.
+    if let Some(v) = find(&blocks, "vars:pre-request") {
+        request.insert("vars".into(), pairs_to_kv(v));
+    }
+    if let Some(s) = find(&blocks, "settings") {
+        request.insert(
+            "settings".into(),
+            Value::Object(
+                s.pairs
+                    .iter()
+                    .map(|p| (p.key.clone(), json!(p.value)))
+                    .collect::<Map<String, Value>>(),
+            ),
+        );
+    }
+
     let mut script = Map::new();
     if let Some(b) = find(&blocks, "script:pre-request") {
         script.insert("req".into(), json!(b.text));
@@ -333,12 +431,28 @@ pub fn bru_text_to_json(text: &str, notes: &mut Vec<String>) -> Result<Value, St
         request.insert("script".into(), Value::Object(script));
     }
 
+    // The `assert` block → expressions on the ITEM, beside the scripts.
+    // A DISABLED assertion is not imported at all: `~` there means "do not
+    // run this", and carrying it as an enabled expression would invent a
+    // check the user had switched off.
+    let mut assertions: Vec<String> = Vec::new();
+    if let Some(b) = find(&blocks, "assert") {
+        for pair in b.pairs.iter().filter(|p| p.enabled) {
+            assertions.push(assertion_expression(&pair.key, &pair.value)?);
+        }
+    }
+
     note_dropped_blocks(&blocks, &name, notes);
 
     Ok(json!({
         "version": "1",
         "name": name,
-        "items": [{ "type": "http", "name": name, "request": Value::Object(request) }],
+        "items": [{
+            "type": "http",
+            "name": name,
+            "request": Value::Object(request),
+            "assertions": assertions,
+        }],
     }))
 }
 
@@ -480,10 +594,12 @@ fn build_body(
 fn note_dropped_blocks(blocks: &[Block], name: &str, notes: &mut Vec<String>) {
     for b in blocks {
         let dropped = match b.name.as_str() {
-            "assert" => "assertions",
-            "vars:pre-request" | "vars:post-response" => "request-local variables",
+            // `vars:pre-request` and `settings` are no longer here: they now
+            // ride on `ScenarioItem.authoring`. `vars:post-response` still is —
+            // it has no home, and claiming otherwise would be worse than the
+            // note, since a note is how a user finds out at all.
+            "vars:post-response" => "post-response variables",
             "tests" => "the tests block",
-            "settings" => "request settings",
             _ => continue,
         };
         if b.pairs.is_empty() && b.text.trim().is_empty() {

--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -356,6 +356,7 @@ fn har_entry_to_item(entry: HarEntry, index: usize) -> Result<ScenarioItem> {
     let body = entry.request.post_data.map(build_body);
 
     Ok(ScenarioItem {
+        authoring: None,
         name: item_name,
         id: None,
         request: Some(Request {

--- a/crates/inputs/tropel-input-http/src/lib.rs
+++ b/crates/inputs/tropel-input-http/src/lib.rs
@@ -270,6 +270,7 @@ fn block_to_item(
     let item_name = name_hint.unwrap_or_else(|| generate_item_name(&url, index));
 
     Ok(Some(ScenarioItem {
+        authoring: None,
         name: item_name,
         id: None,
         request: Some(Request {

--- a/crates/inputs/tropel-input-insomnia/src/lib.rs
+++ b/crates/inputs/tropel-input-insomnia/src/lib.rs
@@ -259,6 +259,7 @@ fn build_items(
             "request_group" => {
                 let id = r.id.clone().unwrap_or_default();
                 out.push(ScenarioItem {
+                    authoring: None,
                     name: r.name.clone().unwrap_or_else(|| "Folder".into()),
                     id: None,
                     request: None,
@@ -337,6 +338,7 @@ fn request_to_item(r: &InsomniaResource) -> Result<ScenarioItem> {
     let auth = r.authentication.as_ref().and_then(build_auth);
 
     Ok(ScenarioItem {
+        authoring: None,
         name: r
             .name
             .clone()

--- a/crates/inputs/tropel-input-k6/src/lib.rs
+++ b/crates/inputs/tropel-input-k6/src/lib.rs
@@ -137,6 +137,7 @@ fn build_scenario_from_source(js_code: &str, name: &str) -> Result<Scenario> {
             schema: None,
         },
         items: vec![ScenarioItem {
+            authoring: None,
             id: None,
             name: name.to_string(),
             request: None,

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -549,6 +549,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
             })?;
 
             items.push(ScenarioItem {
+                authoring: None,
                 name: item_name,
                 id: None,
                 request: Some(Request {

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -197,6 +197,9 @@ fn convert_items(
                     continue;
                 }
                 let scenario_item = ScenarioItem {
+                    // Postman's own model has no disabled-entry or
+                    // request-vars concept to carry here.
+                    authoring: None,
                     id: folder.id.clone(),
                     name: folder.name.clone().unwrap_or_default(),
                     request: None,
@@ -245,6 +248,9 @@ fn convert_request_item(
     events.extend(req.event.iter().cloned());
 
     ScenarioItem {
+        // Postman's own model has no disabled-entry or
+        // request-vars concept to carry here.
+        authoring: None,
         id: req.id.clone(),
         name: req.name.clone().unwrap_or_default(),
         request: Some(request),

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1366,6 +1366,7 @@ mod tests {
 
     fn leaf(name: &str) -> ScenarioItem {
         ScenarioItem {
+            authoring: None,
             name: name.to_string(),
             id: None,
             request: Some(tropel_sdk::types::Request {
@@ -1391,6 +1392,7 @@ mod tests {
 
     fn folder(name: &str, items: Vec<ScenarioItem>) -> ScenarioItem {
         ScenarioItem {
+            authoring: None,
             name: name.to_string(),
             id: None,
             request: None,
@@ -1520,6 +1522,7 @@ mod tests {
         // A leaf with no request and no scripts is not executable; it must
         // not appear in the run order.
         let inert = ScenarioItem {
+            authoring: None,
             name: "inert".into(),
             id: None,
             request: None,
@@ -1653,6 +1656,7 @@ mod tests {
             auth: None,
             conversion_notes: Vec::new(),
             items: vec![ScenarioItem {
+                authoring: None,
                 name: "resolved-item".into(),
                 id: None,
                 request: Some(tropel_sdk::types::Request {
@@ -1722,6 +1726,7 @@ mod tests {
             conversion_notes: Vec::new(),
             items: vec![
                 ScenarioItem {
+                    authoring: None,
                     name: "item-a".into(),
                     id: None,
                     request: Some(tropel_sdk::types::Request {
@@ -1744,6 +1749,7 @@ mod tests {
                     items: vec![],
                 },
                 ScenarioItem {
+                    authoring: None,
                     name: "item-b".into(),
                     id: None,
                     request: Some(tropel_sdk::types::Request {
@@ -1816,6 +1822,7 @@ mod tests {
             // explicit. Both items are script-only — no network traffic.
             items: vec![
                 ScenarioItem {
+                    authoring: None,
                     name: "self".into(),
                     id: None,
                     request: None,
@@ -1825,6 +1832,7 @@ mod tests {
                     items: vec![],
                 },
                 ScenarioItem {
+                    authoring: None,
                     name: "after".into(),
                     id: None,
                     request: None,
@@ -1922,6 +1930,7 @@ mod tests {
             items: vec![folder(
                 "Folder",
                 vec![ScenarioItem {
+                    authoring: None,
                     name: "inner".into(),
                     id: None,
                     request: None,
@@ -2045,6 +2054,7 @@ mod tests {
             //      string would throw here) AND returns early
             //   2: request — must STILL run (return only exits script 1)
             items: vec![ScenarioItem {
+                authoring: None,
                 name: "scoped".into(),
                 id: None,
                 request: None,
@@ -2170,6 +2180,7 @@ mod tests {
 
     fn script_item(name: &str, script: &str) -> ScenarioItem {
         ScenarioItem {
+            authoring: None,
             id: None,
             name: name.into(),
             request: None,
@@ -2328,6 +2339,7 @@ mod tests {
             script_item("start", "postman.setNextRequest('t1');"),
             script_item("t1", "pm.environment.set('sawName', '1');"),
             ScenarioItem {
+                authoring: None,
                 id: Some("t1".into()),
                 name: "by-id".into(),
                 request: None,

--- a/crates/tropel-wasm/src/lib.rs
+++ b/crates/tropel-wasm/src/lib.rs
@@ -1018,6 +1018,7 @@ fn build_item_tree(flat: &[WasmItem]) -> Result<Vec<ScenarioItem>> {
         .iter()
         .map(|wi| -> Result<ScenarioItem> {
             Ok(ScenarioItem {
+                authoring: None,
                 id: wi.id.clone(),
                 name: wi.name.clone(),
                 request: wi.request.as_ref().map(convert_request).transpose()?,
@@ -1046,6 +1047,7 @@ fn build_item_tree(flat: &[WasmItem]) -> Result<Vec<ScenarioItem>> {
             .map(|wi| -> Result<ScenarioItem> {
                 let children = build_item_tree(&wi.items)?;
                 Ok(ScenarioItem {
+                    authoring: None,
                     id: wi.id.clone(),
                     name: wi.name.clone(),
                     request: wi.request.as_ref().map(convert_request).transpose()?,

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -250,6 +250,7 @@ mod tests {
                 schema: None,
             },
             items: vec![ScenarioItem {
+                authoring: None,
                 name: "ping".into(),
                 id: None,
                 request: Some(tropel_sdk::types::Request {

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -140,6 +140,7 @@ fn fixture_response(req: &Request) -> Result<Response> {
 /// axis F3 names (status, headers, variable state, assertion results, trace).
 fn fixture_run_request() -> RunRequest {
     let item = |name: &str, url: &str, test: Option<&str>, body: Option<Body>| ScenarioItem {
+        authoring: None,
         name: name.into(),
         id: None,
         request: Some(Request {
@@ -692,6 +693,7 @@ fn run_request_for(req: Request) -> RunRequest {
             schema: None,
         },
         items: vec![ScenarioItem {
+            authoring: None,
             id: None,
             name: "corpus-item".into(),
             request: Some(req),
@@ -880,6 +882,7 @@ fn native_and_wasm_agree_over_request_corpus() {
                 schema: None,
             },
             items: vec![ScenarioItem {
+                authoring: None,
                 id: None,
                 name: "fail-item".into(),
                 request: Some(base("https://fixture.test/fail")),


### PR DESCRIPTION
Depends on transithq/tropel-sdk#26 (merged) — the submodule pointer moves with this.

## The loss was real, and self-documented

The `.bru` importer built only what gets SENT: disabled headers and params filtered out, and `vars:pre-request`, `settings` and `assert` recorded in `conversion_notes` as having *"no field for the .bru block"*.

Honest, and a real loss for an API client. KnockPort retired its **683-line TypeScript `.bru` parser** for this crate in KT-306 — and that parser had carried all four. Nobody noticed, because the tests covering them stopped running in the same window.

## What now survives

`ScenarioItem.authoring` takes the first three:

- every header and query parameter **as written** — disabled included, with on/off state and declaration order
- `vars:pre-request`, `@` marker already stripped
- the `settings` block, typed; unparseable values are **dropped rather than defaulted**, since inventing `timeout: 0` for `timeout: soon` changes what the request means

Assertions go to `ScenarioItem.assertions`, which already existed. Bruno's `res.status: eq 200` is resolved **here** into `response.status === 200`, all 25 operators.

That table belongs in one place: a copy in each embedder is the second implementation invariant #3 forbids, and it would drift silently because both sides would still produce assertions. An unknown operator **fails the import** — an assertion that can never run looks exactly like one that passes. A `~disabled` assertion isn't imported at all; there `~` means "do not run this".

## What gets sent is unchanged

The URL keeps its query string. The HTTP client re-appends `query_params`, so moving the pair across would only be neutral if every consumer agreed, and one that didn't would silently drop the query. The authored list carries the inline pairs **and** the block's; the reader decides how to present them. A test pins that `req.url` still ends with `?page=2` and that `~x-draft` never reaches `req.headers`.

`note_dropped_blocks` now reports only what still has nowhere to go (`vars:post-response`, `tests`). A note claiming a loss that didn't happen is its own defect — it teaches the reader to ignore the notes.

## Tests

`tropel-input-bru` 22 → **30**. New ones pin: the disabled header is absent from the request but present in `authoring`; the authored query is `[page, limit]` (inline URL pair first, then the block) while the URL is untouched; vars and settings; a disabled assertion is not imported; an unknown operator fails by name; a request with nothing authored carries **no** sidecar, so existing Scenarios serialize byte-identically.

Workspace green: sdk 35, input-bru 30, postman 6, har 20, openapi 30, insomnia 10, collection 55. `cargo check --workspace --all-targets` clean.