### PR TITLE
feat(openapi): carry the spec's declarations into the Scenario [KP-524]

### DIFF
--- a/crates/inputs/tropel-input-bru/src/lib.rs
+++ b/crates/inputs/tropel-input-bru/src/lib.rs
@@ -344,6 +344,9 @@ fn build_items(items: &[BruItem], notes: &mut Vec<String>) -> Vec<ScenarioItem> 
         match item.r#type.as_deref() {
             Some("folder") => out.push(ScenarioItem {
                 authoring: None,
+                // Bruno is a collection, not a schema — there is no
+                // declaration to carry (see ScenarioItem.contract).
+                contract: None,
                 name: item.name.clone().unwrap_or_else(|| "Folder".into()),
                 id: None,
                 request: None,
@@ -568,6 +571,7 @@ fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
 
     Ok(ScenarioItem {
         authoring,
+        contract: None,
         name: item
             .name
             .clone()

--- a/crates/inputs/tropel-input-har/src/lib.rs
+++ b/crates/inputs/tropel-input-har/src/lib.rs
@@ -357,6 +357,9 @@ fn har_entry_to_item(entry: HarEntry, index: usize) -> Result<ScenarioItem> {
 
     Ok(ScenarioItem {
         authoring: None,
+        // a HAR is a collection, not a schema — there is no
+        // declaration to carry (see ScenarioItem.contract).
+        contract: None,
         name: item_name,
         id: None,
         request: Some(Request {

--- a/crates/inputs/tropel-input-http/src/lib.rs
+++ b/crates/inputs/tropel-input-http/src/lib.rs
@@ -271,6 +271,9 @@ fn block_to_item(
 
     Ok(Some(ScenarioItem {
         authoring: None,
+        // an .http file is a collection, not a schema — there is no
+        // declaration to carry (see ScenarioItem.contract).
+        contract: None,
         name: item_name,
         id: None,
         request: Some(Request {

--- a/crates/inputs/tropel-input-insomnia/src/lib.rs
+++ b/crates/inputs/tropel-input-insomnia/src/lib.rs
@@ -260,6 +260,9 @@ fn build_items(
                 let id = r.id.clone().unwrap_or_default();
                 out.push(ScenarioItem {
                     authoring: None,
+                    // Insomnia is a collection, not a schema — there is no
+                    // declaration to carry (see ScenarioItem.contract).
+                    contract: None,
                     name: r.name.clone().unwrap_or_else(|| "Folder".into()),
                     id: None,
                     request: None,
@@ -339,6 +342,7 @@ fn request_to_item(r: &InsomniaResource) -> Result<ScenarioItem> {
 
     Ok(ScenarioItem {
         authoring: None,
+        contract: None,
         name: r
             .name
             .clone()

--- a/crates/inputs/tropel-input-k6/src/lib.rs
+++ b/crates/inputs/tropel-input-k6/src/lib.rs
@@ -137,6 +137,7 @@ fn build_scenario_from_source(js_code: &str, name: &str) -> Result<Scenario> {
             schema: None,
         },
         items: vec![ScenarioItem {
+            contract: None,
             authoring: None,
             id: None,
             name: name.to_string(),

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -30,10 +30,13 @@
 
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use tropel_sdk::{ApiKeyLocation, AuthConfig, Body, FormDataPart, Method, Request};
 use tropel_sdk::{InputAdapter, InputAdapterRegistration};
 use tropel_sdk::{Result, TropelError};
+use tropel_sdk::{
+    DeclaredBody, DeclaredField, DeclaredParameter, DeclaredResponse, RequestContract,
+};
 use tropel_sdk::{Scenario, ScenarioInfo, ScenarioItem};
 
 /// Parse an OpenAPI document as JSON, falling back to YAML (OpenAPI specs
@@ -550,6 +553,8 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
 
             items.push(ScenarioItem {
                 authoring: None,
+                // KP-524: the declaration, beside the example the Request is.
+                contract: build_contract(operation),
                 name: item_name,
                 id: None,
                 request: Some(Request {
@@ -1167,6 +1172,127 @@ fn resolve_pointer<'a>(root: &'a Value, pointer: &str) -> Option<&'a Value> {
 /// Static string for the nullable-array case since we can't return
 /// a reference into a temporary String.
 static NULL_STR: &str = "null";
+
+/// What the SPEC declares about this operation, for `ScenarioItem.contract`.
+///
+/// Everything here was ALREADY being parsed and thrown away — the structs
+/// above carried `#[allow(dead_code)]` and eleven `parsed for spec fidelity
+/// but not consumed` markers precisely because a Request has nowhere to put
+/// a declaration. The Request stays what it was (a synthesized EXAMPLE, which
+/// is what a load run needs); this carries the declaration beside it.
+///
+/// Returns `None` when the operation declares nothing at all, so an item from
+/// a spec with no parameters, body or responses serializes exactly as before.
+fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
+    let parameters: Vec<DeclaredParameter> = operation
+        .parameters
+        .iter()
+        .filter(|p| !p.name.is_empty())
+        .map(|p| DeclaredParameter {
+            name: p.name.clone(),
+            location: p.r#in.clone(),
+            required: p.required,
+            // `None` rather than a guess: a `$ref` or a composition names no
+            // type here, and defaulting to "string" would have a consumer
+            // assert a type the spec never declared.
+            r#type: p.schema.as_ref().and_then(|s| schema_type(s)).map(str::to_string),
+        })
+        .collect();
+
+    let body = operation.request_body.as_ref().map(|rb| DeclaredBody {
+        required: rb.required,
+        content_types: sorted_keys(&rb.content),
+        fields: declared_fields(&rb.content),
+    });
+
+    let responses: BTreeMap<String, DeclaredResponse> = operation
+        .responses
+        .iter()
+        .map(|(status, response)| {
+            (
+                // The spec's own key, verbatim — `default` and `4XX` are
+                // legal and neither parses as a number.
+                status.clone(),
+                DeclaredResponse {
+                    description: response.description.clone(),
+                    content_types: response
+                        .content
+                        .as_ref()
+                        .map(sorted_keys)
+                        .unwrap_or_default(),
+                    fields: response
+                        .content
+                        .as_ref()
+                        .map(declared_fields)
+                        .unwrap_or_default(),
+                },
+            )
+        })
+        .collect();
+
+    if parameters.is_empty() && body.is_none() && responses.is_empty() {
+        return None;
+    }
+    Some(RequestContract { parameters, body, responses })
+}
+
+/// Content-type keys, SORTED.
+///
+/// `content` is a `HashMap`, so its iteration order varies run to run. An
+/// unsorted list would make the same spec serialize differently on each parse
+/// and break every golden test that compares Scenario JSON.
+fn sorted_keys(content: &HashMap<String, OasMediaType>) -> Vec<String> {
+    let mut keys: Vec<String> = content.keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+/// Top-level property names and types from ONE media type.
+///
+/// `application/json` first when present, matching `build_request_body`'s own
+/// preference — so the declaration describes the same representation the
+/// synthesized example was built from. Otherwise the first in sorted
+/// content-type order, which makes "first" deterministic rather than whichever
+/// the HashMap happened to yield.
+///
+/// One media type, not a merge across all of them: `application/json` and
+/// `application/xml` on one body are two encodings of the same shape, and
+/// merging them would invent a union of properties no single representation
+/// declares.
+///
+/// No `$ref` resolution here, deliberately: `resolve_refs` has already run
+/// over the whole document before it was deserialized into these structs, so a
+/// schema reached from here is the resolved one. That is also why
+/// `build_request_body` reads `schema.properties` directly.
+fn declared_fields(content: &HashMap<String, OasMediaType>) -> Vec<DeclaredField> {
+    let mut order = sorted_keys(content);
+    if let Some(pos) = order.iter().position(|k| k == "application/json") {
+        let json = order.remove(pos);
+        order.insert(0, json);
+    }
+    for key in order {
+        let Some(media) = content.get(&key) else { continue };
+        let Some(schema) = media.schema.as_ref() else { continue };
+        let Some(properties) = schema.properties.as_ref() else { continue };
+        let mut fields: Vec<DeclaredField> = properties
+            .iter()
+            .map(|(name, prop)| DeclaredField {
+                name: name.clone(),
+                // `required` is a LIST on the PARENT schema, not a flag on
+                // the property — reading it off the property would report
+                // every field as optional.
+                required: schema.required.iter().any(|r| r == name),
+                r#type: schema_type(prop).map(str::to_string),
+            })
+            .collect();
+        // `properties` is a HashMap too. Same determinism reason.
+        fields.sort_by(|a, b| a.name.cmp(&b.name));
+        if !fields.is_empty() {
+            return fields;
+        }
+    }
+    Vec::new()
+}
 
 fn schema_type(schema: &OasSchema) -> Option<&str> {
     // P1 line 158: handle both "string" and ["string","null"] forms.
@@ -2555,5 +2681,151 @@ components:
             }
             other => panic!("expected Json body, got {:?}", other),
         }
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    //! KP-524: the declaration reaches the Scenario.
+    //!
+    //! Everything asserted here was ALREADY parsed by this adapter and thrown
+    //! away — the structs above carry `#[allow(dead_code)]` and eleven
+    //! `parsed for spec fidelity but not consumed` markers. So these tests are
+    //! about the carrier, not about new parsing.
+
+    use super::*;
+    use tropel_sdk::traits::InputAdapter;
+
+    const SPEC: &str = r#"{
+      "openapi":"3.0.0","info":{"title":"t","version":"1"},
+      "paths":{"/users":{
+        "get":{"parameters":[
+          {"name":"page","in":"query","required":false,"schema":{"type":"integer"}},
+          {"name":"limit","in":"query","required":true,"schema":{"type":"integer"}},
+          {"name":"X-Trace","in":"header","schema":{"type":"string"}}],
+         "responses":{
+           "200":{"description":"ok","content":{"application/json":{"schema":{
+              "type":"object","required":["id"],
+              "properties":{"id":{"type":"integer"},"name":{"type":"string"}}}}}},
+           "4XX":{"description":"client error"},
+           "default":{"description":"fallback"}}},
+        "post":{"requestBody":{"required":true,"content":{"application/json":{"schema":{
+           "type":"object","required":["name"],
+           "properties":{"name":{"type":"string"},"email":{"type":"string"}}}}}},
+         "responses":{"201":{"description":"created"}}}}}}"#;
+
+    fn contract_for(method: &str) -> RequestContract {
+        let scenario = OpenApiInputAdapter.parse(SPEC.as_bytes()).expect("parses");
+        scenario
+            .items
+            .iter()
+            .find(|i| i.name.starts_with(method))
+            .and_then(|i| i.contract.clone())
+            .unwrap_or_else(|| panic!("no contract on {method}"))
+    }
+
+    #[test]
+    fn parameters_carry_location_required_and_type() {
+        let c = contract_for("GET");
+        let names: Vec<&str> = c.parameters.iter().map(|p| p.name.as_str()).collect();
+        // Declaration order, not sorted: a spec's parameter order is
+        // meaningful to a reader and cheap to preserve.
+        assert_eq!(names, vec!["page", "limit", "X-Trace"]);
+        let limit = c.parameters.iter().find(|p| p.name == "limit").expect("limit");
+        assert_eq!(limit.location, "query");
+        assert!(limit.required, "the spec says required: true");
+        assert_eq!(limit.r#type.as_deref(), Some("integer"));
+        // The one the synthesized example cannot express: `page` is declared
+        // optional, and the Request carries a value for it regardless.
+        let page = c.parameters.iter().find(|p| p.name == "page").expect("page");
+        assert!(!page.required);
+        // And a HEADER parameter is distinguishable from a query one, which a
+        // Request's flat `headers` list cannot say.
+        let trace = c.parameters.iter().find(|p| p.name == "X-Trace").expect("X-Trace");
+        assert_eq!(trace.location, "header");
+    }
+
+    #[test]
+    fn responses_reach_the_scenario_at_all() {
+        // Before this, a Request had NOWHERE to put a declared response, so
+        // the `201` in a spec reached nothing.
+        let c = contract_for("GET");
+        assert!(c.responses.contains_key("200"));
+        assert_eq!(c.responses["200"].description.as_deref(), Some("ok"));
+        assert_eq!(c.responses["200"].content_types, vec!["application/json"]);
+    }
+
+    #[test]
+    fn non_numeric_response_keys_survive() {
+        // `4XX` and `default` are legal and neither parses as a number. A
+        // `u16` key would have dropped exactly these.
+        let c = contract_for("GET");
+        assert!(c.responses.contains_key("4XX"), "got {:?}", c.responses.keys());
+        assert!(c.responses.contains_key("default"));
+    }
+
+    #[test]
+    fn response_fields_read_required_off_the_parent_schema() {
+        // `required` is a list on the object schema, not a flag on each
+        // property. Reading it off the property would report every field as
+        // optional.
+        let c = contract_for("GET");
+        let fields = &c.responses["200"].fields;
+        let id = fields.iter().find(|f| f.name == "id").expect("id");
+        let name = fields.iter().find(|f| f.name == "name").expect("name");
+        assert!(id.required, "the schema lists id as required");
+        assert!(!name.required);
+        assert_eq!(id.r#type.as_deref(), Some("integer"));
+    }
+
+    #[test]
+    fn a_body_carries_required_content_types_and_field_types() {
+        let c = contract_for("POST");
+        let body = c.body.expect("POST declares a body");
+        assert!(body.required);
+        assert_eq!(body.content_types, vec!["application/json"]);
+        let name = body.fields.iter().find(|f| f.name == "name").expect("name");
+        assert!(name.required);
+        // The distinction the carrier exists for: a DECLARED string, beside a
+        // synthesized example whose VALUE is the string "string".
+        assert_eq!(name.r#type.as_deref(), Some("string"));
+    }
+
+    #[test]
+    fn fields_are_sorted_so_the_same_spec_serializes_identically() {
+        // `properties` is a HashMap: unsorted output would make one spec
+        // produce different Scenario JSON on each parse and break every
+        // golden test that compares it.
+        let c = contract_for("POST");
+        let names: Vec<&str> =
+            c.body.as_ref().unwrap().fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["email", "name"]);
+    }
+
+    #[test]
+    fn an_operation_declaring_nothing_gets_no_contract() {
+        // So an item from a bare spec serializes exactly as it did before the
+        // field existed.
+        let bare = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/ping":{"get":{}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(bare.as_bytes()).expect("parses");
+        let item = scenario.items.first().expect("one item");
+        assert!(item.contract.is_none(), "got {:?}", item.contract);
+        let json = serde_json::to_string(item).expect("serializes");
+        assert!(!json.contains("contract"), "got {json}");
+    }
+
+    #[test]
+    fn the_request_is_unchanged_by_any_of_this() {
+        // The whole design: the Request stays the synthesized example a load
+        // run needs. If this drifts, the contract has leaked into the wire
+        // view.
+        let scenario = OpenApiInputAdapter.parse(SPEC.as_bytes()).expect("parses");
+        let post = scenario.items.iter().find(|i| i.name.starts_with("POST")).expect("POST");
+        let request = post.request.as_ref().expect("a request");
+        let body = serde_json::to_value(request.body.as_ref().expect("a body")).expect("json");
+        // Still the example, with type-name placeholders — not the schema.
+        assert_eq!(body["name"], "string");
+        assert_eq!(body["email"], "string");
     }
 }

--- a/crates/tropel-collection/src/parser.rs
+++ b/crates/tropel-collection/src/parser.rs
@@ -198,8 +198,10 @@ fn convert_items(
                 }
                 let scenario_item = ScenarioItem {
                     // Postman's own model has no disabled-entry or
-                    // request-vars concept to carry here.
+                    // request-vars concept to carry here, and a collection is
+                    // not a schema — there is no declaration to carry either.
                     authoring: None,
+                    contract: None,
                     id: folder.id.clone(),
                     name: folder.name.clone().unwrap_or_default(),
                     request: None,
@@ -249,8 +251,10 @@ fn convert_request_item(
 
     ScenarioItem {
         // Postman's own model has no disabled-entry or
-        // request-vars concept to carry here.
+        // request-vars concept to carry here, and a collection is not a
+        // schema — there is no declaration to carry either.
         authoring: None,
+        contract: None,
         id: req.id.clone(),
         name: req.name.clone().unwrap_or_default(),
         request: Some(request),

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1366,6 +1366,7 @@ mod tests {
 
     fn leaf(name: &str) -> ScenarioItem {
         ScenarioItem {
+            contract: None,
             authoring: None,
             name: name.to_string(),
             id: None,
@@ -1392,6 +1393,7 @@ mod tests {
 
     fn folder(name: &str, items: Vec<ScenarioItem>) -> ScenarioItem {
         ScenarioItem {
+            contract: None,
             authoring: None,
             name: name.to_string(),
             id: None,
@@ -1522,6 +1524,7 @@ mod tests {
         // A leaf with no request and no scripts is not executable; it must
         // not appear in the run order.
         let inert = ScenarioItem {
+            contract: None,
             authoring: None,
             name: "inert".into(),
             id: None,
@@ -1656,6 +1659,7 @@ mod tests {
             auth: None,
             conversion_notes: Vec::new(),
             items: vec![ScenarioItem {
+                contract: None,
                 authoring: None,
                 name: "resolved-item".into(),
                 id: None,
@@ -1726,6 +1730,7 @@ mod tests {
             conversion_notes: Vec::new(),
             items: vec![
                 ScenarioItem {
+                    contract: None,
                     authoring: None,
                     name: "item-a".into(),
                     id: None,
@@ -1749,6 +1754,7 @@ mod tests {
                     items: vec![],
                 },
                 ScenarioItem {
+                    contract: None,
                     authoring: None,
                     name: "item-b".into(),
                     id: None,
@@ -1822,6 +1828,7 @@ mod tests {
             // explicit. Both items are script-only — no network traffic.
             items: vec![
                 ScenarioItem {
+                    contract: None,
                     authoring: None,
                     name: "self".into(),
                     id: None,
@@ -1832,6 +1839,7 @@ mod tests {
                     items: vec![],
                 },
                 ScenarioItem {
+                    contract: None,
                     authoring: None,
                     name: "after".into(),
                     id: None,
@@ -1930,6 +1938,7 @@ mod tests {
             items: vec![folder(
                 "Folder",
                 vec![ScenarioItem {
+                    contract: None,
                     authoring: None,
                     name: "inner".into(),
                     id: None,
@@ -2054,6 +2063,7 @@ mod tests {
             //      string would throw here) AND returns early
             //   2: request — must STILL run (return only exits script 1)
             items: vec![ScenarioItem {
+                contract: None,
                 authoring: None,
                 name: "scoped".into(),
                 id: None,
@@ -2180,6 +2190,7 @@ mod tests {
 
     fn script_item(name: &str, script: &str) -> ScenarioItem {
         ScenarioItem {
+            contract: None,
             authoring: None,
             id: None,
             name: name.into(),
@@ -2339,6 +2350,7 @@ mod tests {
             script_item("start", "postman.setNextRequest('t1');"),
             script_item("t1", "pm.environment.set('sawName', '1');"),
             ScenarioItem {
+                contract: None,
                 authoring: None,
                 id: Some("t1".into()),
                 name: "by-id".into(),

--- a/crates/tropel-sandbox/BRIDGE.md
+++ b/crates/tropel-sandbox/BRIDGE.md
@@ -161,6 +161,7 @@ follow rule 4 and rule 5.
 | Function | Args | Returns |
 |---|---|---|
 | `__tropel_trp_test_skip` | `name: String` | `()` |
+| `__tropel_trp_get_test_results` | `—` | `String` (JSON `[{name, passed}]`) |
 
 ### Flow control
 

--- a/crates/tropel-wasm/src/lib.rs
+++ b/crates/tropel-wasm/src/lib.rs
@@ -1018,6 +1018,7 @@ fn build_item_tree(flat: &[WasmItem]) -> Result<Vec<ScenarioItem>> {
         .iter()
         .map(|wi| -> Result<ScenarioItem> {
             Ok(ScenarioItem {
+                contract: None,
                 authoring: None,
                 id: wi.id.clone(),
                 name: wi.name.clone(),
@@ -1047,6 +1048,7 @@ fn build_item_tree(flat: &[WasmItem]) -> Result<Vec<ScenarioItem>> {
             .map(|wi| -> Result<ScenarioItem> {
                 let children = build_item_tree(&wi.items)?;
                 Ok(ScenarioItem {
+                    contract: None,
                     authoring: None,
                     id: wi.id.clone(),
                     name: wi.name.clone(),

--- a/crates/tropel-web/src/lib.rs
+++ b/crates/tropel-web/src/lib.rs
@@ -250,6 +250,7 @@ mod tests {
                 schema: None,
             },
             items: vec![ScenarioItem {
+                contract: None,
                 authoring: None,
                 name: "ping".into(),
                 id: None,

--- a/crates/tropel-web/tests/native_vs_wasm.rs
+++ b/crates/tropel-web/tests/native_vs_wasm.rs
@@ -140,6 +140,7 @@ fn fixture_response(req: &Request) -> Result<Response> {
 /// axis F3 names (status, headers, variable state, assertion results, trace).
 fn fixture_run_request() -> RunRequest {
     let item = |name: &str, url: &str, test: Option<&str>, body: Option<Body>| ScenarioItem {
+        contract: None,
         authoring: None,
         name: name.into(),
         id: None,
@@ -693,6 +694,7 @@ fn run_request_for(req: Request) -> RunRequest {
             schema: None,
         },
         items: vec![ScenarioItem {
+            contract: None,
             authoring: None,
             id: None,
             name: "corpus-item".into(),
@@ -882,6 +884,7 @@ fn native_and_wasm_agree_over_request_corpus() {
                 schema: None,
             },
             items: vec![ScenarioItem {
+                contract: None,
                 authoring: None,
                 id: None,
                 name: "fail-item".into(),


### PR DESCRIPTION
The OpenAPI adapter has been parsing responses, parameter types and `required`
flags and **throwing them away**. Eleven `parsed for spec fidelity but not
consumed` markers, `#[allow(dead_code)]` on the structs holding them — all
because a `Request` has nowhere to put a declaration.

It has now. `ScenarioItem.contract` (tropel-sdk#27, submodule bumped here) is
the third view of one item:

```
Request   — what gets SENT
authoring — what the user WROTE
contract  — what the SOURCE DECLARED
```

`build_contract` fills it from data this file already held. The Request is
untouched and stays the synthesized **example** a load run needs — asserted
directly, because if that drifts the declaration has leaked into the wire view.

## Why KnockPort needs it

`knockport drift` compares a collection against a spec (KP-524). Endpoint- and
field-**name** drift already worked off the Scenario; response drift, parameter
**types** and required-vs-optional did not, and could not: a body value of
`"integer"` is a type name that happens to look like data, so reading it back
as a type would call a collection sending `{"age":30}` a mismatch — backwards.
Declared responses had no representation at all.

## Four decisions

- **Responses keyed by the spec's own string.** `default` and `4XX` are legal
  and neither parses as a number, so a `u16` would have silently dropped the
  two cases a drift check most wants to see. Tested.
- **`required` read off the parent schema.** It's a *list* on the object, not a
  flag on each property; reading it off the property would report every field
  as optional.
- **One media type, not a merge.** `application/json` first, matching
  `build_request_body`'s own preference, so the declaration describes the
  representation the example was built from. `application/json` and
  `application/xml` on one body are two encodings of one shape; merging them
  would invent a union no representation declares.
- **Sorted fields and content types.** `properties` and `content` are HashMaps —
  unsorted output would make one spec produce different Scenario JSON on each
  parse and break every golden test that compares it.

No `$ref` resolution here: `resolve_refs` already runs over the whole document
before it's deserialized into these structs, which is also why
`build_request_body` reads `schema.properties` directly. I wrote a resolver call
before checking that, and removed it along with the `components` argument it
needed.

Every other adapter gets `contract: None` with the reason stated once per file:
bru, HAR, .http, Insomnia, Postman and k6 read **collections**, and a collection
is not a schema. `ScenarioItem` isn't `#[non_exhaustive]`, so that's 12
mechanical sites — worth deciding once, before 1.0, whether it should be.

## Also: an undocumented bridge, which is a KnockPort-facing bug

`cargo test --workspace` was **already red on master** before this change:
`every_bridge_is_documented` reported `__tropel_trp_get_test_results`
registered in `efe471a` and absent from `BRIDGE.md`. Documented here.

Not a formality. The guard's own message is the reason: *"A host reads that file
to know what it must implement; an undocumented bridge is one a second host will
not know to provide."* KnockPort **is** that second host — it runs the shims in
its own Worker — so an undocumented bridge means `bru.getTestResults` silently
fails there while working under the agent.

Verified: **1089 workspace tests pass, 0 fail** (was 1 before the BRIDGE.md
fix). `tropel-input-openapi` 38 pass, 8 new. clippy clean on both changed
crates.