### PR TITLE
chore(input-k6): 0.6.1 — 0.6.0 is published and cannot be built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "tropel-input-k6"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "base64 0.23.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ tropel-sdk = { path = "crates/tropel-sdk", version = "0.4.0" }
 tropel-engine = { path = "crates/tropel-engine", version = "0.6.0" }
 tropel-build = { path = "crates/tropel-build", version = "0.6.0" }
 tropel-input-postman = { path = "crates/inputs/tropel-input-postman", version = "0.6.0" }
-tropel-input-k6 = { path = "crates/inputs/tropel-input-k6", version = "0.6.0" }
+tropel-input-k6 = { path = "crates/inputs/tropel-input-k6", version = "0.6.1" }
 tropel-input-har = { path = "crates/inputs/tropel-input-har", version = "0.6.0" }
 tropel-input-knockport = { path = "crates/inputs/tropel-input-knockport", version = "0.6.0" }
 tropel-input-openapi = { path = "crates/inputs/tropel-input-openapi", version = "0.6.0" }

--- a/crates/inputs/tropel-input-k6/Cargo.toml
+++ b/crates/inputs/tropel-input-k6/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tropel-input-k6"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
`tropel-input-k6 0.6.0` went to crates.io from a tree that predates the js symlink
fix (#593). Its tarball contains `driver.rs` and **none** of the shim sources that
file embeds, so anyone depending on it gets:

```
error: couldn't read `src/../../../../js/k6-shim/open-data-shim.js`: No such file or directory
```

`0.6.0` is now **yanked**. Versions are permanent, so the fix ships as `0.6.1`.

## Why cargo didn't catch it

`cargo publish` runs its verify build inside `target/package/` — which is inside the
repo. From `target/package/tropel-input-k6-0.6.0/src/`, the crate's own
`../../../../js/...` climbs src → crate → package → target and lands on the **real
repo root**, where the real `js/` tree is. The verify build read files the tarball
does not contain, and passed.

`tropel-web` sits one directory higher. Its escape resolved to `target/js`, found
nothing, and failed loudly. The deeper crate published silently — the same escape,
opposite outcomes, decided purely by nesting depth.

**A green verify build is not evidence that a tarball is self-contained.** A static
check for include paths that escape their crate root is the thing that actually
proves it; that lands separately, along with four test-only escapes it already found
in `tropel-core-wasm` and `tropel-engine` (both reaching into `packages/`).

## Scope

Version only. The workspace requirement moves to `0.6.1` as well — `^0.6.0` would
have resolved `0.6.1` regardless, but it shouldn't read as though the yanked version
were the intended one.
