### PR TITLE
feat(auth): read EdgeGrid's named credentials, and resolve them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "tropel"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-engine"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-web"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "postcard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ tropel-scheduler = { path = "crates/tropel-scheduler", version = "0.1.0" }
 tropel-metrics = { path = "crates/tropel-metrics" }
 tropel-report = { path = "crates/tropel-report" }
 tropel-ext = { path = "crates/tropel-ext", version = "0.1.0" }
-tropel-sdk = { path = "crates/tropel-sdk", version = "0.3.0" }
+tropel-sdk = { path = "crates/tropel-sdk", version = "0.4.0" }
 tropel-engine = { path = "crates/tropel-engine" }
 tropel-build = { path = "crates/tropel-build" }
 tropel-input-postman = { path = "crates/inputs/tropel-input-postman" }

--- a/crates/inputs/tropel-input-bru/src/lib.rs
+++ b/crates/inputs/tropel-input-bru/src/lib.rs
@@ -42,9 +42,9 @@ use serde::Deserialize;
 mod text;
 use std::collections::HashMap;
 use tropel_sdk::{ApiKeyLocation, AuthConfig, Body, FormDataPart, Method, Request};
+use tropel_sdk::{AuthoredEntry, AuthoredSettings, RequestAuthoring};
 use tropel_sdk::{InputAdapter, InputAdapterRegistration};
 use tropel_sdk::{Result, TropelError};
-use tropel_sdk::{AuthoredEntry, AuthoredSettings, RequestAuthoring};
 use tropel_sdk::{Scenario, ScenarioInfo, ScenarioItem};
 
 // ── Bruno collection JSON model (minimal — only what we need) ────
@@ -536,20 +536,18 @@ fn http_item_to_item(item: &BruItem) -> Result<ScenarioItem> {
 
     let settings = build_settings(&request.settings);
 
-    let authoring = if authored_headers.is_empty()
-        && query.is_empty()
-        && vars.is_empty()
-        && settings.is_none()
-    {
-        None
-    } else {
-        Some(RequestAuthoring {
-            headers: authored_headers,
-            query,
-            vars,
-            settings,
-        })
-    };
+    let authoring =
+        if authored_headers.is_empty() && query.is_empty() && vars.is_empty() && settings.is_none()
+        {
+            None
+        } else {
+            Some(RequestAuthoring {
+                headers: authored_headers,
+                query,
+                vars,
+                settings,
+            })
+        };
 
     let body = request.body.as_ref().and_then(build_body);
     let auth = request.auth.as_ref().and_then(build_auth);
@@ -1435,7 +1433,10 @@ mod bru_text_format {
         // enabled expression would invent a check the user switched off.
         let doc = "meta {\n  name: A\n}\n\nget {\n  url: https://e.com\n}\n\nassert {\n  ~res.status: eq 200\n  res.body.ok: eq true\n}\n";
         let s = BruInputAdapter.parse(doc.as_bytes()).expect("parses");
-        assert_eq!(s.items[0].assertions, vec!["response.body.ok === true".to_string()]);
+        assert_eq!(
+            s.items[0].assertions,
+            vec!["response.body.ok === true".to_string()]
+        );
     }
 
     #[test]
@@ -1443,7 +1444,10 @@ mod bru_text_format {
         // Not a skip: an assertion that can never run looks exactly like one
         // that passes.
         let doc = "meta {\n  name: A\n}\n\nget {\n  url: https://e.com\n}\n\nassert {\n  res.status: teleports 200\n}\n";
-        let err = BruInputAdapter.parse(doc.as_bytes()).unwrap_err().to_string();
+        let err = BruInputAdapter
+            .parse(doc.as_bytes())
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("teleports"), "{err}");
     }
 
@@ -1499,10 +1503,18 @@ mod bru_text_format {
             req.headers
         );
 
-        let draft = a.headers.iter().find(|e| e.key == "x-draft").expect("~x-draft");
+        let draft = a
+            .headers
+            .iter()
+            .find(|e| e.key == "x-draft")
+            .expect("~x-draft");
         assert_eq!(draft.value, "true");
         assert!(!draft.enabled, "the ~ prefix means disabled, not absent");
-        let accept = a.headers.iter().find(|e| e.key == "accept").expect("accept");
+        let accept = a
+            .headers
+            .iter()
+            .find(|e| e.key == "accept")
+            .expect("accept");
         assert!(accept.enabled);
     }
 
@@ -1529,10 +1541,20 @@ mod bru_text_format {
         let item = only_item(POST_LOGIN);
         let a = item.authoring.as_ref().expect("authoring");
 
-        let vars: Vec<(&str, &str)> = a.vars.iter().map(|v| (v.key.as_str(), v.value.as_str())).collect();
+        let vars: Vec<(&str, &str)> = a
+            .vars
+            .iter()
+            .map(|v| (v.key.as_str(), v.value.as_str()))
+            .collect();
         // The `@` marker is Bruno's "request-local" prefix and is not part of
         // the name.
-        assert_eq!(vars, vec![("requestId", "req-1"), ("baseUrl", "https://api.example.com")]);
+        assert_eq!(
+            vars,
+            vec![
+                ("requestId", "req-1"),
+                ("baseUrl", "https://api.example.com")
+            ]
+        );
 
         let st = a.settings.as_ref().expect("settings");
         assert_eq!(st.timeout, Some(3000));

--- a/crates/inputs/tropel-input-bru/src/text.rs
+++ b/crates/inputs/tropel-input-bru/src/text.rs
@@ -314,7 +314,8 @@ fn assertion_literal(value: &str) -> String {
     let v = value.trim();
     if !v.is_empty()
         && v.parse::<f64>().is_ok()
-        && v.chars().all(|c| c.is_ascii_digit() || c == '.' || c == '-')
+        && v.chars()
+            .all(|c| c.is_ascii_digit() || c == '.' || c == '-')
     {
         return v.to_string();
     }

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -32,11 +32,11 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use tropel_sdk::{ApiKeyLocation, AuthConfig, Body, FormDataPart, Method, Request};
-use tropel_sdk::{InputAdapter, InputAdapterRegistration};
-use tropel_sdk::{Result, TropelError};
 use tropel_sdk::{
     DeclaredBody, DeclaredField, DeclaredParameter, DeclaredResponse, RequestContract,
 };
+use tropel_sdk::{InputAdapter, InputAdapterRegistration};
+use tropel_sdk::{Result, TropelError};
 use tropel_sdk::{Scenario, ScenarioInfo, ScenarioItem};
 
 /// Parse an OpenAPI document as JSON, falling back to YAML (OpenAPI specs
@@ -1195,7 +1195,11 @@ fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
             // `None` rather than a guess: a `$ref` or a composition names no
             // type here, and defaulting to "string" would have a consumer
             // assert a type the spec never declared.
-            r#type: p.schema.as_ref().and_then(|s| schema_type(s)).map(str::to_string),
+            r#type: p
+                .schema
+                .as_ref()
+                .and_then(|s| schema_type(s))
+                .map(str::to_string),
         })
         .collect();
 
@@ -1233,7 +1237,11 @@ fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
     if parameters.is_empty() && body.is_none() && responses.is_empty() {
         return None;
     }
-    Some(RequestContract { parameters, body, responses })
+    Some(RequestContract {
+        parameters,
+        body,
+        responses,
+    })
 }
 
 /// Content-type keys, SORTED.
@@ -1271,9 +1279,15 @@ fn declared_fields(content: &HashMap<String, OasMediaType>) -> Vec<DeclaredField
         order.insert(0, json);
     }
     for key in order {
-        let Some(media) = content.get(&key) else { continue };
-        let Some(schema) = media.schema.as_ref() else { continue };
-        let Some(properties) = schema.properties.as_ref() else { continue };
+        let Some(media) = content.get(&key) else {
+            continue;
+        };
+        let Some(schema) = media.schema.as_ref() else {
+            continue;
+        };
+        let Some(properties) = schema.properties.as_ref() else {
+            continue;
+        };
         let mut fields: Vec<DeclaredField> = properties
             .iter()
             .map(|(name, prop)| DeclaredField {
@@ -2731,17 +2745,29 @@ mod contract_tests {
         // Declaration order, not sorted: a spec's parameter order is
         // meaningful to a reader and cheap to preserve.
         assert_eq!(names, vec!["page", "limit", "X-Trace"]);
-        let limit = c.parameters.iter().find(|p| p.name == "limit").expect("limit");
+        let limit = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "limit")
+            .expect("limit");
         assert_eq!(limit.location, "query");
         assert!(limit.required, "the spec says required: true");
         assert_eq!(limit.r#type.as_deref(), Some("integer"));
         // The one the synthesized example cannot express: `page` is declared
         // optional, and the Request carries a value for it regardless.
-        let page = c.parameters.iter().find(|p| p.name == "page").expect("page");
+        let page = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "page")
+            .expect("page");
         assert!(!page.required);
         // And a HEADER parameter is distinguishable from a query one, which a
         // Request's flat `headers` list cannot say.
-        let trace = c.parameters.iter().find(|p| p.name == "X-Trace").expect("X-Trace");
+        let trace = c
+            .parameters
+            .iter()
+            .find(|p| p.name == "X-Trace")
+            .expect("X-Trace");
         assert_eq!(trace.location, "header");
     }
 
@@ -2760,7 +2786,11 @@ mod contract_tests {
         // `4XX` and `default` are legal and neither parses as a number. A
         // `u16` key would have dropped exactly these.
         let c = contract_for("GET");
-        assert!(c.responses.contains_key("4XX"), "got {:?}", c.responses.keys());
+        assert!(
+            c.responses.contains_key("4XX"),
+            "got {:?}",
+            c.responses.keys()
+        );
         assert!(c.responses.contains_key("default"));
     }
 
@@ -2797,8 +2827,14 @@ mod contract_tests {
         // produce different Scenario JSON on each parse and break every
         // golden test that compares it.
         let c = contract_for("POST");
-        let names: Vec<&str> =
-            c.body.as_ref().unwrap().fields.iter().map(|f| f.name.as_str()).collect();
+        let names: Vec<&str> = c
+            .body
+            .as_ref()
+            .unwrap()
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
         assert_eq!(names, vec!["email", "name"]);
     }
 
@@ -2821,7 +2857,11 @@ mod contract_tests {
         // run needs. If this drifts, the contract has leaked into the wire
         // view.
         let scenario = OpenApiInputAdapter.parse(SPEC.as_bytes()).expect("parses");
-        let post = scenario.items.iter().find(|i| i.name.starts_with("POST")).expect("POST");
+        let post = scenario
+            .items
+            .iter()
+            .find(|i| i.name.starts_with("POST"))
+            .expect("POST");
         let request = post.request.as_ref().expect("a request");
         let body = serde_json::to_value(request.body.as_ref().expect("a body")).expect("json");
         // Still the example, with type-name placeholders — not the schema.

--- a/crates/inputs/tropel-input-openapi/src/lib.rs
+++ b/crates/inputs/tropel-input-openapi/src/lib.rs
@@ -554,7 +554,7 @@ fn parse_typed(doc: OasDoc) -> Result<Scenario> {
             items.push(ScenarioItem {
                 authoring: None,
                 // KP-524: the declaration, beside the example the Request is.
-                contract: build_contract(operation),
+                contract: build_contract(operation, &params, path_str),
                 name: item_name,
                 id: None,
                 request: Some(Request {
@@ -1183,9 +1183,18 @@ static NULL_STR: &str = "null";
 ///
 /// Returns `None` when the operation declares nothing at all, so an item from
 /// a spec with no parameters, body or responses serializes exactly as before.
-fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
-    let parameters: Vec<DeclaredParameter> = operation
-        .parameters
+/// `params` is the MERGED list — path-item-level parameters followed by
+/// operation-level ones, the same list the Request is built from. Reading
+/// `operation.parameters` alone would drop every parameter declared once at
+/// the path-item level and shared across its operations, which OpenAPI
+/// explicitly allows and specs of any size use for `{id}`. The declaration
+/// would then disagree with the Request built beside it from the same spec.
+fn build_contract(
+    operation: &OasOperation,
+    params: &[&OasParameter],
+    path_str: &str,
+) -> Option<RequestContract> {
+    let parameters: Vec<DeclaredParameter> = params
         .iter()
         .filter(|p| !p.name.is_empty())
         .map(|p| DeclaredParameter {
@@ -1234,13 +1243,27 @@ fn build_contract(operation: &OasOperation) -> Option<RequestContract> {
         })
         .collect();
 
-    if parameters.is_empty() && body.is_none() && responses.is_empty() {
+    // Only when the path HAS a placeholder, which is exactly when the sent
+    // url stops being able to answer for it. `/ping` needs no template — its
+    // `Request::url` path IS the declaration — and setting one there would
+    // put a `contract` on every item of every spec, ending the "an item from
+    // a bare spec serializes as it did before the field existed" guarantee
+    // for no information gained. A consumer's rule is the one an `Option`
+    // asks for anyway: the template if present, else the url's path.
+    let path_template = if path_str.contains('{') {
+        Some(path_str.to_string())
+    } else {
+        None
+    };
+
+    if parameters.is_empty() && body.is_none() && responses.is_empty() && path_template.is_none() {
         return None;
     }
     Some(RequestContract {
         parameters,
         body,
         responses,
+        path_template,
     })
 }
 
@@ -2836,6 +2859,103 @@ mod contract_tests {
             .map(|f| f.name.as_str())
             .collect();
         assert_eq!(names, vec!["email", "name"]);
+    }
+
+    #[test]
+    fn a_parameterized_path_carries_the_template_the_url_no_longer_has() {
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users/{id}":{"get":{
+            "parameters":[{"name":"id","in":"path","required":true,
+              "schema":{"type":"string"}}],
+            "responses":{"200":{"description":"ok"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        let item = scenario.items.first().expect("one item");
+        let contract = item.contract.as_ref().expect("has a contract");
+        assert_eq!(contract.path_template.as_deref(), Some("/users/{id}"));
+        // And the Request still holds the SUBSTITUTED url, because that is
+        // what a load run sends. Both facts, side by side — which is the
+        // entire point of the contract living beside the Request.
+        let url = &item.request.as_ref().expect("has a request").url;
+        assert!(url.ends_with("/users/example"), "got {url}");
+        // The `{{base_url}}` prefix is a tropel VARIABLE, resolved at run
+        // time — so only the path part is checked for a leftover path
+        // placeholder, which is the thing substitution was meant to remove.
+        let path = url.rsplit("}}").next().unwrap_or(url);
+        assert!(!path.contains('{'), "no path placeholder survives: {path}");
+    }
+
+    #[test]
+    fn a_path_with_no_placeholder_carries_no_template() {
+        // Nothing was destroyed, so there is nothing to carry — and setting
+        // one anyway would put a `contract` on every item of every spec.
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users":{"get":{"responses":{"200":{"description":"ok"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        let contract = scenario.items[0]
+            .contract
+            .as_ref()
+            .expect("responses alone give a contract");
+        assert!(
+            contract.path_template.is_none(),
+            "got {:?}",
+            contract.path_template
+        );
+    }
+
+    #[test]
+    fn a_path_item_level_parameter_reaches_the_declaration() {
+        // The bug this signature change fixes. OpenAPI lets a parameter be
+        // declared ONCE on the path item and shared by its operations, which
+        // is how specs of any size declare `{id}`. `build_contract` read
+        // `operation.parameters` only, so those parameters were in the
+        // Request — built from the merged list — and absent from the
+        // declaration built beside it from the same spec. A consumer would
+        // have seen a request sending `id` that nothing declared.
+        let spec = r#"{"openapi":"3.0.0","info":{"title":"t","version":"1"},
+          "paths":{"/users/{id}":{
+            "parameters":[{"name":"id","in":"path","required":true,
+              "schema":{"type":"string"}}],
+            "get":{"parameters":[{"name":"verbose","in":"query",
+              "schema":{"type":"boolean"}}],
+             "responses":{"200":{"description":"ok"}}},
+            "delete":{"responses":{"204":{"description":"gone"}}}}}}"#;
+        let scenario = OpenApiInputAdapter.parse(spec.as_bytes()).expect("parses");
+        for item in &scenario.items {
+            let contract = item.contract.as_ref().expect("has a contract");
+            let names: Vec<&str> = contract
+                .parameters
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect();
+            assert!(
+                names.contains(&"id"),
+                "{}: the shared path parameter must be declared, got {names:?}",
+                item.name
+            );
+            let id = contract
+                .parameters
+                .iter()
+                .find(|p| p.name == "id")
+                .expect("found");
+            assert_eq!(id.location, "path");
+            assert!(id.required);
+        }
+        // Path-item first, then operation — the same order the Request is
+        // built from, so a positional consumer sees one story.
+        let get = scenario
+            .items
+            .iter()
+            .find(|i| i.name.contains("GET"))
+            .expect("the GET is there");
+        let names: Vec<&str> = get
+            .contract
+            .as_ref()
+            .unwrap()
+            .parameters
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["id", "verbose"]);
     }
 
     #[test]

--- a/crates/tropel-auth/src/edgegrid.rs
+++ b/crates/tropel-auth/src/edgegrid.rs
@@ -119,10 +119,7 @@ pub fn edgegrid_build_header(
         )));
     }
 
-    let timestamp = params
-        .timestamp
-        .clone()
-        .unwrap_or_else(edgegrid_timestamp);
+    let timestamp = params.timestamp.clone().unwrap_or_else(edgegrid_timestamp);
     let nonce = params.nonce.clone().unwrap_or_else(edgegrid_nonce);
 
     // Built ONCE: it is both the header prefix and the seventh signing field,
@@ -153,8 +150,8 @@ pub fn edgegrid_build_header(
 fn base64_hmac(message: &[u8], key: &[u8]) -> String {
     // Same idiom as `signers.rs`: hmac 0.13 puts `new_from_slice` on
     // `KeyInit`, and HMAC accepts a key of any length so this cannot fail.
-    let mut mac = <HmacSha256 as KeyInit>::new_from_slice(key)
-        .expect("HMAC-SHA256 accepts any key length");
+    let mut mac =
+        <HmacSha256 as KeyInit>::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
     mac.update(message);
     base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
 }
@@ -196,7 +193,9 @@ fn canonical_headers(names: &[String], headers: &[(String, String)]) -> String {
     let mut out = String::new();
     for name in names {
         let wanted = name.to_ascii_lowercase();
-        let Some((_, value)) = headers.iter().find(|(k, _)| k.to_ascii_lowercase() == wanted)
+        let Some((_, value)) = headers
+            .iter()
+            .find(|(k, _)| k.to_ascii_lowercase() == wanted)
         else {
             continue;
         };
@@ -234,7 +233,9 @@ fn split_url(url: &str) -> Result<(String, String, String)> {
 /// and produces a signature Akamai rejects with a 401 that says nothing about
 /// the format.
 pub fn edgegrid_timestamp() -> String {
-    chrono::Utc::now().format("%Y%m%dT%H:%M:%S+0000").to_string()
+    chrono::Utc::now()
+        .format("%Y%m%dT%H:%M:%S+0000")
+        .to_string()
 }
 
 /// A fresh nonce.
@@ -301,15 +302,26 @@ mod tests {
             prefix.clone(),
         ]
         .join("\t");
-        let key = base64_hmac(p.timestamp.as_deref().unwrap().as_bytes(), p.client_secret.as_bytes());
-        format!("{prefix}signature={}", base64_hmac(data.as_bytes(), key.as_bytes()))
+        let key = base64_hmac(
+            p.timestamp.as_deref().unwrap().as_bytes(),
+            p.client_secret.as_bytes(),
+        );
+        format!(
+            "{prefix}signature={}",
+            base64_hmac(data.as_bytes(), key.as_bytes())
+        )
     }
 
     #[test]
     fn the_header_has_the_documented_shape() {
         let header = edgegrid_build_header(&params(), &[]).expect("signs");
         assert!(header.starts_with("EG1-HMAC-SHA256 "), "got {header}");
-        for field in ["client_token=ctoken", "access_token=atoken", "nonce=abc123", "signature="] {
+        for field in [
+            "client_token=ctoken",
+            "access_token=atoken",
+            "nonce=abc123",
+            "signature=",
+        ] {
             assert!(header.contains(field), "missing {field} in {header}");
         }
         assert!(header.contains(&format!("timestamp={TS}")));
@@ -348,8 +360,13 @@ mod tests {
         let mut p = params();
         p.client_token = String::new();
         p.client_secret = String::new();
-        let err = edgegrid_build_header(&p, &[]).expect_err("must refuse").to_string();
-        assert!(err.contains("client_token") && err.contains("client_secret"), "got {err}");
+        let err = edgegrid_build_header(&p, &[])
+            .expect_err("must refuse")
+            .to_string();
+        assert!(
+            err.contains("client_token") && err.contains("client_secret"),
+            "got {err}"
+        );
     }
 
     #[test]
@@ -366,8 +383,14 @@ mod tests {
     fn an_oversized_body_is_skipped_not_truncated() {
         // Truncating would produce a signature the server cannot reproduce.
         let body = vec![b'x'; 10];
-        assert!(!content_hash("POST", Some(&body), 10).is_empty(), "exactly at the cap is hashed");
-        assert!(content_hash("POST", Some(&body), 9).is_empty(), "one byte over is skipped");
+        assert!(
+            !content_hash("POST", Some(&body), 10).is_empty(),
+            "exactly at the cap is hashed"
+        );
+        assert!(
+            content_hash("POST", Some(&body), 9).is_empty(),
+            "one byte over is skipped"
+        );
     }
 
     #[test]
@@ -424,7 +447,11 @@ mod tests {
         // goes into the signing data verbatim and produces a signature Akamai
         // rejects with a 401 that says nothing about the format.
         let ts = edgegrid_timestamp();
-        assert_eq!(ts.len(), 22, "yyyyMMddTHH:mm:ss+0000 is 22 chars, got {ts:?}");
+        assert_eq!(
+            ts.len(),
+            22,
+            "yyyyMMddTHH:mm:ss+0000 is 22 chars, got {ts:?}"
+        );
         assert!(ts.ends_with("+0000"), "got {ts}");
         assert_eq!(&ts[8..9], "T", "a literal T at position 8: {ts}");
         assert!(!ts.contains('-'), "no dashes in the date: {ts}");
@@ -446,7 +473,9 @@ mod tests {
     fn an_invalid_url_is_refused_by_name() {
         let mut p = params();
         p.url = "not a url".into();
-        let err = edgegrid_build_header(&p, &[]).expect_err("must refuse").to_string();
+        let err = edgegrid_build_header(&p, &[])
+            .expect_err("must refuse")
+            .to_string();
         assert!(err.contains("invalid URL"), "got {err}");
     }
 }

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -1121,28 +1121,47 @@ pub fn build_auth_signer(auth: &AuthConfig) -> Result<Option<Box<dyn AuthSigner>
         AuthConfig::AkamaiEdgeGrid {
             access_token,
             client_token,
+            client_secret,
+            headers_to_sign,
+            max_body,
             extra,
         } => {
-            let secret = extra
-                .get("client_secret")
-                .or_else(|| extra.get("clientSecret"))
-                .and_then(|v| v.as_str())
-                .unwrap_or_default();
-            let headers_to_sign = extra
-                .get("headers_to_sign")
-                .or_else(|| extra.get("headersToSign"))
-                .and_then(|v| v.as_array())
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str().map(str::to_string))
-                        .collect::<Vec<_>>()
+            // The named fields first, `extra` only as a fallback. They were
+            // read out of `extra` alone until tropel-sdk#30 gave them names —
+            // the variant existed to be REFUSED, so nothing needed them —
+            // and a caller that put `clientSecret` there while that was the
+            // only place must keep working.
+            let secret = client_secret
+                .as_deref()
+                .filter(|v| !v.is_empty())
+                .or_else(|| {
+                    extra
+                        .get("client_secret")
+                        .or_else(|| extra.get("clientSecret"))
+                        .and_then(|v| v.as_str())
                 })
                 .unwrap_or_default();
-            let max_body = extra
-                .get("max_body")
-                .or_else(|| extra.get("maxBody"))
-                .and_then(|v| v.as_u64())
-                .map(|n| n as usize);
+            let headers_to_sign = if headers_to_sign.is_empty() {
+                extra
+                    .get("headers_to_sign")
+                    .or_else(|| extra.get("headersToSign"))
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            } else {
+                headers_to_sign.clone()
+            };
+            let max_body = max_body.or_else(|| {
+                extra
+                    .get("max_body")
+                    .or_else(|| extra.get("maxBody"))
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as usize)
+            });
             // Validated HERE, not at sign time. `build_auth_signer` is where
             // config problems are reported, and handing back a signer that
             // will certainly fail moves the error further from the field that
@@ -2023,6 +2042,9 @@ mod tests {
         let incomplete = AuthConfig::AkamaiEdgeGrid {
             access_token: Some("a".into()),
             client_token: Some("c".into()),
+            client_secret: None,
+            headers_to_sign: Vec::new(),
+            max_body: None,
             extra: Default::default(),
         };
         let err = match build_auth_signer(&incomplete) {
@@ -2031,17 +2053,55 @@ mod tests {
         };
         assert!(err.contains("client_secret"), "names the field: {err}");
 
+        // The NAMED field (tropel-sdk#30).
         let complete = AuthConfig::AkamaiEdgeGrid {
             access_token: Some("a".into()),
             client_token: Some("c".into()),
-            extra: [("client_secret".to_string(), serde_json::json!("s"))]
-                .into_iter()
-                .collect(),
+            client_secret: Some("s".into()),
+            headers_to_sign: vec!["X-A".into()],
+            max_body: Some(4096),
+            extra: Default::default(),
         };
         let signer = build_auth_signer(&complete)
             .expect("a complete edgegrid config builds")
             .expect("a signer");
         assert_eq!(signer.name(), "akamai-edgegrid");
+
+        // And `extra`, which is where all three lived before they had names.
+        // A caller that still sends `clientSecret` must keep working — this
+        // is the fallback, not a leftover.
+        let via_extra = AuthConfig::AkamaiEdgeGrid {
+            access_token: Some("a".into()),
+            client_token: Some("c".into()),
+            client_secret: None,
+            headers_to_sign: Vec::new(),
+            max_body: None,
+            extra: [("clientSecret".to_string(), serde_json::json!("s"))]
+                .into_iter()
+                .collect(),
+        };
+        let signer = build_auth_signer(&via_extra)
+            .expect("the pre-#30 spelling still builds")
+            .expect("a signer");
+        assert_eq!(signer.name(), "akamai-edgegrid");
+
+        // An EMPTY named field is not a credential. Without the `filter`,
+        // `Some("")` would shadow a usable value in `extra` and the config
+        // would be refused for a secret it actually has.
+        let empty_named = AuthConfig::AkamaiEdgeGrid {
+            access_token: Some("a".into()),
+            client_token: Some("c".into()),
+            client_secret: Some(String::new()),
+            headers_to_sign: Vec::new(),
+            max_body: None,
+            extra: [("client_secret".to_string(), serde_json::json!("s"))]
+                .into_iter()
+                .collect(),
+        };
+        assert!(
+            build_auth_signer(&empty_named).is_ok(),
+            "an empty named field must not shadow a usable one in extra"
+        );
 
         // HMAC-SHA256 is supported — proves the picker value round-trips
         let hmac256 = AuthConfig::OAuth1 {

--- a/crates/tropel-auth/src/signers.rs
+++ b/crates/tropel-auth/src/signers.rs
@@ -868,7 +868,10 @@ pub struct WsseAuth {
 
 impl WsseAuth {
     pub fn new(username: &str, password: &str) -> Self {
-        Self { username: username.to_string(), password: password.to_string() }
+        Self {
+            username: username.to_string(),
+            password: password.to_string(),
+        }
     }
 }
 
@@ -953,7 +956,10 @@ impl AuthSigner for EdgeGridAuth {
         // cannot be hashed without consuming it, so it signs as if there were
         // no body — which is what Akamai's own clients do, and is why
         // oversized bodies are skipped rather than truncated.
-        let body = request.body().and_then(|b| b.as_bytes()).map(|b| b.to_vec());
+        let body = request
+            .body()
+            .and_then(|b| b.as_bytes())
+            .map(|b| b.to_vec());
 
         let params = crate::edgegrid::EdgeGridBuildParams {
             method: request.method().as_str().to_string(),
@@ -1931,7 +1937,9 @@ mod tests {
             token_secret: None,
             signature_method: Some("PLAINTEXT".into()),
         };
-        let signer = build_auth_signer(&plaintext).expect("builds").expect("a signer");
+        let signer = build_auth_signer(&plaintext)
+            .expect("builds")
+            .expect("a signer");
 
         let mut secure = reqwest::Request::new(
             reqwest::Method::GET,
@@ -1943,7 +1951,10 @@ mod tests {
             .get(reqwest::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .unwrap_or_default();
-        assert!(header.contains("oauth_signature_method=\"PLAINTEXT\""), "got {header}");
+        assert!(
+            header.contains("oauth_signature_method=\"PLAINTEXT\""),
+            "got {header}"
+        );
 
         let mut insecure = reqwest::Request::new(
             reqwest::Method::GET,
@@ -1979,7 +1990,10 @@ mod tests {
             .get("x-wsse")
             .and_then(|v| v.to_str().ok())
             .unwrap_or_default();
-        assert!(token.starts_with("UsernameToken "), "the token rides X-WSSE: {token:?}");
+        assert!(
+            token.starts_with("UsernameToken "),
+            "the token rides X-WSSE: {token:?}"
+        );
         assert!(token.contains("PasswordDigest="), "got {token:?}");
         assert_eq!(
             request

--- a/crates/tropel-engine/Cargo.toml
+++ b/crates/tropel-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-engine"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -70,7 +70,10 @@ struct RecordingHttpClient {
 
 #[async_trait::async_trait]
 impl tropel_sdk::traits::DriverHttpClient for RecordingHttpClient {
-    async fn execute(&self, req: &tropel_sdk::Request) -> tropel_sdk::Result<tropel_sdk::types::Response> {
+    async fn execute(
+        &self,
+        req: &tropel_sdk::Request,
+    ) -> tropel_sdk::Result<tropel_sdk::types::Response> {
         let started = std::time::Instant::now();
         let out = self.inner.execute(req).await;
         // A FAILED script send is still a send. Dropping it here would make a
@@ -156,8 +159,7 @@ fn cookie_matches_url(cookie: &serde_json::Value, url: &str) -> bool {
         .unwrap_or("")
         .trim_start_matches('.');
     let c_path = cookie.get("path").and_then(|p| p.as_str()).unwrap_or("/");
-    let domain_ok =
-        domain.is_empty() || host == domain || host.ends_with(&format!(".{domain}"));
+    let domain_ok = domain.is_empty() || host == domain || host.ends_with(&format!(".{domain}"));
     domain_ok && path.starts_with(c_path)
 }
 
@@ -949,11 +951,14 @@ async fn handle_connection(sock: &mut TcpStream, state: Arc<AgentState>) -> trop
             // TR-476: an explicit `cookies` array opts the jar in — even an
             // empty one. Absent entirely means "no jar", which the shim
             // refuses by name rather than reporting as an empty one.
-            let cookies = payload.get("cookies").and_then(|c| c.as_array()).map(|arr| {
-                let sc = ScriptCookies::default();
-                *sc.lock_jar() = arr.clone();
-                Arc::new(sc)
-            });
+            let cookies = payload
+                .get("cookies")
+                .and_then(|c| c.as_array())
+                .map(|arr| {
+                    let sc = ScriptCookies::default();
+                    *sc.lock_jar() = arr.clone();
+                    Arc::new(sc)
+                });
 
             let callbacks = run_id.as_ref().map(|id| {
                 let cb = Arc::new(RunCallbacks::default());
@@ -1886,10 +1891,7 @@ async fn run_script_once(
     } = host;
     // Captured BEFORE `request` is moved into the realm state below. The
     // cookie bindings need the executing URL to scope reads and writes.
-    let request_url = request
-        .as_ref()
-        .map(|r| r.url.clone())
-        .unwrap_or_default();
+    let request_url = request.as_ref().map(|r| r.url.clone()).unwrap_or_default();
     let mut ctx = tropel_js::JsContext::new(None, Some(std::time::Duration::from_secs(10)))
         .await
         .map_err(|e| format!("js context: {e:?}"))?;
@@ -2649,7 +2651,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],
@@ -2904,7 +2906,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],
@@ -3006,7 +3008,7 @@ mod tests {
                 token: Some("s3cret".into()),
                 client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                     .expect("http client"),
-                    runs: std::sync::Mutex::new(HashMap::new()),
+                runs: std::sync::Mutex::new(HashMap::new()),
                 allowed_origins: origins,
             });
             tokio::spawn(async move {
@@ -3103,7 +3105,7 @@ mod tests {
             token: Some("s3cret".into()),
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             allowed_origins: vec!["https://app.knockport.dev".into()],
         });
         tokio::spawn(async move {
@@ -3233,7 +3235,11 @@ mod tests {
             Some(request),
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3296,12 +3302,19 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
         assert!(
-            configured.get("scriptError").map(|e| e.is_null()).unwrap_or(false),
+            configured
+                .get("scriptError")
+                .map(|e| e.is_null())
+                .unwrap_or(false),
             "a kp.* script must run when the caller declares the kp namespace: {configured}"
         );
         assert_eq!(
@@ -3319,7 +3332,11 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3383,7 +3400,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: Some(cb.clone()), cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: Some(cb.clone()),
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3420,7 +3441,11 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3457,7 +3482,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3466,7 +3495,11 @@ mod tests {
             .get("scriptSends")
             .and_then(|v| v.as_array())
             .expect("scriptSends is always an array, never null");
-        assert_eq!(sends.len(), 1, "the send must be recorded even though it failed: {out}");
+        assert_eq!(
+            sends.len(),
+            1,
+            "the send must be recorded even though it failed: {out}"
+        );
         let only = &sends[0];
         assert_eq!(
             only.get("url").and_then(|v| v.as_str()),
@@ -3496,12 +3529,18 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
         assert_eq!(
-            out.get("scriptSends").and_then(|v| v.as_array()).map(|a| a.len()),
+            out.get("scriptSends")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
             Some(0),
             "an empty array, not null: {out}"
         );
@@ -3561,7 +3600,11 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3605,7 +3648,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: Some(jar.clone()) },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: Some(jar.clone()),
+            },
         )
         .await
         .expect("the realm runs");
@@ -3656,12 +3703,19 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
 
-        let err = out.get("scriptError").and_then(|e| e.as_str()).unwrap_or("");
+        let err = out
+            .get("scriptError")
+            .and_then(|e| e.as_str())
+            .unwrap_or("");
         assert!(
             err.contains("not available here"),
             "it must refuse by name rather than read as an empty jar: {out}"
@@ -3701,7 +3755,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3737,7 +3795,9 @@ mod tests {
         scopes
             .collection
             .insert("colIn".into(), serde_json::json!("c"));
-        scopes.globals.insert("gloIn".into(), serde_json::json!("g"));
+        scopes
+            .globals
+            .insert("gloIn".into(), serde_json::json!("g"));
         scopes
             .variables
             .insert("varIn".into(), serde_json::json!("v"));
@@ -3754,7 +3814,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3810,7 +3874,11 @@ mod tests {
                 namespace: "kp".into(),
                 aliases: Vec::new(),
             },
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
         .await
         .expect("the realm runs");
@@ -3871,9 +3939,20 @@ mod tests {
                      kp.environment.set('require', typeof require);\
                      kp.environment.set('module', typeof module);\
                      kp.environment.set('viaFn', typeof Function('return this')().process);";
-        let out = run_script_once(probe, ScriptScopes::default(), None, None, kp(), ScriptHost { http: test_http_client(), callbacks: None, cookies: None })
-            .await
-            .expect("the realm runs");
+        let out = run_script_once(
+            probe,
+            ScriptScopes::default(),
+            None,
+            None,
+            kp(),
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
+        )
+        .await
+        .expect("the realm runs");
         let env = out.get("environment").expect("the environment comes back");
         for name in ["process", "require", "module", "viaFn"] {
             assert_eq!(
@@ -3889,7 +3968,19 @@ mod tests {
             ("direct", "import('fs');"),
             ("indirect eval", "var e = eval; e(\"import\" + \"('fs')\");"),
         ] {
-            let result = run_script_once(code, ScriptScopes::default(), None, None, kp(), ScriptHost { http: test_http_client(), callbacks: None, cookies: None }).await;
+            let result = run_script_once(
+                code,
+                ScriptScopes::default(),
+                None,
+                None,
+                kp(),
+                ScriptHost {
+                    http: test_http_client(),
+                    callbacks: None,
+                    cookies: None,
+                },
+            )
+            .await;
             let refused = match &result {
                 Err(why) => why.contains("module"),
                 Ok(out) => out
@@ -3943,10 +4034,14 @@ mod tests {
             None,
             None,
             tropel_sandbox::config::SandboxConfig::default(),
-            ScriptHost { http: test_http_client(), callbacks: None, cookies: None },
+            ScriptHost {
+                http: test_http_client(),
+                callbacks: None,
+                cookies: None,
+            },
         )
-            .await
-            .expect("the realm runs");
+        .await
+        .expect("the realm runs");
 
         let mut wrong: Vec<String> = Vec::new();
         for probe in probes {
@@ -4130,7 +4225,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],
@@ -4268,7 +4363,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],
@@ -4372,7 +4467,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],
@@ -4472,7 +4567,7 @@ mod tests {
             token: None,
             client: tropel_http::HttpClient::new(&tropel_http::config::HttpConfig::default())
                 .expect("http client"),
-                runs: std::sync::Mutex::new(HashMap::new()),
+            runs: std::sync::Mutex::new(HashMap::new()),
             // No browser origin: these drive the socket directly, and an
             // empty allowlist is the default a real agent starts with.
             allowed_origins: vec![],

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -1788,11 +1788,94 @@ fn sign_with_scheme(
                 )
             })
         }
+        "akamai-edgegrid" => {
+            let body = opt("body").map(|b| b.into_bytes());
+            let headers_to_sign: Vec<String> = p
+                .get("headersToSign")
+                .or_else(|| p.get("headers_to_sign"))
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let params = tropel_auth::edgegrid::EdgeGridBuildParams {
+                method: s("method"),
+                url: s("url"),
+                headers_to_sign,
+                body,
+                access_token: s("accessToken"),
+                client_token: s("clientToken"),
+                client_secret: s("clientSecret"),
+                // Absent means GENERATE, not empty. A caller pinning either
+                // is a test reproducing a vector; a caller omitting both
+                // wants a fresh nonce and the host clock, and passing empty
+                // strings through would produce a signature Akamai rejects
+                // for a stale timestamp.
+                nonce: opt("nonce"),
+                timestamp: opt("timestamp"),
+                max_body: p
+                    .get("maxBody")
+                    .or_else(|| p.get("max_body"))
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as usize)
+                    .unwrap_or(tropel_auth::edgegrid::DEFAULT_MAX_BODY),
+            };
+            // The VALUES of the headers being signed, which the canonical
+            // string needs and `headers_to_sign` only names.
+            let signed_headers = pairs("headers");
+            tropel_auth::edgegrid::edgegrid_build_header(&params, &signed_headers)
+                .map(|value| {
+                    vec![tropel_auth::builders::HeaderOut {
+                        name: "Authorization".to_string(),
+                        value,
+                    }]
+                })
+                .map_err(|e| e.to_string())
+        }
+        "wsse" => {
+            let signed = tropel_auth::oauth::sign_wsse(&tropel_auth::oauth::WsseParams {
+                username: s("username"),
+                password: s("password"),
+                nonce: s("nonce"),
+                created: s("created"),
+            })
+            .map_err(|e| e.to_string())?;
+            // BOTH headers, which is the WSSE UsernameToken profile's wire
+            // shape: the token rides `X-WSSE` and the profile marker rides
+            // `Authorization`. Returning only one would serve half the
+            // servers that implement the profile, and the caller has no way
+            // to know which half.
+            Ok(vec![
+                tropel_auth::builders::HeaderOut {
+                    name: "X-WSSE".to_string(),
+                    value: signed.authorization,
+                },
+                tropel_auth::builders::HeaderOut {
+                    name: "Authorization".to_string(),
+                    value: "WSSE profile=\"UsernameToken\"".to_string(),
+                },
+            ])
+        }
         other => Err(format!(
-            "unknown auth scheme '{other}' — supported: digest, hawk, awsSigV4, oauth1"
+            "unknown auth scheme '{other}' — supported: {}",
+            AUTH_SIGN_SCHEMES.join(", ")
         )),
     }
 }
+
+/// The schemes `sign_with_scheme` answers for, in one place.
+///
+/// It used to be a hardcoded string in the error arm, and it drifted the
+/// moment a scheme was added — the message still read "digest, hawk,
+/// awsSigV4, oauth1" while `build_auth_signer` had grown EdgeGrid and WSSE.
+/// A caller reading that message would conclude the agent could not sign
+/// something it could, so the list is derived from one declaration and
+/// asserted against the dispatcher below.
+pub const AUTH_SIGN_SCHEMES: &[&str] = &[
+    "digest",
+    "hawk",
+    "awsSigV4",
+    "oauth1",
+    "akamai-edgegrid",
+    "wsse",
+];
 
 /// Base64 encode, beside the decoder — the same engine, so a round trip
 /// through the agent cannot disagree with itself.
@@ -4342,12 +4425,76 @@ mod tests {
         assert!(raw.starts_with("HTTP/1.1 400"), "{raw}");
         assert!(raw.contains("RSA-SHA1"), "{raw}");
 
+        // EdgeGrid: the signature covers method, url, the NAMED headers and
+        // the body, so the whole lot goes over the wire. Nonce and timestamp
+        // are pinned here to make the header reproducible; omitting them
+        // generates both, which is what a real caller wants.
+        let raw = sign(
+            serde_json::json!({
+                "scheme": "akamai-edgegrid",
+                "params": {
+                    "method": "GET", "url": "https://akaa-x.luna.akamaiapis.net/diagnostic/v1/x",
+                    "clientToken": "ct", "accessToken": "at", "clientSecret": "cs",
+                    "nonce": "nnn", "timestamp": "20260909T12:00:00+0000"
+                }
+            })
+            .to_string(),
+        )
+        .await;
+        assert!(raw.contains("EG1-HMAC-SHA256 "), "{raw}");
+        assert!(raw.contains("client_token=ct"), "{raw}");
+        assert!(raw.contains("nonce=nnn"), "{raw}");
+        // The secret must never appear in a response the caller logs.
+        assert!(
+            !raw.contains("cs\""),
+            "the client secret must not echo: {raw}"
+        );
+
+        // A missing credential is a NAMED 400. Three opaque tokens are easy
+        // to paste into the wrong field and Akamai's 401 will not say which.
+        let raw = sign(
+            serde_json::json!({
+                "scheme": "akamai-edgegrid",
+                "params": {"method": "GET", "url": "https://x/y", "clientToken": "ct"}
+            })
+            .to_string(),
+        )
+        .await;
+        assert!(raw.starts_with("HTTP/1.1 400"), "{raw}");
+        assert!(raw.contains("access_token"), "{raw}");
+        assert!(raw.contains("client_secret"), "{raw}");
+
+        // WSSE returns BOTH headers of the UsernameToken profile: the token
+        // on X-WSSE and the profile marker on Authorization. Returning one
+        // would serve half the servers implementing it, and the caller has
+        // no way to tell which half.
+        let raw = sign(
+            serde_json::json!({
+                "scheme": "wsse",
+                "params": {"username": "u", "password": "p", "nonce": "n", "created": "2026-01-01T00:00:00Z"}
+            })
+            .to_string(),
+        )
+        .await;
+        assert!(raw.contains("X-WSSE"), "{raw}");
+        assert!(raw.contains("UsernameToken"), "{raw}");
+        assert!(raw.contains("PasswordDigest"), "{raw}");
+
         // An unknown scheme is refused, not silently unsigned — sending a
         // request the config calls authenticated with no Authorization is
         // invariant #7's silent data loss.
         let raw = sign(serde_json::json!({"scheme": "ntlm", "params": {}}).to_string()).await;
         assert!(raw.starts_with("HTTP/1.1 400"), "{raw}");
         assert!(raw.contains("unknown auth scheme"), "{raw}");
+        // And the refusal names what IS supported, from the one declaration.
+        // The hardcoded list drifted the moment a scheme was added: it still
+        // read "digest, hawk, awsSigV4, oauth1" while both arms above worked.
+        for scheme in AUTH_SIGN_SCHEMES {
+            assert!(
+                raw.contains(scheme),
+                "the refusal must name {scheme}: {raw}"
+            );
+        }
     }
     /// TR-446: `POST /script`, over the socket.
     ///

--- a/crates/tropel-engine/src/js_bootstrap.rs
+++ b/crates/tropel-engine/src/js_bootstrap.rs
@@ -279,7 +279,9 @@ fn format_shims(format: &str) -> Option<&'static [Shim]> {
         // script, two answers, decided by which bundle the format picked.
         "postman" => &[DeepEqual, K6Core, Pm, Chai, Lodash, CryptoJs, Exec, Fetch],
         // Bruno scripts reach the same library surface plus `bru`.
-        "bru" => &[DeepEqual, K6Core, Pm, Chai, Lodash, CryptoJs, Exec, Bru, Fetch],
+        "bru" => &[
+            DeepEqual, K6Core, Pm, Chai, Lodash, CryptoJs, Exec, Bru, Fetch,
+        ],
         // The k6 InputAdapter fallback (used when the k6 Driver is not
         // registered) wraps the transpiled script as one item's `test`.
         // Arbitrary JS again — minus Bruno's API.
@@ -849,7 +851,10 @@ mod tests {
             format_shims("k6").is_none(),
             "k6 takes the full default bundle; if that changes, it needs Fetch too"
         );
-        assert!(Shim::ALL.contains(&Shim::Fetch), "the default bundle carries fetch");
+        assert!(
+            Shim::ALL.contains(&Shim::Fetch),
+            "the default bundle carries fetch"
+        );
     }
 
     #[test]

--- a/crates/tropel-http/src/proxy.rs
+++ b/crates/tropel-http/src/proxy.rs
@@ -371,7 +371,11 @@ pub struct PacDecision {
 
 impl PacDecision {
     pub fn new(candidates: Vec<PacDirective>) -> Self {
-        Self { candidates, current: 0, decided_at: std::time::Instant::now() }
+        Self {
+            candidates,
+            current: 0,
+            decided_at: std::time::Instant::now(),
+        }
     }
 
     /// The candidate to try now, or `None` when every one has failed.

--- a/crates/tropel-http/tests/proxy_config.rs
+++ b/crates/tropel-http/tests/proxy_config.rs
@@ -11,8 +11,8 @@
 //! an error rather than a fuzzy match.
 
 use tropel_http::{
-    BypassRule, HttpClient, HttpConfig, ProxyConfig, ProxyMode, TlsConfig, bypasses, parse_bypass,
-    parse_bypass_list,
+    bypasses, parse_bypass, parse_bypass_list, BypassRule, HttpClient, HttpConfig, ProxyConfig,
+    ProxyMode, TlsConfig,
 };
 
 fn rules(entries: &[&str]) -> Vec<BypassRule> {
@@ -162,7 +162,10 @@ fn every_bad_entry_is_reported_at_once() {
 /// Did the client BUILD? Returns unit rather than the client because no test
 /// here uses one, and `HttpClient` has no `Debug` for `expect_err` to format.
 fn build(proxy: ProxyConfig) -> Result<(), String> {
-    let config = HttpConfig { proxy, ..HttpConfig::default() };
+    let config = HttpConfig {
+        proxy,
+        ..HttpConfig::default()
+    };
     HttpClient::with_tls(&config, &TlsConfig::default())
         .map(|_| ())
         .map_err(|e| e.to_string())
@@ -188,8 +191,11 @@ fn fixed_mode_builds_with_a_host() {
 #[test]
 fn fixed_mode_with_no_host_is_refused_by_name() {
     // The alternative is a client that says it proxies and doesn't.
-    let err = build(ProxyConfig { mode: ProxyMode::Fixed, ..Default::default() })
-        .expect_err("must refuse");
+    let err = build(ProxyConfig {
+        mode: ProxyMode::Fixed,
+        ..Default::default()
+    })
+    .expect_err("must refuse");
     assert!(err.contains("no host is set"), "got: {err}");
 }
 
@@ -207,7 +213,10 @@ fn fixed_mode_carries_credentials_without_putting_them_in_the_url() {
     };
     let url = cfg.fixed_url().expect("a url");
     assert_eq!(url, "http://proxy.internal:3128");
-    assert!(!url.contains('u') || !url.contains("u:p"), "no credentials in the URL: {url}");
+    assert!(
+        !url.contains('u') || !url.contains("u:p"),
+        "no credentials in the URL: {url}"
+    );
     assert!(build(cfg).is_ok());
 }
 
@@ -292,7 +301,10 @@ fn an_absent_proxy_block_is_off() {
 
 #[test]
 fn pac_fields_read_in_both_spellings() {
-    for json in [r#"{"mode":"pac","pac_url":"http://a/x.dat"}"#, r#"{"mode":"pac","pacUrl":"http://a/x.dat"}"#] {
+    for json in [
+        r#"{"mode":"pac","pac_url":"http://a/x.dat"}"#,
+        r#"{"mode":"pac","pacUrl":"http://a/x.dat"}"#,
+    ] {
         let cfg: ProxyConfig = serde_json::from_str(json).expect("reads");
         assert_eq!(cfg.pac_url.as_deref(), Some("http://a/x.dat"), "for {json}");
     }
@@ -305,7 +317,7 @@ fn pac_fields_read_in_both_spellings() {
 // config with a documented fallback into a single point of failure. These
 // tests are the parser and the ordering — the half where that bug lives.
 
-use tropel_http::{DEFAULT_PAC_TTL, PacDecision, PacDirective, parse_pac_result};
+use tropel_http::{parse_pac_result, PacDecision, PacDirective, DEFAULT_PAC_TTL};
 
 #[test]
 fn a_multi_directive_result_yields_every_candidate_in_order() {
@@ -380,12 +392,18 @@ fn a_directive_becomes_the_proxy_url_reqwest_needs() {
 #[test]
 fn failover_advances_through_the_candidates_in_order() {
     let mut decision = PacDecision::new(parse_pac_result("PROXY a:1; PROXY b:2; DIRECT"));
-    assert_eq!(decision.candidate(), Some(&PacDirective::Proxy("a:1".into())));
+    assert_eq!(
+        decision.candidate(),
+        Some(&PacDirective::Proxy("a:1".into()))
+    );
     assert_eq!(decision.advance(), Some(&PacDirective::Proxy("b:2".into())));
     assert_eq!(decision.advance(), Some(&PacDirective::Direct));
     assert!(!decision.exhausted());
     assert_eq!(decision.advance(), None);
-    assert!(decision.exhausted(), "only after the LAST one fails does the request fail");
+    assert!(
+        decision.exhausted(),
+        "only after the LAST one fails does the request fail"
+    );
 }
 
 #[test]
@@ -402,6 +420,9 @@ fn a_fresh_decision_is_not_stale_and_the_ttl_is_bounded() {
     // unbounded caching would pin the old answer for the process's life.
     let decision = PacDecision::new(parse_pac_result("DIRECT"));
     assert!(!decision.is_stale(DEFAULT_PAC_TTL));
-    assert!(decision.is_stale(std::time::Duration::ZERO), "a zero TTL is always stale");
+    assert!(
+        decision.is_stale(std::time::Duration::ZERO),
+        "a zero TTL is always stale"
+    );
     assert!(DEFAULT_PAC_TTL > std::time::Duration::ZERO);
 }

--- a/crates/tropel-http/tests/tls_ca_bundle.rs
+++ b/crates/tropel-http/tests/tls_ca_bundle.rs
@@ -28,7 +28,11 @@ fn tls(paths: &[&str], keep_system_roots: bool) -> TlsConfig {
 #[test]
 fn a_client_builds_with_a_single_private_ca() {
     let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE], true));
-    assert!(client.is_ok(), "one PEM root should build: {:?}", client.err().map(|e| e.to_string()));
+    assert!(
+        client.is_ok(),
+        "one PEM root should build: {:?}",
+        client.err().map(|e| e.to_string())
+    );
 }
 
 #[test]
@@ -36,7 +40,11 @@ fn two_separate_bundles_both_load() {
     // A list rather than one path, because two independent CAs — a corporate
     // root and a test root — is the ordinary case.
     let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE, TWO], true));
-    assert!(client.is_ok(), "two roots should build: {:?}", client.err().map(|e| e.to_string()));
+    assert!(
+        client.is_ok(),
+        "two roots should build: {:?}",
+        client.err().map(|e| e.to_string())
+    );
 }
 
 #[test]
@@ -52,7 +60,11 @@ fn a_multi_cert_bundle_loads_every_certificate_in_it() {
     // build succeeds is therefore necessary but not sufficient, which is why
     // the parse itself is checked directly below.
     let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[CHAIN], true));
-    assert!(client.is_ok(), "a 2-cert bundle should build: {:?}", client.err().map(|e| e.to_string()));
+    assert!(
+        client.is_ok(),
+        "a 2-cert bundle should build: {:?}",
+        client.err().map(|e| e.to_string())
+    );
 
     let pem = std::fs::read(CHAIN).expect("fixture readable");
     let certs = reqwest::Certificate::from_pem_bundle(&pem).expect("bundle parses");
@@ -80,13 +92,21 @@ fn a_config_that_names_no_roots_still_builds() {
     // Nothing about this ask may change the behaviour of a config that does
     // not use it.
     let client = HttpClient::with_tls(&HttpConfig::default(), &TlsConfig::default());
-    assert!(client.is_ok(), "the untouched path still builds: {:?}", client.err().map(|e| e.to_string()));
+    assert!(
+        client.is_ok(),
+        "the untouched path still builds: {:?}",
+        client.err().map(|e| e.to_string())
+    );
 }
 
 #[test]
 fn pinning_to_only_the_supplied_bundles_builds() {
     let client = HttpClient::with_tls(&HttpConfig::default(), &tls(&[ONE], false));
-    assert!(client.is_ok(), "certs-only should build: {:?}", client.err().map(|e| e.to_string()));
+    assert!(
+        client.is_ok(),
+        "certs-only should build: {:?}",
+        client.err().map(|e| e.to_string())
+    );
 }
 
 #[test]
@@ -100,7 +120,10 @@ fn pinning_with_no_bundle_is_refused_by_name() {
     };
     let message = err.to_string();
     assert!(message.contains("trusts no CA at all"), "got: {message}");
-    assert!(message.contains("root_cert_paths"), "names the field to fix: {message}");
+    assert!(
+        message.contains("root_cert_paths"),
+        "names the field to fix: {message}"
+    );
 }
 
 #[test]
@@ -115,7 +138,10 @@ fn an_unreadable_bundle_names_the_file() {
         Err(e) => e,
     };
     let message = err.to_string();
-    assert!(message.contains("nope.pem"), "names the missing file: {message}");
+    assert!(
+        message.contains("nope.pem"),
+        "names the missing file: {message}"
+    );
     assert!(message.contains("cannot read CA bundle"), "got: {message}");
 }
 
@@ -139,10 +165,9 @@ fn a_bundle_that_is_not_pem_names_the_file_too() {
 fn the_json_surface_accepts_both_spellings() {
     // KnockPort writes camelCase; the engine's own configs are snake_case.
     // Both have to read, or one of the two callers silently gets defaults.
-    let snake: TlsConfig = serde_json::from_str(
-        r#"{"root_cert_paths":["a.pem"],"keep_system_roots":false}"#,
-    )
-    .expect("snake_case reads");
+    let snake: TlsConfig =
+        serde_json::from_str(r#"{"root_cert_paths":["a.pem"],"keep_system_roots":false}"#)
+            .expect("snake_case reads");
     assert_eq!(snake.root_cert_paths, vec!["a.pem".to_string()]);
     assert!(!snake.keep_system_roots);
 
@@ -157,7 +182,9 @@ fn the_json_surface_accepts_both_spellings() {
 fn an_absent_keep_system_roots_defaults_to_true_through_serde_too() {
     // `#[derive(Default)]` would have given false here — the one field whose
     // zero value is the wrong answer, which is why `Default` is hand-written.
-    let cfg: TlsConfig = serde_json::from_str(r#"{"root_cert_paths":["a.pem"]}"#)
-        .expect("reads");
-    assert!(cfg.keep_system_roots, "serde default must match the Default impl");
+    let cfg: TlsConfig = serde_json::from_str(r#"{"root_cert_paths":["a.pem"]}"#).expect("reads");
+    assert!(
+        cfg.keep_system_roots,
+        "serde default must match the Default impl"
+    );
 }

--- a/crates/tropel-runtime/src/runner.rs
+++ b/crates/tropel-runtime/src/runner.rs
@@ -1206,10 +1206,23 @@ fn resolve_auth(
         AuthConfig::AkamaiEdgeGrid {
             access_token,
             client_token,
+            client_secret,
+            headers_to_sign,
+            max_body,
             extra,
         } => AuthConfig::AkamaiEdgeGrid {
             access_token: access_token.as_deref().map(r),
             client_token: client_token.as_deref().map(r),
+            // Resolved like the other two. This function ENUMERATES fields,
+            // so a field added to the variant without a line here silently
+            // skips resolution — and a `client_secret` of
+            // `{{akamai_secret}}` would then sign with the literal template
+            // and 401, with the config looking correct.
+            client_secret: client_secret.as_deref().map(r),
+            // Header NAMES can be templated too; `max_body` is a number and
+            // has nothing to resolve.
+            headers_to_sign: headers_to_sign.iter().map(|h| r(h)).collect(),
+            max_body: *max_body,
             extra: extra
                 .iter()
                 .map(|(k, v)| {
@@ -1492,6 +1505,49 @@ mod tests {
                 assert_eq!(token, "my-secret-jwt");
             }
             other => panic!("expected Bearer, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_auth_edgegrid_named_fields() {
+        // `resolve_auth` ENUMERATES the fields of every variant, so a field
+        // added to one without a line in the match silently skips
+        // resolution. For EdgeGrid that means a `client_secret` of
+        // `{{akamai_secret}}` signs with the literal template and comes back
+        // 401 — with a config that reads as correct.
+        let resolver = tropel_variables::VariableResolver::new();
+        let scope = tropel_variables::VariableScope {
+            env: HashMap::from([
+                ("ak_token".into(), "real-client-token".into()),
+                ("ak_secret".into(), "real-secret".into()),
+                ("trace_header".into(), "X-Trace-Id".into()),
+            ]),
+            ..Default::default()
+        };
+        let auth = tropel_sdk::types::AuthConfig::AkamaiEdgeGrid {
+            access_token: Some("at".into()),
+            client_token: Some("{{ak_token}}".into()),
+            client_secret: Some("{{ak_secret}}".into()),
+            headers_to_sign: vec!["{{trace_header}}".into()],
+            max_body: Some(2048),
+            extra: Default::default(),
+        };
+        match resolve_auth(&auth, &resolver, &scope) {
+            tropel_sdk::types::AuthConfig::AkamaiEdgeGrid {
+                client_token,
+                client_secret,
+                headers_to_sign,
+                max_body,
+                ..
+            } => {
+                assert_eq!(client_token.as_deref(), Some("real-client-token"));
+                assert_eq!(client_secret.as_deref(), Some("real-secret"));
+                // Header NAMES are templatable too — they are part of the
+                // signature, so an unresolved one signs the wrong thing.
+                assert_eq!(headers_to_sign, vec!["X-Trace-Id".to_string()]);
+                assert_eq!(max_body, Some(2048), "a number passes through");
+            }
+            other => panic!("expected AkamaiEdgeGrid, got {other:?}"),
         }
     }
 

--- a/crates/tropel-web/Cargo.toml
+++ b/crates/tropel-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-web"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel/Cargo.toml
+++ b/crates/tropel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel/src/main.rs
+++ b/crates/tropel/src/main.rs
@@ -62,7 +62,8 @@ fn main() -> tropel_sdk::Result<()> {
         // renamed or where it went. Any OTHER `agent` invocation falls through
         // to run_cli() -> Commands::Agent, the loopback agent.
         Some("agent")
-            if std::env::args().any(|a| a == "--controller" || a == "-C" || a == "--token-file") =>
+            if std::env::args()
+                .any(|a| a == "--controller" || a == "-C" || a == "--token-file") =>
         {
             eprintln!(
                 "tropel: `agent` is the loopback HTTP agent \

--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/input-wasm/package.json
+++ b/packages/input-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/input-wasm",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Tropel collection-import slice for browser embedders (KnockPort). Lazy sibling of @tropel/core-wasm: OpenAPI 3.x, Postman v2.x, and HAR parsers compiled to wasm32-unknown-unknown. See API_CLIENT_WEB_PAYLOAD.md \u00a72.3 for the two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-wasm/package.json
+++ b/packages/runtime-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/runtime-wasm",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Browser/Node host for the tropel load-testing runtime compiled to wasm32-wasip1: postcard C ABI driver, WASI preview1 wiring, and the HTTP bridge that answers each request the runtime makes.",
   "license": "Apache-2.0",
   "type": "module",
@@ -45,7 +45,7 @@
     "tropel"
   ],
   "dependencies": {
-    "@tropel/shims": "^0.5.4"
+    "@tropel/shims": "^0.5.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
Takes tropel-sdk `24130b1` (transithq/tropel-sdk#30), where `client_secret`, `headers_to_sign` and `max_body` stopped being untyped `extra` keys and became named fields on `AuthConfig::AkamaiEdgeGrid`.

## The signer

Named fields first, `extra` as a fallback — a caller that put `clientSecret` there while that was the only place must keep working.

One subtlety worth its own test: an **empty** named field must not shadow a usable one in `extra`. Without the `.filter(|v| !v.is_empty())`, a `Some("")` would win and the config would be refused for a secret it actually has.

## The real find: `resolve_auth`

```rust
AuthConfig::AkamaiEdgeGrid { access_token, client_token, extra } => AuthConfig::AkamaiEdgeGrid {
    access_token: access_token.as_deref().map(r),
    client_token: client_token.as_deref().map(r),
    extra: …
}
```

`resolve_auth` **enumerates** every field of every variant. A field added to a variant without a line here silently skips variable resolution — and the compiler only catches it because the pattern is exhaustive, which is how this one surfaced.

The consequence for EdgeGrid specifically: a `client_secret` of `{{akamai_secret}}` would be handed to the signer **literally**, producing a valid-looking `EG1-HMAC-SHA256` header computed with the template text as the key. Akamai answers 401, and every part of the config reads as correct.

`headers_to_sign` resolves too. Those names are part of the canonical string, so an unresolved one does not merely fail to find a header — it signs a different request than the one being sent.

`max_body` is a number and passes through.

## Tests

- named fields build a signer; `extra` (the pre-#30 spelling) still does; an empty named field does not shadow `extra`
- `resolve_auth_edgegrid_named_fields` — a templated secret, client token and header name all resolve, with the number passing through

103 `tropel-auth` tests, full workspace green, clippy and rustfmt clean.