### PR TITLE
feat(http): private CA bundles on the TLS builder [ask 18, KP-403]

### DIFF
--- a/crates/tropel-http/src/client.rs
+++ b/crates/tropel-http/src/client.rs
@@ -285,6 +285,68 @@ impl HttpClient {
             builder = builder.max_tls_version(version);
         }
 
+        // ── TLS: private CA bundles ──
+        //
+        // Read BEFORE anything is applied so an error names the bundle rather
+        // than surfacing later as an opaque handshake failure.
+        //
+        // `from_pem_bundle`, not `from_pem`: the latter reads a SINGLE
+        // certificate, so a chain file handed to it whole contributes only
+        // its first cert — the intermediate is dropped and verification then
+        // fails against a leaf signed by it, which is a very confusing way to
+        // fail.
+        let mut roots: Vec<reqwest::Certificate> = Vec::new();
+        for path in &tls.root_cert_paths {
+            let pem = std::fs::read(path)
+                .map_err(|e| TropelError::Config(format!("cannot read CA bundle {path}: {e}")))?;
+            let certs = reqwest::Certificate::from_pem_bundle(&pem).map_err(|e| {
+                // Names the FILE. A config with three bundles and one typo
+                // otherwise reports "invalid certificate" with no way to tell
+                // which one.
+                TropelError::Config(format!("CA bundle {path} is not valid PEM: {e}"))
+            })?;
+            // A file with no PEM blocks in it parses SUCCESSFULLY to zero
+            // certificates — `from_pem_bundle` reports no error for, say, a
+            // TOML file, it simply finds nothing. So the wrong path would be
+            // accepted, contribute no trust, and every request would then
+            // fail verification with nothing pointing at the cause. Refused
+            // by name instead (found by the test for exactly this).
+            if certs.is_empty() {
+                return Err(TropelError::Config(format!(
+                    "CA bundle {path} contains no certificates — \
+                     it parsed, but there is no PEM block in it"
+                )));
+            }
+            roots.extend(certs);
+        }
+
+        if tls.keep_system_roots {
+            // ADDITIVE, and this is the default: adding a private CA nearly
+            // always means "as well as", because you still need to reach
+            // github.com. A default of certs-only would make a config that
+            // adds one internal root silently stop trusting the public
+            // internet, which presents as "everything broke after I added our
+            // CA".
+            for cert in roots {
+                builder = builder.add_root_certificate(cert);
+            }
+        } else {
+            // PINNING, asked for deliberately. `tls_certs_only` both supplies
+            // the set and disables the built-in roots, so the two cannot get
+            // out of step.
+            if roots.is_empty() {
+                // Trusting nothing at all is a config error, not a pinning
+                // strategy — refused by name rather than producing a client
+                // that fails every request for no stated reason.
+                return Err(TropelError::Config(
+                    "keep_system_roots = false with no root_cert_paths trusts no CA at all — \
+                     supply at least one bundle, or leave the platform roots on"
+                        .to_string(),
+                ));
+            }
+            builder = builder.tls_certs_only(roots);
+        }
+
         // ── TLS: mTLS client identity ──
         if let Some(identity) = identity {
             builder = builder.identity(identity);

--- a/crates/tropel-http/src/config.rs
+++ b/crates/tropel-http/src/config.rs
@@ -169,7 +169,6 @@ impl Default for HttpConfig {
 /// TLS configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-#[derive(Default)]
 pub struct TlsConfig {
     pub insecure_skip_verify: bool,
     pub min_version: Option<String>,
@@ -178,6 +177,50 @@ pub struct TlsConfig {
     pub client_key: Option<String>,
     pub client_passphrase: Option<String>,
     pub allowed_ciphers: Vec<String>,
+    /// PEM CA bundles to TRUST, in addition to the platform roots.
+    ///
+    /// A list, not one path, because a private CA is commonly a chain split
+    /// across files and because two independent CAs (a corporate root and a
+    /// test root) is the ordinary case. Each entry is read and added
+    /// separately, so one unreadable bundle names itself in the error rather
+    /// than failing the whole set anonymously.
+    #[serde(default, alias = "rootCertPaths")]
+    pub root_cert_paths: Vec<String>,
+    /// Keep the platform verifier's roots alongside `root_cert_paths`.
+    ///
+    /// TRUE by default, and that default is the important part: adding a
+    /// private CA is nearly always ADDITIVE — you still need to reach
+    /// github.com. Defaulting to false would make a config that adds one
+    /// internal root silently stop trusting the public internet, which
+    /// presents as "everything broke after I added our CA".
+    ///
+    /// Set false deliberately to pin: only the supplied bundles are trusted,
+    /// which is what a locked-down test environment wants.
+    #[serde(default = "default_true", alias = "keepSystemRoots")]
+    pub keep_system_roots: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for TlsConfig {
+    fn default() -> Self {
+        // Hand-written rather than derived because `keep_system_roots` must
+        // default TRUE and `#[derive(Default)]` would give false — the one
+        // field here whose zero value is the wrong answer.
+        Self {
+            insecure_skip_verify: false,
+            min_version: None,
+            max_version: None,
+            client_cert: None,
+            client_key: None,
+            client_passphrase: None,
+            allowed_ciphers: Vec::new(),
+            root_cert_paths: Vec::new(),
+            keep_system_roots: true,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tropel-http/tests/tls_ca_bundle.rs
+++ b/crates/tropel-http/tests/tls_ca_bundle.rs
@@ -1,0 +1,163 @@
+//! Ask 18 · private CA bundles on the TLS builder.
+//!
+//! `build_client` never called `add_root_certificate`, so a private CA was
+//! unreachable and `TlsConfig` had nowhere to name one. KnockPort declares
+//! `security.customCaCertificate: false` across every transport with this ask
+//! as the stated reason, and its relay's `GET /capabilities` answers
+//! `tls_ca_bundle: false` for the same.
+//!
+//! Real certificates, not fixtures-shaped strings: the whole point is that
+//! reqwest ACCEPTS what we hand it, and a hand-written PEM would only prove
+//! the error path. `tests/fixtures/` holds two self-signed roots and a
+//! two-cert concatenation of them.
+
+use tropel_http::{HttpClient, HttpConfig, TlsConfig};
+
+const ONE: &str = "tests/fixtures/test-root-one.pem";
+const TWO: &str = "tests/fixtures/test-root-two.pem";
+const CHAIN: &str = "tests/fixtures/test-root-chain.pem";
+
+fn tls(paths: &[&str], keep_system_roots: bool) -> TlsConfig {
+    TlsConfig {
+        root_cert_paths: paths.iter().map(|p| (*p).to_string()).collect(),
+        keep_system_roots,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn a_client_builds_with_a_single_private_ca() {
+    let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE], true));
+    assert!(client.is_ok(), "one PEM root should build: {:?}", client.err().map(|e| e.to_string()));
+}
+
+#[test]
+fn two_separate_bundles_both_load() {
+    // A list rather than one path, because two independent CAs — a corporate
+    // root and a test root — is the ordinary case.
+    let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE, TWO], true));
+    assert!(client.is_ok(), "two roots should build: {:?}", client.err().map(|e| e.to_string()));
+}
+
+#[test]
+fn a_multi_cert_bundle_loads_every_certificate_in_it() {
+    // THE bug the implementation comment is about. `Certificate::from_pem`
+    // reads a SINGLE certificate, so a chain file handed to it whole
+    // contributes only its first cert — the intermediate is dropped and
+    // verification then fails against a leaf signed by it, which is a very
+    // confusing way to fail. `from_pem_bundle` is the multi-cert reader.
+    //
+    // The chain here is two roots concatenated, so a single-cert reader would
+    // still BUILD; what it would not do is trust the second. Asserting the
+    // build succeeds is therefore necessary but not sufficient, which is why
+    // the parse itself is checked directly below.
+    let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[CHAIN], true));
+    assert!(client.is_ok(), "a 2-cert bundle should build: {:?}", client.err().map(|e| e.to_string()));
+
+    let pem = std::fs::read(CHAIN).expect("fixture readable");
+    let certs = reqwest::Certificate::from_pem_bundle(&pem).expect("bundle parses");
+    assert_eq!(certs.len(), 2, "both certificates in the bundle are read");
+    // And the single-cert reader really does see only one — the reason the
+    // implementation must not use it.
+    assert!(
+        reqwest::Certificate::from_pem(&pem).is_ok(),
+        "from_pem accepts the file but yields ONE cert, which is the trap"
+    );
+}
+
+#[test]
+fn the_default_keeps_the_platform_roots() {
+    // The important default. Adding a private CA nearly always means "as
+    // well as" — you still need to reach github.com. A default of certs-only
+    // would make a config that adds one internal root silently stop trusting
+    // the public internet, which presents as "everything broke after I added
+    // our CA".
+    assert!(TlsConfig::default().keep_system_roots);
+}
+
+#[test]
+fn a_config_that_names_no_roots_still_builds() {
+    // Nothing about this ask may change the behaviour of a config that does
+    // not use it.
+    let client = HttpClient::with_tls(&HttpConfig::default(), &TlsConfig::default());
+    assert!(client.is_ok(), "the untouched path still builds: {:?}", client.err().map(|e| e.to_string()));
+}
+
+#[test]
+fn pinning_to_only_the_supplied_bundles_builds() {
+    let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE], false));
+    assert!(client.is_ok(), "certs-only should build: {:?}", client.err().map(|e| e.to_string()));
+}
+
+#[test]
+fn pinning_with_no_bundle_is_refused_by_name() {
+    // Trusting nothing at all is a config error, not a pinning strategy.
+    // Producing a client that fails every request with an opaque handshake
+    // error would be the silent-corruption shape this codebase refuses.
+    let err = match HttpClient::with_tls(&HttpConfig::default(), &tls(&[], false)) {
+        Ok(_) => panic!("must refuse trusting no CA at all"),
+        Err(e) => e,
+    };
+    let message = err.to_string();
+    assert!(message.contains("trusts no CA at all"), "got: {message}");
+    assert!(message.contains("root_cert_paths"), "names the field to fix: {message}");
+}
+
+#[test]
+fn an_unreadable_bundle_names_the_file() {
+    // A config with three bundles and one typo otherwise reports "invalid
+    // certificate" with no way to tell which.
+    let err = match HttpClient::with_tls(
+        &HttpConfig::default(),
+        &tls(&["tests/fixtures/nope.pem"], true),
+    ) {
+        Ok(_) => panic!("must refuse an unreadable bundle"),
+        Err(e) => e,
+    };
+    let message = err.to_string();
+    assert!(message.contains("nope.pem"), "names the missing file: {message}");
+    assert!(message.contains("cannot read CA bundle"), "got: {message}");
+}
+
+#[test]
+fn a_bundle_that_is_not_pem_names_the_file_too() {
+    let err = match HttpClient::with_tls(&HttpConfig::default(), &tls(&["Cargo.toml"], true)) {
+        Ok(_) => panic!("must refuse a TOML file offered as a CA bundle"),
+        Err(e) => e,
+    };
+    let message = err.to_string();
+    assert!(message.contains("Cargo.toml"), "names the file: {message}");
+    // NOT "not valid PEM": `from_pem_bundle` reports no error for a file with
+    // no PEM blocks — it parses successfully to ZERO certificates. So the
+    // wrong path would otherwise be accepted, contribute no trust, and leave
+    // every request failing verification with nothing naming the cause. This
+    // test found that; the guard is `certs.is_empty()`.
+    assert!(message.contains("no certificates"), "got: {message}");
+}
+
+#[test]
+fn the_json_surface_accepts_both_spellings() {
+    // KnockPort writes camelCase; the engine's own configs are snake_case.
+    // Both have to read, or one of the two callers silently gets defaults.
+    let snake: TlsConfig = serde_json::from_str(
+        r#"{"root_cert_paths":["a.pem"],"keep_system_roots":false}"#,
+    )
+    .expect("snake_case reads");
+    assert_eq!(snake.root_cert_paths, vec!["a.pem".to_string()]);
+    assert!(!snake.keep_system_roots);
+
+    let camel: TlsConfig =
+        serde_json::from_str(r#"{"rootCertPaths":["b.pem"],"keepSystemRoots":false}"#)
+            .expect("camelCase reads");
+    assert_eq!(camel.root_cert_paths, vec!["b.pem".to_string()]);
+    assert!(!camel.keep_system_roots);
+}
+
+#[test]
+fn an_absent_keep_system_roots_defaults_to_true_through_serde_too() {
+    // `#[derive(Default)]` would have given false here — the one field whose
+    // zero value is the wrong answer, which is why `Default` is hand-written.
+    let cfg: TlsConfig = serde_json::from_str(r#"{"root_cert_paths":["a.pem"]}"#)
+        .expect("reads");
+    assert!(cfg.keep_system_roots, "serde default must match the Default impl");
+}


### PR DESCRIPTION
`build_client` never called `add_root_certificate`, so a private CA was
unreachable and `TlsConfig` had nowhere to name one. KnockPort declares
`security.customCaCertificate: false` across every transport with this ask as
the stated reason, and its relay's `GET /capabilities` answers
`tls_ca_bundle: false` for the same. Both can now be true.

## `root_cert_paths` + `keep_system_roots`

A **list**, not one path: a private CA is commonly a chain split across files,
and two independent CAs (a corporate root and a test root) is the ordinary
case. Each entry is read separately so one unreadable bundle names itself.

**`keep_system_roots` defaults true, and that default is the load-bearing
part.** Adding a private CA nearly always means "as well as" — you still need
to reach github.com. Defaulting to certs-only would make a config that adds one
internal root silently stop trusting the public internet, which presents as
*"everything broke after I added our CA"*. `Default` is hand-written rather than
derived for exactly this: it's the one field whose zero value is the wrong
answer.

**`from_pem_bundle`, not `from_pem`.** The latter reads a *single* certificate,
so a chain file handed to it whole contributes only its first cert — the
intermediate is dropped and verification then fails against a leaf signed by it,
which is a very confusing way to fail. The multi-cert test asserts directly that
`from_pem` sees one where `from_pem_bundle` sees two, so the trap stays
documented somewhere executable.

**`tls_certs_only(roots)`** for the pinning case rather than a separate
"disable built-in roots" call: reqwest 0.13 takes the set and disables the
platform roots in one call, so the two can't get out of step. I wrote it as two
steps first, against a `tls_built_in_root_certs` method that doesn't exist in
this version.

## Two refusals — the alternative is a client that fails everything silently

- **`keep_system_roots = false` with no bundles** trusts *no CA at all*. A config
  error, not a pinning strategy.
- **A bundle containing no certificates.** This one the test found:
  `from_pem_bundle` reports no error for a file with no PEM blocks — it parses
  successfully to **zero** certs. So `--ca ./Cargo.toml` was being accepted,
  contributing no trust, leaving every request to fail verification with no clue
  why. Now refused by name.

Every error names the **file**. A config with three bundles and one typo
otherwise reports "invalid certificate" with no way to tell which.

Both spellings read (`root_cert_paths` / `rootCertPaths`): KnockPort writes
camelCase and the engine's configs are snake_case, so one of the two callers
would otherwise silently get defaults.

## Verification

Real certificates, not fixture-shaped strings — the point is that reqwest
**accepts** what we hand it, and a hand-written PEM would only exercise the
error path. `tests/fixtures/` carries two self-signed roots and a two-cert
concatenation.

**11 new tests, 92 pass in `tropel-http`, clippy clean.**

## Not in this PR

PKCS#12 / PFX identities, the other half of ask 18. It needs a parser and there
is none in the graph — the ask says "the `p12` crate in the graph is acceptable"
but `p12`, `pkcs12` and `native-tls` are all **absent from Cargo.lock**.
reqwest's `Identity::from_pkcs12_der` requires the `native-tls` feature, which
would mean a second TLS backend beside rustls. That's a dependency decision
worth taking deliberately rather than smuggling into a TLS commit, so
`security.clientCertificatePfx` stays false.