### PR TITLE
fix(publish): fail the build when an include! escapes its crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,23 @@ env:
   CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
 
 jobs:
+  include-paths:
+    name: include! paths confined to their crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Catches the class of bug that published tropel-input-k6 0.6.0 broken:
+    # an include_str! reaching outside its own crate packages into a tarball
+    # without the file, and `cargo publish` still says OK, because it verifies
+    # inside target/package/ where the escape can climb back out to the real
+    # repo. Static, needs no toolchain, runs in a second.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # crates/tropel-sdk is a git submodule of transithq/tropel-sdk
+          # (see .gitmodules) — it carries crates of its own to check.
+          submodules: recursive
+      - run: bash scripts/include-paths-in-crate.sh
+
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -869,7 +886,7 @@ jobs:
   ci-ok:
     name: CI OK
     if: always()
-    needs: [fmt, clippy, test, msrv, perf-regression, semver, deny, sdk-gates, wasm, smoke, npm-packages, k6-conformance, soak-smoke]
+    needs: [fmt, clippy, test, msrv, perf-regression, semver, deny, sdk-gates, wasm, smoke, npm-packages, k6-conformance, soak-smoke, include-paths]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/crates/tropel-core-wasm/src/lib.rs
+++ b/crates/tropel-core-wasm/src/lib.rs
@@ -725,7 +725,7 @@ mod tests {
     // Shipped in the npm package so an embedder reads the same bytes instead
     // of copying cases into its own suite, where they would drift exactly
     // like the code did.
-    const CORPUS: &str = include_str!("../../../packages/core-wasm/fixtures/resolve-corpus.json");
+    const CORPUS: &str = include_str!("../testdata/resolve-corpus.json");
 
     /// The generated `vars` for a case that needs more than a literal map.
     fn generated_vars(kind: &str) -> serde_json::Value {
@@ -966,7 +966,7 @@ mod tests {
             &s[..end]
         }
 
-        let facade = include_str!("../../../packages/core-wasm/src/index.js");
+        let facade = include_str!("../testdata/index.js");
 
         // The facade reaches the wasm through NAMED HANDLES: the module-level
         // `glue`, and any local alias bound from `requireGlue(...)` (today

--- a/crates/tropel-core-wasm/testdata/index.js
+++ b/crates/tropel-core-wasm/testdata/index.js
@@ -1,0 +1,1 @@
+../../../packages/core-wasm/src/index.js

--- a/crates/tropel-core-wasm/testdata/resolve-corpus.json
+++ b/crates/tropel-core-wasm/testdata/resolve-corpus.json
@@ -1,0 +1,1 @@
+../../../packages/core-wasm/fixtures/resolve-corpus.json

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -2975,7 +2975,7 @@ mod tests {
     #[tokio::test]
     async fn the_resolution_corpus_agrees_over_the_socket() {
         const CORPUS: &str =
-            include_str!("../../../packages/core-wasm/fixtures/resolve-corpus.json");
+            include_str!("../testdata/resolve-corpus.json");
 
         /// Mirrors `tropel-core-wasm`'s `generated_vars` — same kind, same
         /// construction from the SAME constant, so the two legs cannot drift
@@ -4109,7 +4109,7 @@ mod tests {
     #[tokio::test]
     async fn the_script_realm_matches_the_committed_corpus() {
         const CORPUS: &str =
-            include_str!("../../../packages/shims/fixtures/script-realm-corpus.json");
+            include_str!("../testdata/script-realm-corpus.json");
         let doc: serde_json::Value = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
         let probes = doc["probes"].as_array().expect("probes array");
         assert!(!probes.is_empty(), "an empty corpus asserts nothing");

--- a/crates/tropel-engine/src/agent.rs
+++ b/crates/tropel-engine/src/agent.rs
@@ -2974,8 +2974,7 @@ mod tests {
     /// smoke.mjs, which IS the TypeScript leg.
     #[tokio::test]
     async fn the_resolution_corpus_agrees_over_the_socket() {
-        const CORPUS: &str =
-            include_str!("../testdata/resolve-corpus.json");
+        const CORPUS: &str = include_str!("../testdata/resolve-corpus.json");
 
         /// Mirrors `tropel-core-wasm`'s `generated_vars` — same kind, same
         /// construction from the SAME constant, so the two legs cannot drift
@@ -4108,8 +4107,7 @@ mod tests {
     /// bug the `bru` probe found.
     #[tokio::test]
     async fn the_script_realm_matches_the_committed_corpus() {
-        const CORPUS: &str =
-            include_str!("../testdata/script-realm-corpus.json");
+        const CORPUS: &str = include_str!("../testdata/script-realm-corpus.json");
         let doc: serde_json::Value = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
         let probes = doc["probes"].as_array().expect("probes array");
         assert!(!probes.is_empty(), "an empty corpus asserts nothing");

--- a/crates/tropel-engine/testdata/resolve-corpus.json
+++ b/crates/tropel-engine/testdata/resolve-corpus.json
@@ -1,0 +1,1 @@
+../../../packages/core-wasm/fixtures/resolve-corpus.json

--- a/crates/tropel-engine/testdata/script-realm-corpus.json
+++ b/crates/tropel-engine/testdata/script-realm-corpus.json
@@ -1,0 +1,1 @@
+../../../packages/shims/fixtures/script-realm-corpus.json

--- a/scripts/include-paths-in-crate.sh
+++ b/scripts/include-paths-in-crate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Every include_str!/include_bytes!/include! path must resolve INSIDE its own
+# crate directory.
+#
+# This exists because tropel-input-k6 0.6.0 was published BROKEN and cargo
+# said it was fine. Its sources embedded the repo-root js/ tree via
+# `include_str!("../../../../js/...")`. Cargo cannot package files from
+# outside a package root, so the tarball shipped without them — but the
+# verify build passed, because cargo verifies inside `target/package/`, which
+# is INSIDE the repo: from `target/package/<crate>/src/`, four `..` climb back
+# out to the real repo root and find the real js/ tree. The deeper a crate
+# sits under crates/, the more likely its own escape path lands somewhere
+# real. tropel-web, one level shallower, failed loudly; tropel-input-k6
+# published silently and nobody could build it.
+#
+# So a green `cargo publish --dry-run`, verify build included, does NOT prove
+# a tarball is self-contained. This check does, statically and in a second:
+# a path that does not escape the crate root cannot resolve to a file the
+# tarball lacks.
+#
+# Paths are normalised LEXICALLY, not with realpath — `crates/x/src/../js/a.js`
+# must read as `crates/x/js/a.js`. The js/ entry in those crates is a symlink
+# to the single tree at the repo root, which cargo dereferences into the
+# tarball; resolving symlinks here would report the real target outside the
+# crate and defeat the check.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+python3 - <<'PY'
+import os, re, sys
+
+pat = re.compile(r'include(?:_str|_bytes)?!\s*\(\s*"([^"]+)"\s*\)')
+roots = []
+for base in ('crates',):
+    for dirpath, dirnames, filenames in os.walk(base):
+        if 'target' in dirpath.split(os.sep):
+            continue
+        if 'Cargo.toml' in filenames:
+            roots.append(dirpath)
+            dirnames[:] = [d for d in dirnames if d != 'target']
+
+bad = []
+checked = 0
+for root in sorted(roots):
+    for sub in ('src', 'tests', 'benches', 'examples'):
+        for dirpath, _, filenames in os.walk(os.path.join(root, sub)):
+            for fn in filenames:
+                if not fn.endswith('.rs'):
+                    continue
+                f = os.path.join(dirpath, fn)
+                try:
+                    src = open(f, encoding='utf-8', errors='replace').read()
+                except OSError:
+                    continue
+                for m in pat.finditer(src):
+                    p = m.group(1)
+                    checked += 1
+                    # lexical, NOT realpath — see the header
+                    resolved = os.path.normpath(os.path.join(os.path.dirname(f), p))
+                    if os.path.relpath(resolved, root).startswith('..'):
+                        line = src[:m.start()].count('\n') + 1
+                        bad.append((f, line, p, root))
+
+print(f"── include! paths confined to their crate ──")
+print(f"{checked} literal include paths checked across {len(roots)} crates")
+if bad:
+    print(f"\n{len(bad)} ESCAPE their crate root — these package into a tarball")
+    print("that cannot build, even if `cargo publish` verifies locally:\n")
+    for f, line, p, root in bad:
+        print(f"  {f}:{line}")
+        print(f"      {p}   escapes {root}/")
+    sys.exit(1)
+print("ok: none escape")
+PY


### PR DESCRIPTION
`tropel-input-k6 0.6.0` was published containing none of the shim sources its own
`driver.rs` embeds — and every check we had said it was fine.

`cargo publish` runs its verify build inside `target/package/`, which is **inside the
repo**. So from `target/package/<crate>/src/`, an escaping relative path can climb
straight back out and find the real file. Whether that happens is decided by nothing
but how deep the crate sits:

| crate | escape resolves to | outcome |
|---|---|---|
| `tropel-web` (`crates/<name>/`) | `target/js` — nothing there | failed loudly |
| `tropel-input-k6` (`crates/inputs/<name>/`) | the real repo root | compiled, shipped a tarball nobody can build |

**A green verify build is not evidence that a tarball is self-contained.**

## The check

No `include_str!` / `include_bytes!` / `include!` path may leave its own crate
directory. A path that cannot escape cannot reference a file the tarball lacks,
whatever cargo's verify step happens to resolve. Static, no toolchain, ~1 second.

Paths are normalised **lexically**, not through `realpath` — otherwise every `js`
symlink would report its target outside the crate and the check would fail on the
very mechanism that fixes it.

Wired into `ci-ok`. It's cheap enough that there's no reason for it to be advisory,
unlike the publish dry-run job, which stays non-blocking because its blockers are
release facts rather than code.

## What it found immediately

Four more escapes, none of them js — `tropel-core-wasm` and `tropel-engine` both
reach into `packages/` for test corpora:

```
crates/tropel-core-wasm/src/lib.rs:728  ../../../packages/core-wasm/fixtures/resolve-corpus.json
crates/tropel-core-wasm/src/lib.rs:969  ../../../packages/core-wasm/src/index.js
crates/tropel-engine/src/agent.rs:2978  ../../../packages/core-wasm/fixtures/resolve-corpus.json
crates/tropel-engine/src/agent.rs:4112  ../../../packages/shims/fixtures/script-realm-corpus.json
```

All four are `#[cfg(test)]`, so no consumer was ever affected. But:

- `tropel-core-wasm 0.6.0` is **already live** with tests that cannot build from its
  own tarball (as are `tropel-runtime 0.6.0` and `tropel-sandbox 0.6.0`, same cause)
- `tropel-engine` was about to be published for the **first time** carrying the same
  flaw — fixed before it ships rather than after

Those fixtures come in the same way the shims did, by symlink. Cargo dereferences a
symlinked *file* into the tarball exactly as it does a symlinked directory, so there
is still one copy in the repo and nothing can drift.

## Verification

- the check passes: **192** literal include paths across 36 crates, none escape
- `cargo check --workspace --all-targets` passes
- `tropel-engine`'s tarball now carries **11 of 11** files it embeds (was 9 of 11)
