### PR TITLE
feat(http): PAC directives and failover ordering [ask 17]

### DIFF
--- a/crates/tropel-http/src/proxy.rs
+++ b/crates/tropel-http/src/proxy.rs
@@ -276,3 +276,127 @@ pub fn system_no_proxy() -> Vec<String> {
     }
     Vec::new()
 }
+
+// ── PAC directives and failover  [ask 17] ──────────────────────────────────
+//
+// The ask carries the spec because this is the differentiator: "Bruno honours
+// only the FIRST directive of the first matching return." A PAC script's
+// return value is a LIST of candidates separated by `;`, and honouring one of
+// them turns a config with a documented fallback into a single point of
+// failure.
+//
+// This half is the parser and the ordering — pure, and where the bug is.
+// Evaluating `FindProxyForURL` needs a JS engine and its built-ins
+// (`isInNet`, `dnsDomainIs`, `shExpMatch`, …); that is the other half, and it
+// wants its own crate rather than a JS engine inside the HTTP client.
+
+/// One PAC directive — a single candidate to try.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PacDirective {
+    /// `DIRECT` — no proxy for this URL.
+    Direct,
+    /// `PROXY host:port` — an HTTP proxy.
+    Proxy(String),
+    /// `SOCKS host:port` (also `SOCKS4`/`SOCKS5`).
+    Socks(String),
+}
+
+impl PacDirective {
+    /// The proxy URL to hand reqwest, or `None` for `DIRECT`.
+    pub fn proxy_url(&self) -> Option<String> {
+        match self {
+            PacDirective::Direct => None,
+            PacDirective::Proxy(target) => Some(format!("http://{target}")),
+            // `socks5://`, not `socks4://`: reqwest's socks support is
+            // SOCKS5, and a PAC `SOCKS` directive predates the distinction.
+            // Naming 5 is honest about what would actually be attempted.
+            PacDirective::Socks(target) => Some(format!("socks5://{target}")),
+        }
+    }
+}
+
+/// Parse a PAC return value into candidates, IN ORDER.
+///
+/// `"PROXY a:8080; PROXY b:8080; DIRECT"` is three candidates, tried in that
+/// order. Returning only the first is the Bruno bug this exists to avoid.
+///
+/// Unparseable directives are SKIPPED rather than failing the whole result: a
+/// PAC script is often generated, and one malformed entry in a list of four
+/// should not take the other three down with it. An entirely unparseable
+/// result yields an empty list, which the caller must treat as a failure
+/// rather than as "go direct" — going direct on a PAC script we could not
+/// read is the silent misroute the whole surface exists to prevent.
+pub fn parse_pac_result(result: &str) -> Vec<PacDirective> {
+    result
+        .split(';')
+        .filter_map(|candidate| parse_pac_directive(candidate.trim()))
+        .collect()
+}
+
+fn parse_pac_directive(directive: &str) -> Option<PacDirective> {
+    if directive.is_empty() {
+        return None;
+    }
+    // Split on ANY whitespace, not just one space: `PROXY   host:80` and
+    // `PROXY\thost:80` both occur in generated scripts.
+    let mut parts = directive.split_whitespace();
+    let keyword = parts.next()?.to_ascii_uppercase();
+    let target = parts.next();
+    match (keyword.as_str(), target) {
+        ("DIRECT", _) => Some(PacDirective::Direct),
+        // `PROXY` with no target is malformed — skipped rather than turned
+        // into a DIRECT, which would send traffic somewhere the script did
+        // not say.
+        ("PROXY", Some(t)) | ("HTTP", Some(t)) => Some(PacDirective::Proxy(t.to_string())),
+        ("HTTPS", Some(t)) => Some(PacDirective::Proxy(t.to_string())),
+        ("SOCKS", Some(t)) | ("SOCKS4", Some(t)) | ("SOCKS5", Some(t)) => {
+            Some(PacDirective::Socks(t.to_string()))
+        }
+        _ => None,
+    }
+}
+
+/// A per-host PAC decision, cached for a bounded time.
+///
+/// Bounded because a PAC script's answer can change (a laptop moves networks)
+/// and unbounded caching would pin the old answer for the process's life. The
+/// ask names k6's `dns.ttl` discipline as the model.
+#[derive(Debug, Clone)]
+pub struct PacDecision {
+    pub candidates: Vec<PacDirective>,
+    /// Which candidate is currently believed good. Advanced on failure.
+    pub current: usize,
+    pub decided_at: std::time::Instant,
+}
+
+impl PacDecision {
+    pub fn new(candidates: Vec<PacDirective>) -> Self {
+        Self { candidates, current: 0, decided_at: std::time::Instant::now() }
+    }
+
+    /// The candidate to try now, or `None` when every one has failed.
+    pub fn candidate(&self) -> Option<&PacDirective> {
+        self.candidates.get(self.current)
+    }
+
+    /// This candidate failed to CONNECT — advance to the next.
+    ///
+    /// Only connect/TLS/unsatisfiable-407 failures advance. An HTTP error
+    /// RESPONSE (a 500 from the target) means the proxy worked, so advancing
+    /// on it would try every candidate for a fault none of them can fix.
+    pub fn advance(&mut self) -> Option<&PacDirective> {
+        self.current += 1;
+        self.candidate()
+    }
+
+    pub fn exhausted(&self) -> bool {
+        self.current >= self.candidates.len()
+    }
+
+    pub fn is_stale(&self, ttl: std::time::Duration) -> bool {
+        self.decided_at.elapsed() >= ttl
+    }
+}
+
+/// Default PAC decision TTL.
+pub const DEFAULT_PAC_TTL: std::time::Duration = std::time::Duration::from_secs(300);

--- a/crates/tropel-http/tests/proxy_config.rs
+++ b/crates/tropel-http/tests/proxy_config.rs
@@ -297,3 +297,111 @@ fn pac_fields_read_in_both_spellings() {
         assert_eq!(cfg.pac_url.as_deref(), Some("http://a/x.dat"), "for {json}");
     }
 }
+
+// ── PAC directives and failover  [ask 17] ──────────────────────────────────
+//
+// "Bruno honours only the FIRST directive of the first matching return." A PAC
+// return value is a LIST separated by `;`, and honouring one of them turns a
+// config with a documented fallback into a single point of failure. These
+// tests are the parser and the ordering — the half where that bug lives.
+
+use tropel_http::{DEFAULT_PAC_TTL, PacDecision, PacDirective, parse_pac_result};
+
+#[test]
+fn a_multi_directive_result_yields_every_candidate_in_order() {
+    // THE test. Three candidates, in the order the script wrote them.
+    let got = parse_pac_result("PROXY a:8080; PROXY b:8080; DIRECT");
+    assert_eq!(
+        got,
+        vec![
+            PacDirective::Proxy("a:8080".into()),
+            PacDirective::Proxy("b:8080".into()),
+            PacDirective::Direct,
+        ]
+    );
+}
+
+#[test]
+fn socks_and_its_versioned_spellings_all_parse() {
+    let got = parse_pac_result("SOCKS a:1080; SOCKS4 b:1080; SOCKS5 c:1080");
+    assert_eq!(got.len(), 3);
+    assert!(got.iter().all(|d| matches!(d, PacDirective::Socks(_))));
+}
+
+#[test]
+fn the_keyword_is_case_insensitive_and_whitespace_is_flexible() {
+    // Generated scripts use tabs and mixed case. A strict single-space parse
+    // would silently drop directives that are perfectly valid.
+    let got = parse_pac_result("proxy   a:8080;\tPROXY\tb:8080 ; direct");
+    assert_eq!(got.len(), 3);
+}
+
+#[test]
+fn a_malformed_directive_is_skipped_not_fatal() {
+    // A PAC script is often generated; one malformed entry in a list of four
+    // must not take the other three down.
+    let got = parse_pac_result("PROXY a:8080; NONSENSE; PROXY b:8080");
+    assert_eq!(got.len(), 2, "the two good ones survive: {got:?}");
+}
+
+#[test]
+fn a_proxy_with_no_target_is_skipped_rather_than_becoming_direct() {
+    // Turning it into DIRECT would send traffic somewhere the script did not
+    // say — the silent misroute this whole surface exists to prevent.
+    let got = parse_pac_result("PROXY; DIRECT");
+    assert_eq!(got, vec![PacDirective::Direct]);
+}
+
+#[test]
+fn an_entirely_unparseable_result_is_empty_not_direct() {
+    // The caller must treat empty as a failure. Going direct on a PAC script
+    // we could not read is exactly the misroute to avoid, so the parser
+    // reports nothing rather than inventing a fallback.
+    assert!(parse_pac_result("garbage in").is_empty());
+    assert!(parse_pac_result("").is_empty());
+    assert!(parse_pac_result(";;;").is_empty());
+}
+
+#[test]
+fn a_directive_becomes_the_proxy_url_reqwest_needs() {
+    assert_eq!(PacDirective::Direct.proxy_url(), None);
+    assert_eq!(
+        PacDirective::Proxy("a:8080".into()).proxy_url().as_deref(),
+        Some("http://a:8080")
+    );
+    // socks5, not socks4: reqwest's SOCKS support is 5, and naming it is
+    // honest about what would actually be attempted.
+    assert_eq!(
+        PacDirective::Socks("a:1080".into()).proxy_url().as_deref(),
+        Some("socks5://a:1080")
+    );
+}
+
+#[test]
+fn failover_advances_through_the_candidates_in_order() {
+    let mut decision = PacDecision::new(parse_pac_result("PROXY a:1; PROXY b:2; DIRECT"));
+    assert_eq!(decision.candidate(), Some(&PacDirective::Proxy("a:1".into())));
+    assert_eq!(decision.advance(), Some(&PacDirective::Proxy("b:2".into())));
+    assert_eq!(decision.advance(), Some(&PacDirective::Direct));
+    assert!(!decision.exhausted());
+    assert_eq!(decision.advance(), None);
+    assert!(decision.exhausted(), "only after the LAST one fails does the request fail");
+}
+
+#[test]
+fn an_empty_decision_is_exhausted_immediately() {
+    // So a caller cannot mistake "no candidates" for "try the first".
+    let decision = PacDecision::new(Vec::new());
+    assert!(decision.exhausted());
+    assert_eq!(decision.candidate(), None);
+}
+
+#[test]
+fn a_fresh_decision_is_not_stale_and_the_ttl_is_bounded() {
+    // Bounded because a PAC answer changes when a laptop moves networks;
+    // unbounded caching would pin the old answer for the process's life.
+    let decision = PacDecision::new(parse_pac_result("DIRECT"));
+    assert!(!decision.is_stale(DEFAULT_PAC_TTL));
+    assert!(decision.is_stale(std::time::Duration::ZERO), "a zero TTL is always stale");
+    assert!(DEFAULT_PAC_TTL > std::time::Duration::ZERO);
+}


### PR DESCRIPTION
_(Re-opened: #580 was closed when I deleted the branch before confirming the
merge had landed — a network timeout on the merge call, and I ran the delete in
the same command. Same commit, rebased on master.)_

The ask carries a spec for this because it's the differentiator: *"Bruno honours
only the FIRST directive of the first matching return."* A PAC return value is a
**list** separated by `;`, and honouring one of them turns a config with a
documented fallback into a single point of failure.

PAC has two halves. **This is the one where the bug lives:**

- **the directive parser and failover ordering** — pure logic, no engine, fully
  testable. Here.
- **evaluating `FindProxyForURL(url, host)`** with its built-ins (`isInNet`,
  `dnsDomainIs`, `shExpMatch`, `weekdayRange`, …). That needs a JS engine, and
  `rquickjs` in `tropel-http` would put one inside the HTTP client crate —
  `tropel-sandbox` deliberately has no dependency on tropel-http and the reverse
  is equally deliberate. It wants its own crate: next, not blocked.

`parse_pac_result` returns **every** candidate in the order the script wrote
them. `PacDecision` walks them: `candidate()` is the one to try, `advance()`
moves on after a connect failure, `exhausted()` is the only state in which the
request fails — exactly "try candidates in order; only after the last one fails
does the request fail".

## Five decisions where the obvious alternative misroutes traffic

- **A malformed directive is skipped, not fatal.** PAC scripts are usually
  generated; one bad entry in a list of four mustn't take the other three down.
- **A `PROXY` with no target is skipped, not turned into `DIRECT`.** Promoting it
  would send traffic somewhere the script didn't say.
- **An entirely unparseable result is empty, not `DIRECT`.** The caller must
  treat empty as failure — going direct on a PAC script we couldn't read is the
  silent misroute this surface exists to prevent, so the parser refuses to
  invent a fallback.
- **Only connect failures advance.** An HTTP error *response* (a 500 from the
  target) means the proxy worked; advancing would try every candidate for a
  fault none can fix.
- **The decision TTL is bounded.** A PAC answer changes when a laptop moves
  networks; unbounded caching pins the old answer for the process's life. The
  ask names k6's `dns.ttl` discipline as the model.

The keyword is case-insensitive and any whitespace separates it from its target
— generated scripts use tabs and mixed case, and a strict single-space parse
would silently drop valid directives. `HTTP`/`HTTPS` alias `PROXY`;
`SOCKS4`/`SOCKS5` alias `SOCKS`.

A `SOCKS` directive maps to `socks5://`, not `socks4://`: reqwest's SOCKS
support is 5 and PAC's bare `SOCKS` predates the distinction, so naming 5 is
honest about what would actually be attempted. (SOCKS still needs `tokio-socks`,
absent from Cargo.lock — the dependency decision flagged in #579.)

**10 new tests, 126 pass in `tropel-http`, clippy clean.**