### PR TITLE
feat(openapi): declare the path template, and stop dropping shared parameters

### DIFF
--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -32,11 +32,11 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use tropel_sdk::{ApiKeyLocation, AuthConfig, Body, FormDataPart, Method, Request};
-use tropel_sdk::{InputAdapter, InputAdapterRegistration};
-use tropel_sdk::{Result, TropelError};
 use tropel_sdk::{
     DeclaredBody, DeclaredField, DeclaredParameter, DeclaredResponse, RequestContract,
 };
+use tropel_sdk::{InputAdapter, InputAdapterRegistration};
+use tropel_sdk::{Result, TropelError};
 use tropel_sdk::{Scenario, ScenarioInfo, ScenarioItem};
 
 /// Parse an OpenAPI document as JSON, falling back to YAML (OpenAPI specs
@@ -554,7 +554,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
             items.push(ScenarioItem {
                 authoring: None,
                 // KP-524: the declaration, beside the example the Request is.
-                contract: build_contract(operation),
+                contract: build_contract(operation, &params, path_str),
                 name: item_name,
                 id: None,
                 request: Some(Request {
@@ -1183,9 +1183,18 @@ static NULL_STR: &str = "null";
 ///
 /// Returns `None` when the operation declares nothing at all, so an item from
 /// a spec with no parameters, body or responses serializes exactly as before.
-fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
-    let parameters: Vec<DeclaredParameter> = operation
-        .parameters
+/// `params` is the MERGED list — path-item-level parameters followed by
+/// operation-level ones, the same list the Request is built from. Reading
+/// `operation.parameters` alone would drop every parameter declared once at
+/// the path-item level and shared across its operations, which OpenAPI
+/// explicitly allows and specs of any size use for `{id}`. The declaration
+/// would then disagree with the Request built beside it from the same spec.
+fn build_contract(
+    operation: &OasOperation,
+    params: &[&OasParameter],
+    path_str: &str,
+) -> Option<RequestContract> {
+    let parameters: Vec<DeclaredParameter> = params
         .iter()
         .filter(|p| !p.name.is_empty())
         .map(|p| DeclaredParameter {
@@ -1195,7 +1204,11 @@ fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
             // `None` rather than a guess: a `$ref` or a composition names no
             // type here, and defaulting to "string" would have a consumer
             // assert a type the spec never declared.
-            r#type: p.schema.as_ref().and_then(|s| schema_type(s)).map(str::to_string),
+            r#type: p
+                .schema
+                .as_ref()
+                .and_then(|s| schema_type(s))
+                .map(str::to_string),
         })
         .collect();
 
@@ -1230,10 +1243,28 @@ fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
         })
         .collect();
 
-    if parameters.is_empty() && body.is_none() && responses.is_empty() {
+    // Only when the path HAS a placeholder, which is exactly when the sent
+    // url stops being able to answer for it. `/ping` needs no template — its
+    // `Request::url` path IS the declaration — and setting one there would
+    // put a `contract` on every item of every spec, ending the "an item from
+    // a bare spec serializes as it did before the field existed" guarantee
+    // for no information gained. A consumer's rule is the one an `Option`
+    // asks for anyway: the template if present, else the url's path.
+    let path_template = if path_str.contains('{') {
+        Some(path_str.to_string())
+    } else {
+        None
+    };
+
+    if parameters.is_empty() && body.is_none() && responses.is_empty() && path_template.is_none() {
         return None;
     }
-    Some(RequestContract { parameters, body, responses })
+    Some(RequestContract {
+        parameters,
+        body,
+        responses,
+        path_template,
+    })
 }
 
 /// Content-type keys, SORTED.
@@ -1271,9 +1302,15 @@ fn declared_fields(content: &HashMap<String, OasMediaType>) -> Vec<DeclaredField
         order.insert(0, json);
     }
     for key in order {
-        let Some(media) = content.get(&key) else { continue };
-        let Some(schema) = media.schema.as_ref() else { continue };
-        let Some(properties) = schema.properties.as_ref() else { continue };
+        let Some(media) = content.get(&key) else {
+            continue;
+        };
+        let Some(schema) = media.schema.as_ref() else {
+            continue;
+        };
+        let Some(properties) = schema.properties.as_ref() else {
+            continue;
+        };
         let mut fields: Vec<DeclaredField> = properties
             .iter()
             .map(|(name, prop)| DeclaredField {
@@ -2731,17 +2768,29 @@ mod contract_tests {
         // Declaration order, not sorted: a spec's parameter order is
         // meaningful to a reader and cheap to preserve.
         assert_eq!(names, vec!["page", "limit", "X-Trace"]);
-        let limit = c.parameters.iter().find(|p| p.name == "limit").expect("limit");
+        let limit = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "limit")
+            .expect("limit");
         assert_eq!(limit.location, "query");
         assert!(limit.required, "the spec says required: true");
         assert_eq!(limit.r#type.as_deref(), Some("integer"));
         // The one the synthesized example cannot express: `page` is declared
         // optional, and the Request carries a value for it regardless.
-        let page = c.parameters.iter().find(|p| p.name == "page").expect("page");
+        let page = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "page")
+            .expect("page");
         assert!(!page.required);
         // And a HEADER parameter is distinguishable from a query one, which a
         // Request's flat `headers` list cannot say.
-        let trace = c.parameters.iter().find(|p| p.name == "X-Trace").expect("X-Trace");
+        let trace = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "X-Trace")
+            .expect("X-Trace");
         assert_eq!(trace.location, "header");
     }
 
@@ -2760,7 +2809,11 @@ mod contract_tests {
         // `4XX` and `default` are legal and neither parses as a number. A
         // `u16` key would have dropped exactly these.
         let c = contract_for("GET");
-        assert!(c.responses.contains_key("4XX"), "got {:?}", c.responses.keys());
+        assert!(
+            c.responses.contains_key("4XX"),
+            "got {:?}",
+            c.responses.keys()
+        );
         assert!(c.responses.contains_key("default"));
     }
 
@@ -2797,9 +2850,112 @@ mod contract_tests {
         // produce different Scenario JSON on each parse and break every
         // golden test that compares it.
         let c = contract_for("POST");
-        let names: Vec<&str> =
-            c.body.as_ref().unwrap().fields.iter().map(|f| f.name.as_str()).collect();
+        let names: Vec<&str> = c
+            .body
+            .as_ref()
+            .unwrap()
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
         assert_eq!(names, vec!["email", "name"]);
+    }
+
+    #[test]
+    fn a_parameterized_path_carries_the_template_the_url_no_longer_has() {
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users/{id}":{"get":{
+            "parameters":[{"name":"id","in":"path","required":true,
+              "schema":{"type":"string"}}],
+            "responses":{"200":{"description":"ok"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        let item = scenario.items.first().expect("one item");
+        let contract = item.contract.as_ref().expect("has a contract");
+        assert_eq!(contract.path_template.as_deref(), Some("/users/{id}"));
+        // And the Request still holds the SUBSTITUTED url, because that is
+        // what a load run sends. Both facts, side by side — which is the
+        // entire point of the contract living beside the Request.
+        let url = &item.request.as_ref().expect("has a request").url;
+        assert!(url.ends_with("/users/example"), "got {url}");
+        // The `{{base_url}}` prefix is a tropel VARIABLE, resolved at run
+        // time — so only the path part is checked for a leftover path
+        // placeholder, which is the thing substitution was meant to remove.
+        let path = url.rsplit("}}").next().unwrap_or(url);
+        assert!(!path.contains('{'), "no path placeholder survives: {path}");
+    }
+
+    #[test]
+    fn a_path_with_no_placeholder_carries_no_template() {
+        // Nothing was destroyed, so there is nothing to carry — and setting
+        // one anyway would put a `contract` on every item of every spec.
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users":{"get":{"responses":{"200":{"description":"ok"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        let contract = scenario.items[0]
+            .contract
+            .as_ref()
+            .expect("responses alone give a contract");
+        assert!(
+            contract.path_template.is_none(),
+            "got {:?}",
+            contract.path_template
+        );
+    }
+
+    #[test]
+    fn a_path_item_level_parameter_reaches_the_declaration() {
+        // The bug this signature change fixes. OpenAPI lets a parameter be
+        // declared ONCE on the path item and shared by its operations, which
+        // is how specs of any size declare `{id}`. `build_contract` read
+        // `operation.parameters` only, so those parameters were in the
+        // Request — built from the merged list — and absent from the
+        // declaration built beside it from the same spec. A consumer would
+        // have seen a request sending `id` that nothing declared.
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users/{id}":{
+            "parameters":[{"name":"id","in":"path","required":true,
+              "schema":{"type":"string"}}],
+            "get":{"parameters":[{"name":"verbose","in":"query",
+              "schema":{"type":"boolean"}}],
+             "responses":{"200":{"description":"ok"}}},
+            "delete":{"responses":{"204":{"description":"gone"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        for item in &scenario.items {
+            let contract = item.contract.as_ref().expect("has a contract");
+            let names: Vec<&str> = contract
+                .parameters
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect();
+            assert!(
+                names.contains(&"id"),
+                "{}: the shared path parameter must be declared, got {names:?}",
+                item.name
+            );
+            let id = contract
+                .parameters
+                .iter()
+                .find(|p| p.name == "id")
+                .expect("found");
+            assert_eq!(id.location, "path");
+            assert!(id.required);
+        }
+        // Path-item first, then operation — the same order the Request is
+        // built from, so a positional consumer sees one story.
+        let get = scenario
+            .items
+            .iter()
+            .find(|i| i.name.contains("GET"))
+            .expect("the GET is there");
+        let names: Vec<&str> = get
+            .contract
+            .as_ref()
+            .unwrap()
+            .parameters
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["id", "verbose"]);
     }
 
     #[test]
@@ -2821,7 +2977,11 @@ mod contract_tests {
         // run needs. If this drifts, the contract has leaked into the wire
         // view.
         let scenario = OpenApiInputAdapter.parse(SPEC.as_bytes()).expect("parses");
-        let post = scenario.items.iter().find(|i| i.name.starts_with("POST")).expect("POST");
+        let post = scenario
+            .items
+            .iter()
+            .find(|i| i.name.starts_with("POST"))
+            .expect("POST");
         let request = post.request.as_ref().expect("a request");
         let body = serde_json::to_value(request.body.as_ref().expect("a body")).expect("json");
         // Still the example, with type-name placeholders — not the schema.


### PR DESCRIPTION
Consumes tropel-sdk#28. Two facts the OpenAPI declaration was missing, both about parameterized paths.

## The template

Building an executable request substitutes every path parameter — `/users/{id}` becomes `/users/example` — which is correct for a load run and unrecoverable afterwards, since the substituted segment is indistinguishable from a literal one.

A consumer comparing a collection against a spec therefore finds **no pair for any parameterized path** and reports each one twice: "declared but missing from the collection" and "in the collection but not declared". Parameterized paths are most of any REST API, so a perfectly synchronized collection produces a page of findings.

Set only when the path actually contains a placeholder. `/ping` needs no template — its url path *is* the declaration — and setting one there would put a `contract` on every item of every spec, ending the "an item from a bare spec serializes as it did before the field existed" guarantee for no information gained.

## The shared parameters

`build_contract` read `operation.parameters`. The `Request` built beside it, from the same spec, is built from the **merged** list — path-item-level parameters followed by operation-level ones.

OpenAPI lets a parameter be declared once on the path item and shared by its operations, which is how specs of any size declare `{id}`. Those parameters were therefore *sent* and *not declared*: a consumer would see a request carrying `id` that nothing accounted for, and the `DELETE` in the new fixture — which has no operation-level parameters at all — declared nothing whatsoever.

The new test fails on the old code with `GET /users/{id}: the shared path parameter must be declared, got ["verbose"]`. Verified by reverting the one-line change and re-running.

## Tests

3 new, 41 pass:
- the template arrives *and* the Request still holds the substituted url — both facts side by side, which is why the contract lives beside the Request rather than inside it
- a path with no placeholder carries no template
- a path-item-level parameter reaches the declaration, in path-item-then-operation order

clippy clean, rustfmt clean.