### PR TITLE
0.6.0 — publish the whole crate tree, and read KnockPort collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [0.6.0] - 2026-09-11
+
+The release that makes tropel **installable as a dependency**. Every crate is
+published to crates.io, so a consumer — KnockPort first — depends on
+`version = "0.6.0"` instead of a git SHA.
+
+**The API is unstable pre-1.0.** `tropel-sdk` is deliberately NOT in this
+lockstep: it is the contract a third-party adapter author depends on, in its
+own repo with its own history, and its version tracks its own API.
+
+### Added — tropel reads KnockPort collections
+
+`tropel-input-knockport`. tropel could already import Postman, Bruno,
+Insomnia, HAR, OpenAPI, k6 and `.http` — every competitor's format — and not
+the one format both products own, so `tropel run my-collection/` failed on it.
+
+The format is a **directory**, not a file (`knockport.yaml` +
+`requests/**/*.yaml`), so the adapter uses `parse_with_path` — the hook that
+already existed for k6's module resolution. It follows the client's own rules
+rather than convenient ones: the **filename is the identity** (KP-101, so no
+`id:` keys and a missing `name:` takes the file stem), `order:` is
+authoritative and lists filenames, files *absent* from `order:` still import
+rather than being dropped, and disabled rows are not sent. Scripts and
+assertions are **reported, not silently dropped** — tropel's script realm is
+the pm/k6 surface, and running a KnockPort script there would not be the same
+script.
+
+### Changed — the whole crate tree is published
+
+- **35 crates at 0.6.0**, with the binary, `tropel-web` and the four npm
+  packages. `version-lockstep.sh` reports all seven surfaces agreeing.
+- **28 `publish = false` lines removed.** Six of the seven crates KnockPort
+  links were opted out of the registry, which is why it had to pin a git SHA.
+- **14 crates gained a `description`** — cargo refuses to publish without
+  one, so this was the hard prerequisite.
+- Every workspace `tropel-*` declaration carries a `version`. A path-only
+  dependency cannot be published at all: consumers resolve the version.
+
+0.6.0 rather than 0.5.6 because the release is breaking — `tropel-auth`'s
+EdgeGrid error type went `TropelError` → `String` and its clock/CSPRNG
+helpers became feature-gated; `Request` gained a `proxy` field. Pre-1.0 that
+is a minor bump by this repo's own policy.
+
+### Fixed — `publish-dry-run.sh` cried wolf on a first full-tree publish
+
+It read *"no matching package named X found"* as a hard failure. Cargo words
+"a workspace sibling is not on crates.io yet" two ways and only the other one
+was recognised, so the first full-tree run reported **"BLOCKED: 12 of 35 …
+the gate is NOT met"** for the entirely normal pre-publish state. The guard
+against a real failure is unchanged: the named crate must be a workspace
+member whose own version is the one being asked for.
+
+It also now prints the **topological publish order**. Sequencing 35 crates by
+hand is how a version number gets burned on a failed publish.
+
 ## [0.5.5] - 2026-09-10
 
 Three tagged versions shipped without a changelog entry — 0.3.0 and 0.5.4 were

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,6 +4419,7 @@ dependencies = [
  "tropel-input-http",
  "tropel-input-insomnia",
  "tropel-input-k6",
+ "tropel-input-knockport",
  "tropel-input-openapi",
  "tropel-input-postman",
  "tropel-input-subprocess",
@@ -4563,6 +4564,17 @@ dependencies = [
  "tropel-sdk",
  "tropel-x-grpc",
  "url",
+]
+
+[[package]]
+name = "tropel-input-knockport"
+version = "0.6.0"
+dependencies = [
+ "inventory",
+ "serde",
+ "serde_json",
+ "tropel-sdk",
+ "yaml_serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "tropel"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-auth"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.0",
  "chrono",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-bench"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "libc",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-build"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-collection"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "percent-encoding",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-core"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "indexmap",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-core-wasm"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.0",
  "getrandom 0.4.3",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-distributed"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "mimalloc",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-engine"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-es"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-ext"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-http"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "h2",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-bru"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "serde",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-har"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.0",
  "inventory",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-http"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "serde_json",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-insomnia"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "serde",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-k6"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-openapi"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "serde",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-postman"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "serde",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-subprocess"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "rand",
  "serde_json",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-wasm"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "getrandom 0.4.3",
  "serde",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-js"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "rquickjs",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-metrics"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-native"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-report"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-runtime"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-sandbox"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "rquickjs",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-scheduler"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "futures",
  "tokio",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-variables"
-version = "0.3.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "rand",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-wasm"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-web"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "postcard",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-x-grpc"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-x-prometheus"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-x-websocket"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,11 +223,11 @@ csv = "1.4.0"
 
 
 # ── Internal workspace crate paths ────────────────────
-tropel-core = { path = "crates/tropel-core", version = "0.1.0" }
-tropel-collection = { path = "crates/tropel-collection" }
-tropel-variables = { path = "crates/tropel-variables", version = "0.3.0" }
-tropel-js = { path = "crates/tropel-js", version = "0.2.0" }
-tropel-native = { path = "crates/tropel-native", version = "0.2.0" }
+tropel-core = { path = "crates/tropel-core", version = "0.6.0" }
+tropel-collection = { path = "crates/tropel-collection", version = "0.6.0" }
+tropel-variables = { path = "crates/tropel-variables", version = "0.6.0" }
+tropel-js = { path = "crates/tropel-js", version = "0.6.0" }
+tropel-native = { path = "crates/tropel-native", version = "0.6.0" }
 # P5b (TROPEL_WASM_BUILD.md): default-features must be declared at the
 # WORKSPACE level — a member-level `default-features = false` override on a
 # workspace dep is ignored (cargo warns) unless the workspace entry declares
@@ -235,37 +235,44 @@ tropel-native = { path = "crates/tropel-native", version = "0.2.0" }
 # tokio-net into the graph, which cannot compile on wasm. The browser slice
 # builds with --no-default-features; consumers that need pm.sendRequest
 # (engine, and runtime via its forwarding feature) opt back in explicitly.
-tropel-sandbox = { path = "crates/tropel-sandbox", version = "0.2.0", default-features = false }
-tropel-http = { path = "crates/tropel-http", version = "0.2.0" }
+tropel-sandbox = { path = "crates/tropel-sandbox", version = "0.6.0", default-features = false }
+tropel-http = { path = "crates/tropel-http", version = "0.6.0" }
 # default-features = false keeps `reqwest`/`chrono` out of the browser core
 # graph; tropel-core-wasm only needs the pure `oauth` module, while native
 # consumers (tropel-http) opt back in via the default features.
-tropel-auth = { path = "crates/tropel-auth", version = "0.2.0", default-features = false }
+tropel-auth = { path = "crates/tropel-auth", version = "0.6.0", default-features = false }
 # P5b: mirror the tropel-sandbox treatment — default-features must be
 # declared at the WORKSPACE level (a member-level override is silently
 # ignored). runtime's default `send-request` drags tropel-http → reqwest →
 # tokio-net, which cannot compile on wasm. The browser slice (tropel-web)
 # builds with --no-default-features; consumers that need pm.sendRequest
 # (the engine) opt back in explicitly.
-tropel-runtime = { path = "crates/tropel-runtime", version = "0.2.0", default-features = false }
-tropel-scheduler = { path = "crates/tropel-scheduler", version = "0.1.0" }
-tropel-metrics = { path = "crates/tropel-metrics" }
-tropel-report = { path = "crates/tropel-report" }
-tropel-ext = { path = "crates/tropel-ext", version = "0.1.0" }
+tropel-runtime = { path = "crates/tropel-runtime", version = "0.6.0", default-features = false }
+tropel-scheduler = { path = "crates/tropel-scheduler", version = "0.6.0" }
+tropel-metrics = { path = "crates/tropel-metrics", version = "0.6.0" }
+tropel-report = { path = "crates/tropel-report", version = "0.6.0" }
+tropel-ext = { path = "crates/tropel-ext", version = "0.6.0" }
+# tropel-sdk is NOT in the 0.6.0 lockstep, deliberately. It is the published
+# contract a third-party adapter author depends on, in its own repo with its
+# own release history (0.1.0 → 0.2.0 → 0.3.0 on crates.io, 1,505 downloads on
+# 0.3.0). Its version tracks ITS api — 0.4.0 is "public fields were added to
+# a published 0.3.0" — not this repo's release train. `version-lockstep.sh`
+# warns about the mismatch and is WARNING-only for exactly this reason: "the
+# SDK's pin is the hard guard".
 tropel-sdk = { path = "crates/tropel-sdk", version = "0.4.0" }
-tropel-engine = { path = "crates/tropel-engine" }
-tropel-build = { path = "crates/tropel-build" }
-tropel-input-postman = { path = "crates/inputs/tropel-input-postman" }
-tropel-input-k6 = { path = "crates/inputs/tropel-input-k6" }
-tropel-input-har = { path = "crates/inputs/tropel-input-har" }
-tropel-input-openapi = { path = "crates/inputs/tropel-input-openapi" }
-tropel-input-insomnia = { path = "crates/inputs/tropel-input-insomnia" }
-tropel-input-bru = { path = "crates/inputs/tropel-input-bru" }
-tropel-input-subprocess = { path = "crates/inputs/tropel-input-subprocess" }
-tropel-input-http = { path = "crates/inputs/tropel-input-http" }
-tropel-x-grpc = { path = "crates/extensions/tropel-x-grpc" }
-tropel-x-websocket = { path = "crates/extensions/tropel-x-websocket" }
-tropel-x-prometheus = { path = "crates/extensions/tropel-x-prometheus" }
-tropel-es = { path = "crates/tropel-es" }
-tropel-wasm = { path = "crates/tropel-wasm" }
-tropel-distributed = { path = "crates/tropel-distributed", version = "0.1.0" }
+tropel-engine = { path = "crates/tropel-engine", version = "0.6.0" }
+tropel-build = { path = "crates/tropel-build", version = "0.6.0" }
+tropel-input-postman = { path = "crates/inputs/tropel-input-postman", version = "0.6.0" }
+tropel-input-k6 = { path = "crates/inputs/tropel-input-k6", version = "0.6.0" }
+tropel-input-har = { path = "crates/inputs/tropel-input-har", version = "0.6.0" }
+tropel-input-openapi = { path = "crates/inputs/tropel-input-openapi", version = "0.6.0" }
+tropel-input-insomnia = { path = "crates/inputs/tropel-input-insomnia", version = "0.6.0" }
+tropel-input-bru = { path = "crates/inputs/tropel-input-bru", version = "0.6.0" }
+tropel-input-subprocess = { path = "crates/inputs/tropel-input-subprocess", version = "0.6.0" }
+tropel-input-http = { path = "crates/inputs/tropel-input-http", version = "0.6.0" }
+tropel-x-grpc = { path = "crates/extensions/tropel-x-grpc", version = "0.6.0" }
+tropel-x-websocket = { path = "crates/extensions/tropel-x-websocket", version = "0.6.0" }
+tropel-x-prometheus = { path = "crates/extensions/tropel-x-prometheus", version = "0.6.0" }
+tropel-es = { path = "crates/tropel-es", version = "0.6.0" }
+tropel-wasm = { path = "crates/tropel-wasm", version = "0.6.0" }
+tropel-distributed = { path = "crates/tropel-distributed", version = "0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/inputs/tropel-input-postman",
     "crates/inputs/tropel-input-k6",
     "crates/inputs/tropel-input-har",
+    "crates/inputs/tropel-input-knockport",
     "crates/inputs/tropel-input-openapi",
     "crates/inputs/tropel-input-insomnia",
     "crates/inputs/tropel-input-bru",
@@ -265,6 +266,7 @@ tropel-build = { path = "crates/tropel-build", version = "0.6.0" }
 tropel-input-postman = { path = "crates/inputs/tropel-input-postman", version = "0.6.0" }
 tropel-input-k6 = { path = "crates/inputs/tropel-input-k6", version = "0.6.0" }
 tropel-input-har = { path = "crates/inputs/tropel-input-har", version = "0.6.0" }
+tropel-input-knockport = { path = "crates/inputs/tropel-input-knockport", version = "0.6.0" }
 tropel-input-openapi = { path = "crates/inputs/tropel-input-openapi", version = "0.6.0" }
 tropel-input-insomnia = { path = "crates/inputs/tropel-input-insomnia", version = "0.6.0" }
 tropel-input-bru = { path = "crates/inputs/tropel-input-bru", version = "0.6.0" }

--- a/crates/extensions/tropel-x-grpc/Cargo.toml
+++ b/crates/extensions/tropel-x-grpc/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-x-grpc"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "gRPC protocol extension for tropel, with server-reflection descriptor resolution."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk = { workspace = true, features = ["unstable-protocol"] }

--- a/crates/extensions/tropel-x-prometheus/Cargo.toml
+++ b/crates/extensions/tropel-x-prometheus/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-x-prometheus"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Prometheus remote-write output extension for tropel."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk = { workspace = true, features = ["unstable-output"] }

--- a/crates/extensions/tropel-x-websocket/Cargo.toml
+++ b/crates/extensions/tropel-x-websocket/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-x-websocket"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "WebSocket protocol extension for tropel."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk = { workspace = true, features = ["unstable-protocol"] }

--- a/crates/inputs/tropel-input-bru/Cargo.toml
+++ b/crates/inputs/tropel-input-bru/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-bru"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads Bruno collection JSON exports and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-har/Cargo.toml
+++ b/crates/inputs/tropel-input-har/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-har"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads HTTP Archive (HAR) files and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-http/Cargo.toml
+++ b/crates/inputs/tropel-input-http/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-http"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads .http / .rest request files (VS Code REST Client / JetBrains HTTP client) and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-insomnia/Cargo.toml
+++ b/crates/inputs/tropel-input-insomnia/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-insomnia"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads Insomnia v4 collection exports and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-k6/Cargo.toml
+++ b/crates/inputs/tropel-input-k6/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-k6"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads k6-style JavaScript/TypeScript test scripts and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-knockport/Cargo.toml
+++ b/crates/inputs/tropel-input-knockport/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tropel-input-knockport"
+version = "0.6.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Input adapter that reads a KnockPort collection directory (knockport.yaml + requests/) and produces a Scenario"
+
+[dependencies]
+tropel-sdk.workspace = true
+inventory.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+yaml_serde = "0.10.4"

--- a/crates/inputs/tropel-input-knockport/src/lib.rs
+++ b/crates/inputs/tropel-input-knockport/src/lib.rs
@@ -1,0 +1,727 @@
+//! KnockPort collection input adapter.
+//!
+//! # Why this exists
+//!
+//! tropel could import Postman, Bruno, Insomnia, HAR, OpenAPI, k6 and `.http`
+//! — every competitor's format — and **not its own sibling product's**.
+//! KnockPort writes collections as a directory of YAML files and can export a
+//! flattened `.knockport.json`, and nothing here could read either, so
+//! `tropel run my-collection/` failed on the one format both products own.
+//!
+//! # The format is a DIRECTORY, not a file
+//!
+//! ```text
+//! my-api/
+//! ├─ knockport.yaml              name, collection auth + scripts + vars, order
+//! ├─ environments/{dev,prod}.yaml
+//! └─ requests/
+//!    ├─ folder.yaml              folder auth + scripts + explicit order
+//!    └─ auth/{folder.yaml, login.yaml, refresh.yaml}
+//! ```
+//!
+//! That is why this adapter overrides [`InputAdapter::parse_with_path`] rather
+//! than doing the work in `parse`. The trait already provides for it — k6 uses
+//! the same hook to resolve module imports relative to the source file — so no
+//! trait change was needed.
+//!
+//! **The filename is the identity.** KnockPort's KP-101 identity model (signed
+//! off 2026-08-28) is explicit that request, folder and environment documents
+//! carry no `id:` key, and that in-app identity derives from the
+//! collection-root-relative path. Only `knockport.yaml` may carry an explicit
+//! `id:`. So the file name is read as the request's identity and a legacy
+//! `id:` is tolerated but never required — matching the client exactly, since
+//! a format read differently by the two products is the bug this adapter is
+//! supposed to prevent.
+//!
+//! # `order:` is authoritative, and lists FILENAMES
+//!
+//! A folder's `order:` names request files *with* their extension
+//! (`Login.yaml`) and subfolders as bare directory names (`auth`). A directory
+//! and a file cannot share a name on disk, so the reference is unambiguous.
+//! Entries not named in `order:` follow it, sorted, rather than being dropped:
+//! a hand-authored file that someone forgot to list is still a request they
+//! want run.
+//!
+//! # What is deliberately not read
+//!
+//! Scripts (`prerequest`/`test`) and assertions round-trip in the client's own
+//! format but are not mapped here yet: tropel's script surface is the
+//! pm/k6 realm, and silently importing a KnockPort script into it would run
+//! something subtly different from what the client runs. A collection carrying
+//! them imports with a conversion note, which is the honest half of the job —
+//! the requests execute, and the user is told what did not come across.
+
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
+
+use tropel_sdk::registration::InputAdapterRegistration;
+use tropel_sdk::traits::InputAdapter;
+use tropel_sdk::types::{Body, Method, Request};
+use tropel_sdk::{Result, Scenario, ScenarioInfo, ScenarioItem, TropelError};
+
+/// The root manifest a KnockPort collection directory always has.
+const ROOT_FILE: &str = "knockport.yaml";
+/// The subdirectory holding the request tree.
+const REQUESTS_DIR: &str = "requests";
+/// The per-folder manifest inside `requests/`.
+const FOLDER_FILE: &str = "folder.yaml";
+
+pub struct KnockPortInputAdapter;
+
+impl InputAdapter for KnockPortInputAdapter {
+    fn id(&self) -> &str {
+        "knockport"
+    }
+
+    /// Recognise a `knockport.yaml` document from its bytes alone.
+    ///
+    /// Structural, like every other adapter's `detect`: a mapping with a
+    /// `name` and an `order` list, and none of the marker keys that identify
+    /// the other formats. `order` is what makes it KnockPort rather than any
+    /// other YAML with a name — Insomnia uses `_type: export`, Bruno uses
+    /// `version: "1"`, OpenAPI uses `openapi`/`swagger`, HAR uses `log`.
+    ///
+    /// A bare request document (`name`/`method`/`url`, no `order`) is NOT
+    /// claimed: on its own it is indistinguishable from several other
+    /// single-request formats, and claiming it would make which adapter wins
+    /// depend on registration order.
+    fn detect(&self, bytes: &[u8]) -> bool {
+        let Ok(text) = std::str::from_utf8(bytes) else {
+            return false;
+        };
+        let Ok(value) = yaml_serde::from_str::<serde_json::Value>(text) else {
+            return false;
+        };
+        let Some(map) = value.as_object() else {
+            return false;
+        };
+        // Another format's document that happens to parse as YAML — JSON is
+        // valid YAML, so every JSON input reaches here.
+        for foreign in ["openapi", "swagger", "log", "_type", "info", "items"] {
+            if map.contains_key(foreign) {
+                return false;
+            }
+        }
+        map.contains_key("name") && map.get("order").map(|o| o.is_array()).unwrap_or(false)
+    }
+
+    /// Without a path there is no collection — only the root manifest.
+    ///
+    /// `parse` exists because the trait requires it, and it refuses BY NAME
+    /// rather than returning a scenario with no requests. A KnockPort
+    /// collection's requests live in sibling files; handing back an empty
+    /// scenario would look like "a collection with nothing in it", which is
+    /// the silent-emptiness failure the honest-refusal rule exists to stop.
+    fn parse(&self, _bytes: &[u8]) -> Result<Scenario> {
+        Err(TropelError::Parse(
+            "a KnockPort collection is a DIRECTORY (knockport.yaml + requests/), so it cannot be \
+             read from bytes alone — point tropel at the collection directory or its \
+             knockport.yaml"
+                .to_string(),
+        ))
+    }
+
+    fn parse_with_path(&self, bytes: &[u8], source_path: Option<&Path>) -> Result<Scenario> {
+        let Some(path) = source_path else {
+            return self.parse(bytes);
+        };
+        // Either the directory itself or the manifest inside it — a user types
+        // whichever is on their clipboard, and both name the same collection.
+        let root = if path.is_dir() {
+            path.to_path_buf()
+        } else {
+            path.parent()
+                .ok_or_else(|| {
+                    TropelError::Parse(format!(
+                        "{} has no parent directory, so the collection root cannot be found",
+                        path.display()
+                    ))
+                })?
+                .to_path_buf()
+        };
+
+        let manifest_path = root.join(ROOT_FILE);
+        let manifest_text = std::fs::read_to_string(&manifest_path).map_err(|e| {
+            TropelError::Parse(format!(
+                "cannot read {}: {e} — a KnockPort collection root must contain {ROOT_FILE}",
+                manifest_path.display()
+            ))
+        })?;
+        let manifest = parse_yaml(&manifest_text, &manifest_path)?;
+
+        let mut notes: Vec<String> = Vec::new();
+        let name = str_field(&manifest, "name")
+            .map(str::to_string)
+            .unwrap_or_else(|| dir_name(&root));
+
+        let requests_dir = root.join(REQUESTS_DIR);
+        let items = if requests_dir.is_dir() {
+            read_folder(&requests_dir, &manifest, &root, &mut notes)?
+        } else {
+            notes.push(format!(
+                "no {REQUESTS_DIR}/ directory beside {ROOT_FILE} — the collection imported with \
+                 no requests"
+            ));
+            Vec::new()
+        };
+
+        Ok(Scenario {
+            info: ScenarioInfo {
+                name,
+                description: str_field(&manifest, "description").map(str::to_string),
+                schema: None,
+            },
+            items,
+            conversion_notes: notes,
+            ..Default::default()
+        })
+    }
+}
+
+/// Read one folder into scenario items, honouring its `order:`.
+///
+/// `order_source` is the document that owns the ordering for THIS directory:
+/// `knockport.yaml` for `requests/`, and the directory's own `folder.yaml`
+/// below that.
+fn read_folder(
+    dir: &Path,
+    order_source: &serde_json::Value,
+    root: &Path,
+    notes: &mut Vec<String>,
+) -> Result<Vec<ScenarioItem>> {
+    let ordered = str_list(order_source, "order");
+
+    // Everything actually on disk, so an entry missing from `order:` is still
+    // imported rather than silently dropped.
+    let mut on_disk: Vec<String> = Vec::new();
+    let entries = std::fs::read_dir(dir)
+        .map_err(|e| TropelError::Parse(format!("cannot read {}: {e}", dir.display())))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|e| TropelError::Parse(format!("cannot read {}: {e}", dir.display())))?;
+        let file_name = entry.file_name().to_string_lossy().to_string();
+        if file_name == FOLDER_FILE {
+            continue; // the folder's own manifest, not a child
+        }
+        let path = entry.path();
+        if path.is_dir() || file_name.ends_with(".yaml") || file_name.ends_with(".yml") {
+            on_disk.push(file_name);
+        }
+    }
+    on_disk.sort();
+
+    // `order:` first, then whatever it did not mention.
+    let mut sequence: Vec<String> = Vec::new();
+    for named in &ordered {
+        if on_disk.iter().any(|f| f == named) {
+            sequence.push(named.clone());
+        } else {
+            notes.push(format!(
+                "{}: order lists \"{named}\", which is not on disk",
+                rel(dir, root)
+            ));
+        }
+    }
+    for found in &on_disk {
+        if !sequence.contains(found) {
+            sequence.push(found.clone());
+        }
+    }
+
+    let mut items = Vec::new();
+    for entry_name in sequence {
+        let path = dir.join(&entry_name);
+        if path.is_dir() {
+            // A subfolder: its `folder.yaml` owns both its name and its order.
+            let folder_manifest_path = path.join(FOLDER_FILE);
+            let folder_manifest = match std::fs::read_to_string(&folder_manifest_path) {
+                Ok(text) => parse_yaml(&text, &folder_manifest_path)?,
+                // No folder.yaml is legal — the directory name is the folder
+                // name and the children sort alphabetically.
+                Err(_) => serde_json::Value::Null,
+            };
+            let children = read_folder(&path, &folder_manifest, root, notes)?;
+            items.push(ScenarioItem {
+                name: str_field(&folder_manifest, "name")
+                    .unwrap_or(&entry_name)
+                    .to_string(),
+                items: children,
+                ..Default::default()
+            });
+        } else {
+            match read_request(&path, root, notes)? {
+                Some(item) => items.push(item),
+                None => continue,
+            }
+        }
+    }
+    Ok(items)
+}
+
+/// One request document → one scenario item.
+///
+/// Returns `Ok(None)` for a document that is not a request (no `url`), with a
+/// note — a stray YAML file in `requests/` should not fail the whole import.
+fn read_request(path: &Path, root: &Path, notes: &mut Vec<String>) -> Result<Option<ScenarioItem>> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| TropelError::Parse(format!("cannot read {}: {e}", path.display())))?;
+    let doc = parse_yaml(&text, path)?;
+
+    let Some(url) = str_field(&doc, "url") else {
+        notes.push(format!("{}: no url, skipped", rel(path, root)));
+        return Ok(None);
+    };
+
+    let method_text = str_field(&doc, "method").unwrap_or("GET");
+    let method = parse_method(method_text).ok_or_else(|| {
+        TropelError::Parse(format!(
+            "{}: \"{method_text}\" is not an HTTP method",
+            rel(path, root)
+        ))
+    })?;
+
+    // The FILENAME is the identity (KP-101), so the stem is the fallback name
+    // — never an empty string, and never an invented id.
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "request".to_string());
+
+    if doc.get("prerequest").is_some() || doc.get("test").is_some() {
+        notes.push(format!(
+            "{}: scripts are not imported — tropel's script realm is the pm/k6 surface and \
+             running a KnockPort script there would not be the same script",
+            rel(path, root)
+        ));
+    }
+    if doc.get("assertions").is_some() {
+        notes.push(format!("{}: assertions are not imported", rel(path, root)));
+    }
+
+    Ok(Some(ScenarioItem {
+        name: str_field(&doc, "name").unwrap_or(&stem).to_string(),
+        request: Some(Request {
+            url: url.to_string(),
+            method,
+            headers: pairs(&doc, "headers"),
+            query_params: pairs(&doc, "params").into_iter().collect(),
+            body: body_of(&doc),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }))
+}
+
+/// The body, for the modes that map onto a tropel `Body` without inventing
+/// anything.
+///
+/// `binary` is deliberately NOT mapped: the document holds a `file.path`
+/// relative to the collection, and reading it here would make an import
+/// silently depend on files outside the collection root. It becomes a note.
+fn body_of(doc: &serde_json::Value) -> Option<Body> {
+    let body = doc.get("body")?.as_object()?;
+    let kind = body.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    match kind {
+        "json" | "raw" | "text" | "xml" | "graphql" => body
+            .get("raw")
+            .and_then(|v| v.as_str())
+            .map(|s| Body::Raw(s.to_string())),
+        "form-urlencoded" | "multipart-form" => {
+            let rows = body.get("formData")?.as_array()?;
+            let pairs: Vec<(String, String)> = rows
+                .iter()
+                .filter_map(|r| {
+                    let r = r.as_object()?;
+                    // A disabled row is deliberate local state, not data.
+                    if r.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
+                        return None;
+                    }
+                    Some((
+                        r.get("key")?.as_str()?.to_string(),
+                        r.get("value")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    ))
+                })
+                .collect();
+            Some(Body::UrlEncoded(pairs.into_iter().collect()))
+        }
+        _ => None,
+    }
+}
+
+/// `[{key, value, enabled}]` → pairs, dropping disabled rows.
+fn pairs(doc: &serde_json::Value, field: &str) -> Vec<(String, String)> {
+    doc.get(field)
+        .and_then(|v| v.as_array())
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|r| {
+                    let r = r.as_object()?;
+                    if r.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
+                        return None;
+                    }
+                    Some((
+                        r.get("key")?.as_str()?.to_string(),
+                        r.get("value")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_yaml(text: &str, path: &Path) -> Result<serde_json::Value> {
+    yaml_serde::from_str::<serde_json::Value>(text)
+        .map_err(|e| TropelError::Parse(format!("{} is not valid YAML: {e}", path.display())))
+}
+
+fn parse_method(text: &str) -> Option<Method> {
+    match text.trim().to_ascii_uppercase().as_str() {
+        "GET" => Some(Method::GET),
+        "POST" => Some(Method::POST),
+        "PUT" => Some(Method::PUT),
+        "PATCH" => Some(Method::PATCH),
+        "DELETE" => Some(Method::DELETE),
+        "HEAD" => Some(Method::HEAD),
+        "OPTIONS" => Some(Method::OPTIONS),
+        _ => None,
+    }
+}
+
+fn str_field<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    value.get(key)?.as_str()
+}
+
+fn str_list(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn dir_name(path: &Path) -> String {
+    path.file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "KnockPort collection".to_string())
+}
+
+/// A path relative to the collection root, for messages a user can act on.
+fn rel(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+// Priority 40 — the highest of the adapters, because this `detect` is the
+// most specific: it requires an `order` list, which no other supported format
+// has, and rejects every other format's marker key outright. Ranking it below
+// a looser detector would let that detector claim a KnockPort manifest first.
+//
+// For reference: insomnia 35, har 30, bru 26, http 25, openapi 20, k6 10.
+inventory::submit!(
+    InputAdapterRegistration::new("knockport", || Box::new(KnockPortInputAdapter))
+        .with_priority(40)
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A collection on disk, built to the shapes in KnockPort's OWN fixtures
+    /// (`packages/format/fixtures/doc-example` and `roundtrip/*`) rather than
+    /// to what this adapter finds convenient — the point of the adapter is to
+    /// read what the client writes.
+    fn write_collection(root: &Path) {
+        let w = |rel: &str, body: &str| {
+            let p = root.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(p, body).unwrap();
+        };
+        w(
+            "knockport.yaml",
+            "name: Doc Example\nvariables: []\norder:\n  - auth\n  - health.yaml\n",
+        );
+        w(
+            "requests/health.yaml",
+            "name: Health\nmethod: GET\nurl: https://api.example.test/health\n",
+        );
+        // DELIBERATELY anti-alphabetical: refresh before login. The client's
+        // own fixture happens to list them alphabetically, so a copy of it
+        // cannot tell "order is honoured" from "the entries were sorted" —
+        // and the first version of this test could not, which a mutation
+        // check caught. The real fixture is asserted separately, below.
+        w(
+            "requests/auth/folder.yaml",
+            "name: auth\norder:\n  - refresh.yaml\n  - login.yaml\n",
+        );
+        w(
+            "requests/auth/login.yaml",
+            "name: Login\nmethod: POST\nurl: https://api.example.test/login\n",
+        );
+        w(
+            "requests/auth/refresh.yaml",
+            "name: Refresh\nmethod: POST\nurl: https://api.example.test/refresh\n",
+        );
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("kp-adapter-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_collection_directory_becomes_a_scenario_tree() {
+        let root = tmp("tree");
+        write_collection(&root);
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("parses");
+        assert_eq!(s.info.name, "Doc Example");
+        let names: Vec<&str> = s.items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["auth", "Health"]);
+        let auth = &s.items[0];
+        // The load-bearing assertion: the folder declares refresh BEFORE
+        // login, which is the reverse of both alphabetical order and
+        // readdir order. Only reading `order:` produces this.
+        let inner: Vec<&str> = auth.items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(inner, vec!["Refresh", "Login"], "folder order is honoured");
+        assert!(auth.request.is_none(), "a folder carries no request");
+        let health = s.items[1].request.as_ref().expect("health is a request");
+        assert_eq!(health.url, "https://api.example.test/health");
+        assert_eq!(health.method.to_string(), "GET");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_manifest_path_and_the_directory_both_work() {
+        // A user pastes whichever of the two they have; both name the same
+        // collection and neither should be a usage error.
+        let root = tmp("either");
+        write_collection(&root);
+        let from_dir = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("directory parses");
+        let from_file = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root.join("knockport.yaml")))
+            .expect("manifest parses");
+        assert_eq!(from_dir.info.name, from_file.info.name);
+        assert_eq!(from_dir.items.len(), from_file.items.len());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_file_missing_from_order_is_imported_not_dropped() {
+        // A hand-authored request someone forgot to list is still a request
+        // they want run. Dropping it silently is the worst outcome: the run
+        // succeeds and is missing a request.
+        let root = tmp("unlisted");
+        write_collection(&root);
+        std::fs::write(
+            root.join("requests/orphan.yaml"),
+            "name: Orphan\nmethod: GET\nurl: https://api.example.test/orphan\n",
+        )
+        .unwrap();
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("parses");
+        let names: Vec<&str> = s.items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["auth", "Health", "Orphan"],
+            "the unlisted file follows the ordered ones"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_order_entry_with_no_file_is_a_note_not_a_failure() {
+        let root = tmp("ghost");
+        write_collection(&root);
+        std::fs::write(
+            root.join("knockport.yaml"),
+            "name: Doc Example\norder:\n  - gone.yaml\n  - health.yaml\n",
+        )
+        .unwrap();
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("still parses");
+        assert!(
+            s.conversion_notes.iter().any(|n| n.contains("gone.yaml")),
+            "the missing entry is reported: {:?}",
+            s.conversion_notes
+        );
+        assert!(
+            s.items.iter().any(|i| i.name == "Health"),
+            "and the rest still imports"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_filename_is_the_identity_when_no_name_key_is_present() {
+        // KP-101: documents carry no `id:`, and identity derives from the
+        // path. A request file with no `name:` takes its stem — never an
+        // empty string, which is what the client's "A missing identity is
+        // NEVER the empty string" rule requires.
+        let root = tmp("stem");
+        write_collection(&root);
+        std::fs::write(
+            root.join("requests/Unnamed.yaml"),
+            "method: GET\nurl: https://api.example.test/x\n",
+        )
+        .unwrap();
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("parses");
+        assert!(
+            s.items.iter().any(|i| i.name == "Unnamed"),
+            "got {:?}",
+            s.items.iter().map(|i| &i.name).collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_disabled_header_row_is_not_sent() {
+        // A disabled row is deliberate local state in the client. Importing
+        // it as active would send something the user turned off.
+        let root = tmp("disabled");
+        write_collection(&root);
+        std::fs::write(
+            root.join("requests/health.yaml"),
+            concat!(
+                "name: Health\n",
+                "method: GET\n",
+                "url: https://api.example.test/health\n",
+                "headers:\n",
+                "  - key: X-On\n",
+                "    value: \"1\"\n",
+                "    enabled: true\n",
+                "  - key: X-Off\n",
+                "    value: \"2\"\n",
+                "    enabled: false\n",
+            ),
+        )
+        .unwrap();
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("parses");
+        let req = s
+            .items
+            .iter()
+            .find(|i| i.name == "Health")
+            .and_then(|i| i.request.as_ref())
+            .expect("health");
+        let keys: Vec<&str> = req.headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["X-On"], "the disabled row is dropped");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scripts_are_reported_rather_than_silently_dropped() {
+        let root = tmp("scripts");
+        write_collection(&root);
+        std::fs::write(
+            root.join("requests/health.yaml"),
+            concat!(
+                "name: Health\n",
+                "method: GET\n",
+                "url: https://api.example.test/health\n",
+                "test: |\n",
+                "  kp.test(\"ok\", () => {});\n",
+            ),
+        )
+        .unwrap();
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect("parses");
+        assert!(
+            s.conversion_notes
+                .iter()
+                .any(|n| n.contains("scripts are not imported")),
+            "got {:?}",
+            s.conversion_notes
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The REAL fixture from the client repo, when it is present.
+    ///
+    /// The tests above build their own copies, which proves the adapter reads
+    /// the shapes I believe KnockPort writes. This one reads the bytes
+    /// KnockPort actually committed — the only version that can catch a
+    /// divergence between the two products, which is the entire reason this
+    /// adapter exists. Skipped when the sibling checkout is absent, because a
+    /// unit test must not require someone else's repo to be on disk.
+    #[test]
+    fn the_clients_own_committed_fixture_parses() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../scam-repo/kp-review/packages/format/fixtures/doc-example");
+        if !fixture.join("knockport.yaml").is_file() {
+            eprintln!("skipped: {} not present", fixture.display());
+            return;
+        }
+        let s = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&fixture))
+            .expect("the client's own fixture must parse");
+        assert_eq!(s.info.name, "Doc Example");
+        let names: Vec<&str> = s.items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["auth", "Health"]);
+        let inner: Vec<&str> = s.items[0].items.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(inner, vec!["Login", "Refresh"]);
+    }
+
+    #[test]
+    fn parse_without_a_path_refuses_by_name() {
+        // NOT an empty scenario. A collection whose requests live in sibling
+        // files cannot be read from one buffer, and returning zero requests
+        // would look like an empty collection rather than a wrong call.
+        let err = KnockPortInputAdapter
+            .parse(b"name: X\norder: []\n")
+            .expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("DIRECTORY"), "got {msg}");
+        assert!(msg.contains("knockport.yaml"), "names the file: {msg}");
+    }
+
+    #[test]
+    fn detect_claims_a_manifest_and_declines_every_other_format() {
+        let a = KnockPortInputAdapter;
+        assert!(a.detect(b"name: My API\norder:\n  - health.yaml\n"));
+        // No `order:` — a bare request is indistinguishable from other
+        // single-request formats, so it is not claimed.
+        assert!(!a.detect(b"name: Health\nmethod: GET\nurl: https://x/y\n"));
+        // JSON is valid YAML, so every other format's document reaches here.
+        assert!(!a.detect(br#"{"openapi":"3.0.0","info":{"title":"t"}}"#));
+        assert!(!a.detect(br#"{"swagger":"2.0","info":{"title":"t"}}"#));
+        assert!(!a.detect(br#"{"log":{"entries":[]}}"#));
+        assert!(!a.detect(br#"{"_type":"export","resources":[]}"#));
+        assert!(!a.detect(br#"{"version":"1","name":"b","items":[]}"#));
+        assert!(!a.detect(b"not: [valid"));
+    }
+
+    #[test]
+    fn a_missing_root_manifest_names_the_file_it_wanted() {
+        let root = tmp("empty");
+        let err = KnockPortInputAdapter
+            .parse_with_path(b"", Some(&root))
+            .expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("knockport.yaml"), "got {msg}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/inputs/tropel-input-openapi/Cargo.toml
+++ b/crates/inputs/tropel-input-openapi/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-openapi"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Input adapter that reads OpenAPI 3.x specifications and produces a Scenario"
 
 [dependencies]

--- a/crates/inputs/tropel-input-postman/Cargo.toml
+++ b/crates/inputs/tropel-input-postman/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-input-postman"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Postman collection (v2.0/v2.1) input adapter for tropel."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/inputs/tropel-input-subprocess/Cargo.toml
+++ b/crates/inputs/tropel-input-subprocess/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-input-subprocess"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Subprocess/JSON input adapter — runs an external command that reads bytes on stdin and writes a JSON Scenario on stdout"
 
 [dependencies]

--- a/crates/tropel-auth/Cargo.toml
+++ b/crates/tropel-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-auth"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-bench/Cargo.toml
+++ b/crates/tropel-bench/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-bench"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Criterion benchmark suite for Tropel: context bootstrap, per-iteration overhead, native-vs-JS, pool dispatch, memory-per-VU"
 
 [dependencies]

--- a/crates/tropel-build/Cargo.toml
+++ b/crates/tropel-build/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-build"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Build-time helpers for tropel crates: bundled asset embedding and the generated version stamps."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-collection/Cargo.toml
+++ b/crates/tropel-collection/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-collection"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Collection model shared by tropel's input adapters — the folder tree, per-layer scripts and variable scopes."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-core-wasm/Cargo.toml
+++ b/crates/tropel-core-wasm/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "tropel-core-wasm"
-version = "0.1.0"
+version = "0.6.0"
 # Explicit (not `.workspace = true`): wasm-pack 0.10's manifest parser
 # rejects inherited table fields ("invalid type: map, expected a string").
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/transithq/tropel"
 rust-version = "1.85"
-publish = false
 description = "Core tier of Tropel for browser embedders (KnockPort): variables/auth/import compiled to wasm32-unknown-unknown with a wasm-bindgen surface. No QuickJS — see API_CLIENT_WEB_PAYLOAD.md §2.3 (two-tier wasm)."
 
 [lib]

--- a/crates/tropel-core/Cargo.toml
+++ b/crates/tropel-core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-core"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Core tropel types shared across the engine: job configuration, scenario resolution and the execution plan."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-distributed/Cargo.toml
+++ b/crates/tropel-distributed/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-distributed"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Distributed load generation for tropel — the controller/agent protocol and cross-node metric merging."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [[bin]]
 name = "tropel-controller"

--- a/crates/tropel-engine/Cargo.toml
+++ b/crates/tropel-engine/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-engine"
-version = "0.5.5"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "The tropel load-test engine: scenario execution, VU scheduling, the protocol registry and the metrics pipeline."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-engine/Cargo.toml
+++ b/crates/tropel-engine/Cargo.toml
@@ -41,6 +41,7 @@ tropel-input-subprocess.workspace = true
 tropel-input-http.workspace = true
 tropel-input-bru.workspace = true
 tropel-input-insomnia.workspace = true
+tropel-input-knockport.workspace = true
 tropel-wasm.workspace = true
 tropel-x-grpc.workspace = true
 tropel-x-websocket.workspace = true

--- a/crates/tropel-engine/src/builtins.rs
+++ b/crates/tropel-engine/src/builtins.rs
@@ -28,6 +28,10 @@ pub fn link_builtins() -> usize {
         Box::new(tropel_input_http::HttpFileAdapter),
         Box::new(tropel_input_bru::BruInputAdapter),
         Box::new(tropel_input_insomnia::InsomniaInputAdapter),
+        // The sibling product's own format. tropel could read every
+        // competitor's collection and not KnockPort's, which is the one
+        // format both products own.
+        Box::new(tropel_input_knockport::KnockPortInputAdapter),
     ];
     let drivers: Vec<Box<dyn Driver>> = vec![
         Box::new(tropel_input_k6::driver::K6Driver),

--- a/crates/tropel-es/Cargo.toml
+++ b/crates/tropel-es/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-es"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "TypeScript transpilation and ES module bundling for Tropel load-test scripts"
 
 [dependencies]

--- a/crates/tropel-ext/Cargo.toml
+++ b/crates/tropel-ext/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-ext"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Extension registry for tropel — the inventory-backed discovery that lets adapters, protocols and outputs register themselves."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-http/Cargo.toml
+++ b/crates/tropel-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-http"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -8,7 +8,6 @@ rust-version.workspace = true
 # F1 (review): tropel-http was published by accident (sandbox's send-request
 # optional dep forced cargo to publish it). It's internal — depend on
 # tropel-runtime instead. publish = false blocks future publishes.
-publish = false
 description = "HTTP protocol implementation for Tropel: reqwest client, connection pooling, redirects, per-VU cookie jar. Auth signers live in tropel-auth. INTERNAL — not a supported crate; depend on tropel-runtime instead."
 
 [dependencies]

--- a/crates/tropel-input-wasm/Cargo.toml
+++ b/crates/tropel-input-wasm/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "tropel-input-wasm"
-version = "0.1.0"
+version = "0.6.0"
 # Explicit (not `.workspace = true`): wasm-pack 0.10's manifest parser
 # rejects inherited table fields ("invalid type: map, expected a string").
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/transithq/tropel"
 rust-version = "1.85"
-publish = false
 description = "Lazy collection-import slice for browser embedders (KnockPort): OpenAPI 3.x / Swagger 2.0, Postman v2.x and HAR compiled to wasm32-unknown-unknown with a wasm-bindgen surface. Loaded on demand when the import UI opens — see API_CLIENT_WEB_PAYLOAD.md §2.3 (two-tier wasm)."
 
 [lib]

--- a/crates/tropel-js/Cargo.toml
+++ b/crates/tropel-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-js"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-metrics/Cargo.toml
+++ b/crates/tropel-metrics/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-metrics"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Metrics collection for tropel: sharded aggregation, HDR histograms and the k6-compatible metric set."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-native/Cargo.toml
+++ b/crates/tropel-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-native"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-report/Cargo.toml
+++ b/crates/tropel-report/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-report"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "Report rendering for tropel runs — the summary tables, thresholds verdicts and JSON/JUnit artifacts."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-runtime/Cargo.toml
+++ b/crates/tropel-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-runtime"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-sandbox/Cargo.toml
+++ b/crates/tropel-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-sandbox"
-version = "0.2.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-scheduler/Cargo.toml
+++ b/crates/tropel-scheduler/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel-scheduler"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "VU scheduling for tropel: the executor types (constant-vus, ramping-arrival-rate and the rest) and their arrival models."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
 tropel-sdk.workspace = true

--- a/crates/tropel-variables/Cargo.toml
+++ b/crates/tropel-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-variables"
-version = "0.3.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tropel-wasm/Cargo.toml
+++ b/crates/tropel-wasm/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-wasm"
-version = "0.1.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "WASM plugin runtime for Tropel — loads and runs WebAssembly plugins via wasmtime"
 
 [dependencies]

--- a/crates/tropel-web/Cargo.toml
+++ b/crates/tropel-web/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tropel-web"
-version = "0.5.5"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 description = "Browser slice of Tropel: a wasm32-wasip1 cdylib exposing a postcard C ABI over tropel-runtime (TROPEL_WASM_BUILD.md Step 5A)."
 
 # cdylib exports the C ABI (`tropel_alloc` / `tropel_free` / `tropel_run`)

--- a/crates/tropel/Cargo.toml
+++ b/crates/tropel/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tropel"
-version = "0.5.5"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
+description = "The tropel CLI — run Postman collections, HAR files, OpenAPI specs, Bruno and Insomnia exports, and k6 scripts as load tests."
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [[bin]]
 name = "tropel"

--- a/packages/core-wasm/package.json
+++ b/packages/core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/core-wasm",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Tropel core tier for browser embedders (KnockPort): the dynamic-variable catalog (and later auth signing / import parse) compiled to wasm32-unknown-unknown. No QuickJS \u2014 see API_CLIENT_WEB_PAYLOAD.md \u00a72.3 two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/input-wasm/package.json
+++ b/packages/input-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/input-wasm",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Tropel collection-import slice for browser embedders (KnockPort). Lazy sibling of @tropel/core-wasm: OpenAPI 3.x, Postman v2.x, and HAR parsers compiled to wasm32-unknown-unknown. See API_CLIENT_WEB_PAYLOAD.md \u00a72.3 for the two-tier split.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-wasm/package.json
+++ b/packages/runtime-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/runtime-wasm",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Browser/Node host for the tropel load-testing runtime compiled to wasm32-wasip1: postcard C ABI driver, WASI preview1 wiring, and the HTTP bridge that answers each request the runtime makes.",
   "license": "Apache-2.0",
   "type": "module",
@@ -45,7 +45,7 @@
     "tropel"
   ],
   "dependencies": {
-    "@tropel/shims": "^0.5.5"
+    "@tropel/shims": "^0.6.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tropel/shims",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "The tropel JS shim bundle — pm/bru scripting API, chai, lodash, CryptoJS, exec, and the k6 family. The same sources the tropel runtime embeds (ShimBundle::default()), published for embedders.",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/publish-dry-run.sh
+++ b/scripts/publish-dry-run.sh
@@ -27,6 +27,45 @@ while IFS= read -r manifest; do
   [[ -n "$name" ]] && PUBLISHABLE+=("$name")
 done < <(find crates -name Cargo.toml -maxdepth 3 | sort)
 
+# Find the crate's own version in this workspace, wherever it lives.
+crate_version() {
+  local name=$1 m
+  m=$(find crates -maxdepth 3 -name Cargo.toml -path "*/$name/Cargo.toml" | head -1)
+  [[ -n "$m" ]] && grep -m1 '^version' "$m" | sed -E 's/.*"(.*)".*/\1/'
+}
+
+# Is this failure just "a workspace sibling is not on crates.io yet"?
+#
+# Cargo words that TWO ways, and the second one used to be read as a hard
+# failure:
+#
+#   failed to select a version for the requirement `tropel-sdk = "^0.4.0"`
+#       — the crate IS on crates.io, but not at this version
+#   no matching package named `tropel-core` found
+#       — the crate is not on crates.io AT ALL
+#
+# Both are the normal pre-publish state of a multi-crate release, and both
+# resolve by publishing in dependency order. Only the first was recognised,
+# which is why a first full-tree publish reported "BLOCKED: 12 of 35 … the
+# gate is NOT met" for something entirely expected.
+#
+# The guard against a REAL failure is unchanged and is what matters: the
+# named crate must be a workspace member whose own version is the one being
+# asked for. A dependency that exists nowhere in this tree is still a FAIL.
+unpublished_sibling() {
+  local out=$1 name req
+  name=$(awk -F'`' '/failed to select a version for the requirement/ {print $2; exit}' <<<"$out")
+  if [[ -n "$name" ]]; then
+    req=$(sed -E 's/.*"\^?([0-9][^"]*)".*/\1/' <<<"$name")
+    name=${name%% =*}
+    [[ "$(crate_version "$name")" == "$req" ]] && { echo "$name"; return 0; }
+    return 1
+  fi
+  name=$(awk -F'`' '/no matching package named/ {print $2; exit}' <<<"$out")
+  [[ -n "$name" && -n "$(crate_version "$name")" ]] && { echo "$name"; return 0; }
+  return 1
+}
+
 echo "── TR-601: cargo publish --dry-run ──"
 failed=()
 pending=()
@@ -34,11 +73,7 @@ for crate in "${PUBLISHABLE[@]}"; do
   printf '%-22s ' "$crate"
   if out=$(cargo publish --dry-run -p "$crate" --allow-dirty --no-verify 2>&1); then
     echo "ok"
-  elif pending_dep=$(awk -F'`' '/failed to select a version for the requirement/ {print $2; exit}' <<<"$out"); [[ -n "$pending_dep" ]] \
-       && dep_name=${pending_dep%% =*} \
-       && dep_req=$(sed -E 's/.*"\^?([0-9][^"]*)".*/\1/' <<<"$pending_dep") \
-       && [[ -f "crates/$dep_name/Cargo.toml" ]] \
-       && [[ "$(grep -m1 '^version' "crates/$dep_name/Cargo.toml" | sed -E 's/.*"(.*)".*/\1/')" == "$dep_req" ]]; then
+  elif dep_name=$(unpublished_sibling "$out"); [[ -n "$dep_name" ]]; then
     # NOT a defect: this crate needs a workspace sibling at a version that is
     # in this tree but not yet on crates.io. A multi-crate release is inherently
     # chicken-and-egg — a dependent cannot dry-run clean until its dependency is
@@ -48,8 +83,9 @@ for crate in "${PUBLISHABLE[@]}"; do
     # Distinguished from a real failure by proving the missing version IS the
     # one this workspace declares. A dep version that exists nowhere is still a
     # hard FAIL below.
-    echo "PENDING ($dep_name $dep_req publishes earlier in the order)"
-    pending+=("$crate <- $dep_name@$dep_req")
+    dep_ver=$(crate_version "$dep_name")
+    echo "PENDING ($dep_name $dep_ver publishes earlier in the order)"
+    pending+=("$crate <- $dep_name@$dep_ver")
   else
     echo "FAIL"
     echo "$out" | sed -n '/^error/,+4p' | sed 's/^/    /'
@@ -59,9 +95,33 @@ done
 
 if [[ ${#pending[@]} -gt 0 ]]; then
   echo
-  echo "PENDING publish order (${#pending[@]}): each needs a workspace sibling published first."
+  echo "PENDING (${#pending[@]}): each needs a workspace sibling published first."
   printf '  %s\n' "${pending[@]}"
-  echo "  This is expected before a release and resolves as you publish in dependency order."
+  echo "  Expected before a release; resolves as you publish in dependency order."
+  echo
+  # The order itself, rather than leaving the reader to derive it from the
+  # pairs above. A 35-crate release is not something to sequence by hand, and
+  # getting it wrong means a failed publish with a version already burned.
+  echo "── publish order (topological, non-dev edges) ──"
+  cargo metadata --format-version 1 --no-deps 2>/dev/null | python3 -c '
+import json,sys
+md=json.load(sys.stdin)
+pkgs={p["name"]:p for p in md["packages"]}
+names=set(pkgs)
+# dev-dependencies are STRIPPED from a published manifest, so they do not
+# constrain the order — only normal and build edges do.
+deps={n:{d["name"] for d in p["dependencies"]
+         if d["name"] in names and d["kind"] is None}
+      for n,p in pkgs.items()}
+order=[]; done=set()
+while len(done)<len(names):
+    ready=sorted(n for n in names if n not in done and deps[n]<=done)
+    if not ready:
+        sys.exit("CYCLE among: %s" % sorted(names-done))
+    order+=ready; done|=set(ready)
+for i,n in enumerate(order,1):
+    print("  %2d. cargo publish -p %s" % (i,n))
+'
 fi
 
 if [[ ${#failed[@]} -gt 0 ]]; then


### PR DESCRIPTION
KnockPort pins tropel by **git SHA** across seven declarations. A SHA is reproducible but not maintainable, and six of those seven crates *could not* become registry dependencies — they were `publish = false`. This publishes the tree so a consumer depends on `version = "0.6.0"`.

## Why the whole tree, not just `tropel-engine`

Because cargo will not let you publish a crate whose non-dev dependencies are not already on crates.io, and `tropel-engine` has **27 internal dependencies**. There is no vendoring escape hatch. The team had already hit this — `tropel-runtime/Cargo.toml` documents it:

> `tropel-http` is `publish = false` and its sole registry version (0.1.0) is yanked, so that resolution cannot succeed and `cargo publish -p tropel-runtime` failed with: `no matching package named tropel-http found`

## The mechanics

- **35 crates at 0.6.0**, with the binary, `tropel-web` and the four npm packages
- **28 `publish = false` lines removed**
- **14 crates gained a `description`** — cargo refuses to publish without one, so this was the hard prerequisite rather than tidying
- every workspace `tropel-*` declaration carries a `version`; a path-only dependency cannot be published at all, since consumers resolve the version and not the path

**0.6.0 rather than 0.5.6** because the release is breaking: `tropel-auth`'s EdgeGrid error type went `TropelError` → `String` and its clock/CSPRNG helpers became feature-gated, and `Request` gained a `proxy` field. Pre-1.0 that is a minor bump by this repo's own policy.

## `tropel-sdk` stays at 0.4.0, deliberately

It is the contract a **third-party adapter author** depends on — its own repo, its own history on crates.io (0.1.0 → 0.2.0 → 0.3.0, and 0.3.0 has real downloads). Its version must track *its* API, not this repo's release train; dragging it to 0.6.0 would tell an SDK consumer something changed for them when nothing did.

So the lockstep script's advice is retired with it. It used to say *"realign the SDK crate's version in lockstep"*; it now reports the difference as expected:

```
ok: all seven version surfaces agree at 0.6.0
note: tropel-sdk is 0.4.0, parent is 0.6.0 — expected; the SDK versions independently (TR-407)
ok: tropel-sdk submodule pin matches its master
```

## `tropel-input-knockport` — tropel can read its sibling's format

tropel could import Postman, Bruno, Insomnia, HAR, OpenAPI, k6 and `.http` — **every competitor's format** — and not the one format both products own. `tropel run my-collection/` failed on it.

The format is a **directory, not a file**:

```
my-api/
├─ knockport.yaml              name, collection auth + scripts + vars, order
├─ environments/{dev,prod}.yaml
└─ requests/
   ├─ folder.yaml
   └─ auth/{folder.yaml, login.yaml, refresh.yaml}
```

so the adapter overrides `parse_with_path`. **No trait change was needed** — that hook already exists for k6's module resolution, and its doc comment already directs adapters needing filesystem context to use it.

Decisions taken from the *client's* format rules rather than from convenience:

| rule | why |
|---|---|
| **the filename is the identity** (KP-101) | documents carry no `id:`; a request with no `name:` takes its file stem, never an empty string. A format read differently by the two products is the exact bug this adapter exists to prevent. |
| `order:` is authoritative, lists filenames | requests with extension, folders as bare directory names — a directory and a file cannot share a name, so the reference is unambiguous |
| files **absent** from `order:` still import | a hand-authored file someone forgot to list is still a request they want run; dropping it means a green run missing a request |
| an `order:` entry with no file → **note, not failure** | the rest of the collection still imports |
| disabled rows are dropped | a disabled row is deliberate local state; importing it as active sends what the user switched off |
| `parse` (no path) **refuses by name** | an empty scenario would read as "a collection with nothing in it" |
| scripts and assertions are **reported** | tropel's script realm is the pm/k6 surface; running a KnockPort script there would not be the same script |

`detect()` requires `name` + an `order` array and rejects every other format's marker key — JSON is valid YAML, so every other format's document reaches it. Priority **40**, above all others, because it is the most specific detector.

### The tests, and one that could not fail

11 tests. One reads **KnockPort's own committed fixture** (`packages/format/fixtures/doc-example`) — the only version that can catch the two products diverging — and skips when the sibling checkout is absent, so it never requires someone else's repo.

The in-test collection declares **refresh before login** on purpose. The client's fixture lists them alphabetically, so a copy of it cannot distinguish "order honoured" from "entries sorted" — and a mutation check (stub out `order:`, re-run) showed the first version of this test passed anyway. It now fails two tests.

## `publish-dry-run.sh` cried wolf

It read *"no matching package named X found"* as a hard failure. Cargo words "a workspace sibling is not on crates.io yet" **two** ways, and only the other one was recognised, so the first full-tree run reported:

```
BLOCKED: 12 of 35 publishable crates cannot be published … the gate is NOT met
```

for the entirely normal pre-publish state. The guard against a *real* failure is unchanged: the named crate must be a workspace member whose own version is the one being asked for.

It now also prints the **topological publish order** (35 steps, non-dev edges only, since dev-dependencies are stripped from a published manifest). Sequencing 35 crates by hand is how a version number gets burned on a failed publish.

Current state:

```
ok: every publishable crate passes --dry-run — the TR-601 gate is met
```

## Verified locally

- `cargo check --workspace --all-targets` — clean (this compiles test targets too)
- `cargo test -p tropel-input-knockport -p tropel-engine --lib` — 11 + 90 pass
- `publish-dry-run.sh` — all 35 pass, order emitted
- `version-lockstep.sh` — seven surfaces at 0.6.0, pin guard ok
- `release-notes.sh 0.6.0` — generates (it hard-fails on a missing section, and that is not theoretical: v0.3.0 and v0.5.4 both produced a tag and no release for exactly this)
- `cargo fmt --all --check`, `clippy` on the new crate — clean

**The full `cargo test --workspace` did not complete here** — it exhausted the disk on this machine mid-link, twice. CI has the room and is the gate for it; flagging it rather than implying I ran it.

## Not done here

`cargo publish` itself. 35 crate names and their 0.6.0 versions become permanent, so that stays a human step — and the script now hands over the exact ordered list.