### PR TITLE
feat(auth): OAuth1 PLAINTEXT, over TLS only — and a third method list removed

### DIFF
--- a/crates/tropel-auth/src/builders.rs
+++ b/crates/tropel-auth/src/builders.rs
@@ -690,7 +690,8 @@ const RFC3986_UNRESERVED: AsciiSet = NON_ALPHANUMERIC
 /// dispatch read from ONE list. When they were separate, adding a method to
 /// one and not the other was a silent downgrade — the TR-004/TR-409 failure
 /// shape, where an unsupported method quietly signs as HMAC-SHA1.
-pub const OAUTH1_SIGNATURE_METHODS: [&str; 3] = ["HMAC-SHA1", "HMAC-SHA256", "HMAC-SHA512"];
+pub const OAUTH1_SIGNATURE_METHODS: [&str; 4] =
+    ["HMAC-SHA1", "HMAC-SHA256", "HMAC-SHA512", "PLAINTEXT"];
 
 /// Whether `method` (case-insensitive) is one of [`OAUTH1_SIGNATURE_METHODS`].
 pub fn oauth1_is_supported_signature_method(method: &str) -> bool {
@@ -769,6 +770,16 @@ pub fn oauth1_signature(
         "HMAC-SHA1" => sign_with!(Sha1),
         "HMAC-SHA256" => sign_with!(Sha256),
         "HMAC-SHA512" => sign_with!(Sha512),
+        // ask 8: RFC 5849 §3.4.4 — the PLAINTEXT signature IS the key, so
+        // the `key` built above is already it. No hashing, which is the
+        // point: the secrets travel in the clear.
+        //
+        // Which is also why the SIGNER refuses PLAINTEXT over a non-TLS URL.
+        // The spec says it "MUST only be used over a secure channel", and a
+        // consumer secret sent as plaintext over http:// is a credential
+        // leak — not a weak signature, a disclosed key. That guard belongs
+        // where the scheme is visible, not here where only a base string is.
+        "PLAINTEXT" => key.clone(),
         _ => return None,
     })
 }
@@ -1503,7 +1514,10 @@ mod tests {
         }
         // And the converse: unsupported methods must return None, NOT fall
         // back to HMAC-SHA1. A silent downgrade is the TR-004/TR-409 shape.
-        for method in ["RSA-SHA1", "RSA-SHA256", "PLAINTEXT", "HMAC-MD5", ""] {
+        // ask 8: PLAINTEXT left this list — it is implemented now. The RSA
+        // family stays: it needs key material (`private_key_pem` on the
+        // config) and an RSA crate, neither of which is in the graph.
+        for method in ["RSA-SHA1", "RSA-SHA256", "RSA-SHA512", "HMAC-MD5", ""] {
             assert!(
                 !oauth1_is_supported_signature_method(method),
                 "{method} must not be treated as supported"
@@ -1521,6 +1535,7 @@ mod tests {
         // digest type. A copy-paste slip that passed `Sha256` twice would
         // leave every test above green — they never compare the arms against
         // each other — while silently signing SHA-512 requests with SHA-256.
+        // Distinctness holds across EVERY listed method, PLAINTEXT included.
         let sigs: Vec<String> = OAUTH1_SIGNATURE_METHODS
             .iter()
             .map(|m| oauth1_signature("base-string", "cs", "ts", m).expect("listed method"))
@@ -1535,11 +1550,30 @@ mod tests {
             }
         }
         // Lengths follow the digest, so a wrong arm is visible even if two
-        // digests somehow collided.
+        // digests somehow collided. Scoped to the HMAC FAMILY: PLAINTEXT has
+        // no digest — its signature is the key itself, so its length is a
+        // function of the secrets and asserting a constant would be
+        // asserting the fixture rather than the algorithm (ask 8).
+        let hmac_lengths: Vec<usize> = OAUTH1_SIGNATURE_METHODS
+            .iter()
+            .zip(sigs.iter())
+            .filter(|(m, _)| m.starts_with("HMAC-"))
+            .map(|(_, s)| s.len())
+            .collect();
         assert_eq!(
-            sigs.iter().map(|s| s.len()).collect::<Vec<_>>(),
+            hmac_lengths,
             vec![28, 44, 88],
             "base64 lengths must match SHA-1 (20B), SHA-256 (32B), SHA-512 (64B)"
+        );
+        // And PLAINTEXT is the key verbatim, per RFC 5849 §3.4.4 — asserted
+        // rather than assumed, because "the signature is the key" is exactly
+        // the kind of claim that reads as a bug.
+        let plaintext = oauth1_signature("any-base-string", "cs", "ts", "PLAINTEXT").unwrap();
+        assert_eq!(plaintext, "cs&ts");
+        assert_eq!(
+            oauth1_signature("a-different-base-string", "cs", "ts", "PLAINTEXT").unwrap(),
+            plaintext,
+            "PLAINTEXT does not depend on the base string at all"
         );
     }
 

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -467,6 +467,18 @@ impl OAuth1Auth {
             )));
         }
 
+        // ask 8: PLAINTEXT sends the consumer secret in the clear. RFC 5849
+        // §3.4.4 requires a secure channel, and over http:// this is not a
+        // weak signature — it is a DISCLOSED KEY. Refused rather than signed,
+        // because a leaked credential cannot be un-leaked by noticing later.
+        if method_str == "PLAINTEXT" && url.scheme() != "https" {
+            return Err(TropelError::Other(format!(
+                "OAuth1 PLAINTEXT over {}:// would send the consumer secret in the clear — \
+                 RFC 5849 requires a secure channel; request not sent",
+                url.scheme()
+            )));
+        }
+
         let base_uri = base_url(url);
         let out = crate::builders::oauth1_build_header(&crate::builders::OAuth1BuildParams {
             method,
@@ -1031,15 +1043,19 @@ pub fn build_auth_signer(auth: &AuthConfig) -> Result<Option<Box<dyn AuthSigner>
         } => {
             // TR-409: validate the picker's signature method before constructing
             // the signer. Unsupported methods are reported, not degraded.
+            //
+            // Reads `OAUTH1_SIGNATURE_METHODS` rather than its own list. It
+            // had one — a hardcoded `matches!` over the three HMAC names —
+            // which is the THIRD copy of the same set and exactly the drift
+            // the builder exports that constant to prevent: ask 8 added
+            // PLAINTEXT to the list and the dispatch, and this guard went on
+            // refusing it. A list nobody remembers is worse than no list.
             if let Some(m) = signature_method {
-                let up = m.to_ascii_uppercase();
-                if !matches!(
-                    up.as_str(),
-                    "HMAC-SHA1" | "HMAC-SHA256" | "HMAC-SHA512"
-                ) {
+                if !crate::builders::oauth1_is_supported_signature_method(m) {
                     return Err(TropelError::Other(format!(
-                        "unsupported auth scheme: oauth1 signature_method '{}' — supported: HMAC-SHA1, HMAC-SHA256, HMAC-SHA512 (TR-409)",
-                        m
+                        "unsupported auth scheme: oauth1 signature_method '{}' — supported: {} (TR-409)",
+                        m,
+                        crate::builders::OAUTH1_SIGNATURE_METHODS.join(", ")
                     )));
                 }
             }
@@ -1894,13 +1910,6 @@ mod tests {
                 token_secret: None,
                 signature_method: Some("RSA-SHA1".into()),
             },
-            AuthConfig::OAuth1 {
-                consumer_key: "c".into(),
-                consumer_secret: "s".into(),
-                token: None,
-                token_secret: None,
-                signature_method: Some("PLAINTEXT".into()),
-            },
         ];
         for cfg in unsupported {
             let err = match build_auth_signer(&cfg) {
@@ -1912,6 +1921,41 @@ mod tests {
                 "error must mention unsupported: {err}"
             );
         }
+        // ask 8: PLAINTEXT is supported now — but only over TLS. RFC 5849
+        // §3.4.4 requires a secure channel, and over http:// this is not a
+        // weak signature but a DISCLOSED consumer secret.
+        let plaintext = AuthConfig::OAuth1 {
+            consumer_key: "c".into(),
+            consumer_secret: "s".into(),
+            token: None,
+            token_secret: None,
+            signature_method: Some("PLAINTEXT".into()),
+        };
+        let signer = build_auth_signer(&plaintext).expect("builds").expect("a signer");
+
+        let mut secure = reqwest::Request::new(
+            reqwest::Method::GET,
+            reqwest::Url::parse("https://example.test/x").unwrap(),
+        );
+        signer.sign(&mut secure).expect("https signs");
+        let header = secure
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(header.contains("oauth_signature_method=\"PLAINTEXT\""), "got {header}");
+
+        let mut insecure = reqwest::Request::new(
+            reqwest::Method::GET,
+            reqwest::Url::parse("http://example.test/x").unwrap(),
+        );
+        let err = match signer.sign(&mut insecure) {
+            Ok(()) => panic!("PLAINTEXT over http:// must be refused"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("in the clear"), "says what leaks: {err}");
+        assert!(err.contains("not sent"), "and that nothing went out: {err}");
+
         // ask 11: WSSE is supported now. The PLACEMENT is what matters —
         // `X-WSSE` carries the token and `Authorization` the profile marker,
         // matching KnockPort's wasm pipeline exactly. A native tier that put


### PR DESCRIPTION
Ask 8's two halves have very different costs. **PLAINTEXT is here; the RSA
family is not**, and the reason is a dependency.

## PLAINTEXT was already computed

RFC 5849 §3.4.4 defines the signature as
`enc(consumer_secret)&enc(token_secret)` — exactly the `key` that
`oauth1_signature` already builds for the HMAC family. So the arm is
`key.clone()`, and the test asserts that rather than trusting it: the signature
**is** the key verbatim, and it doesn't depend on the base string at all.

## Over TLS only — the part worth arguing about

RFC 5849 says PLAINTEXT "MUST only be used over a secure channel". Over `http://`
this is not a weak signature — it's a **disclosed consumer secret**, and a
leaked credential can't be un-leaked by noticing later. So the signer refuses,
naming what would have leaked, rather than signing and hoping.

The guard lives in the **signer**, not the builder: only the signer sees the URL
scheme, and `oauth1_signature` is handed a base string. Putting it in the builder
would mean passing the scheme in for one method's benefit.

## A third copy of the same list

`OAUTH1_SIGNATURE_METHODS` exists with a comment explaining why: *"the caller's
'unsupported method' guard and the builder's own dispatch read from ONE list.
When they were separate, adding a method to one and not the other was a silent
downgrade."*

`build_auth_signer` had a **third** — a hardcoded `matches!` over the three HMAC
names. Adding PLAINTEXT to the constant *and* the dispatch left that guard
refusing it, with an error listing the old three. The drift the constant exists
to prevent had already happened, one layer up. It now reads the constant.

## Verification

**103 pass in `tropel-auth`**, clippy clean, workspace compiles.

**Three existing tests changed, each on purpose:**

- `oauth1_every_listed_method_actually_dispatches` — PLAINTEXT leaves the
  unsupported list; `RSA-SHA512` joins it so the RSA family stays covered.
- `oauth1_signature_methods_produce_distinct_signatures` — distinctness still
  holds across all four, but the base64 **length** assertion is scoped to the
  HMAC family. PLAINTEXT has no digest: its length is a function of the secrets,
  so a constant there would assert the fixture rather than the algorithm.
- `build_auth_signer_covers_all_variants` — PLAINTEXT moves from "unsupported"
  to a case that signs over https and is **refused** over http.

## Not in this PR

**RSA-SHA1/256/512.** The ask says it "needs key material — add
`private_key_pem` to the OAuth1 config variant and `sign_jwt`-style RSA
signing", and there is no RSA anywhere: `rsa`, `pkcs1`, `pkcs8`, `signature` and
`spki` are all absent from Cargo.lock, and `sign_jwt` is HMAC-only (which is ask
12's subject). So it needs a new crypto dependency plus an SDK field — a
dependency decision, and one that wants taking together with ask 12's RSA/ES JWT
algorithms rather than twice.