### PR TITLE
build(release): fat LTO for the binaries we ship, and shorter release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,24 @@ jobs:
         run: |
           set -euo pipefail
           tool=$([[ "$CROSS" == "true" ]] && echo cross || echo cargo)
+          # FAT LTO for the binaries we actually ship.
+          #
+          # [profile.release] uses thin LTO because every PR compiles it and
+          # fat + codegen-units=1 is the slowest configuration cargo offers —
+          # the release-wasm profile documents that trade with a measurement
+          # (thin cost core-wasm 15,396 B, +2.7%, against fat). None of that
+          # reasoning applies here: this job runs once per tag, so build time
+          # is worth nothing and the shipped binary should be the best one the
+          # toolchain can produce. With codegen-units = 1 already set, fat is
+          # the maximal configuration.
+          #
+          # Passed as --config rather than CARGO_PROFILE_RELEASE_LTO because
+          # two of the five targets build through `cross`, which runs cargo in
+          # a container and does not forward arbitrary CARGO_* env vars — the
+          # env form would have silently skipped both musl targets while
+          # appearing to work.
           $tool build --release --locked --target "$T" \
+            --config 'profile.release.lto="fat"' \
             -p tropel -p tropel-distributed
 
       # Ship the distributed binaries too: a load generator that cannot be run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,19 @@ license = "Apache-2.0"
 repository = "https://github.com/transithq/tropel"
 rust-version = "1.94"
 
-# Native release profile. Optimized for load generation: thin LTO for
-# size, single codegen unit for best optimization, symbols stripped.
+# Native release profile. Optimized for load generation: single codegen unit
+# for best optimization, symbols stripped.
+#
+# `lto = "thin"` is a BUILD-TIME choice, not a size one. This profile said
+# "thin LTO for size" and had it backwards — the release-wasm profile below
+# measures the trade the other way: thin cost core-wasm 15,396 B (+2.7%)
+# against fat. Thin is here because every PR compiles this profile and fat
+# with codegen-units = 1 is the slowest configuration cargo offers.
+#
+# The binaries we SHIP do not inherit that compromise: release.yml overrides
+# this to `fat` per build, where the job runs once per tag and wall-clock is
+# worth nothing.
+#
 # Do NOT set panic = "abort" — the VU pool depends on unwinding.
 [profile.release]
 lto           = "thin"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -8,10 +8,15 @@
 # buries the release being announced, and it shipped withdrawn measurements
 # from old entries as if they were current.
 #
-# This emits what an open-source release page is actually for: what the thing
-# is, how to install it on each platform, how to verify the download, what is
-# inside each archive, and the highlights for THIS version — then links to the
-# full changelog rather than inlining it.
+# This emits what an open-source release page is actually for: what changed,
+# and one command to get the thing. Everything else — the other four
+# platforms, checksum verification, building from source, and the version's
+# full changelog section — sits behind <details>, because a release page that
+# opens with five curl blocks buries the one thing the reader came for.
+#
+# What tropel IS, its feature list and its quick start are deliberately NOT
+# here. They are the README's job, and duplicating them meant every release
+# page restated them and then drifted from them.
 #
 # The highlights come from CHANGELOG.md's own `## [x.y.z]` section, so the
 # release notes cannot drift from the changelog. A missing section is a hard
@@ -34,37 +39,45 @@ if [[ -z "$(tr -d '[:space:]' <<<"$SECTION")" ]]; then
   exit 1
 fi
 
-cat <<EOF
-**Tropel** is an open-source load-testing framework in Rust. It runs
-**Postman collections**, **HAR files**, **OpenAPI specs**, **Bruno** and
-**Insomnia** exports, and **k6 scripts** as load tests — a native Rust hot
-path with an embedded QuickJS engine for script execution.
+# Visible summary: the section's own lead paragraphs, then its `###` headings
+# as bullets. The full section still ships, collapsed — a breaking-change note
+# lives in a heading's BODY (0.6.0's tropel-auth signature change did), so
+# headings alone would drop exactly what a reader must not miss.
+LEAD=$(awk '/^### /{exit} {print}' <<<"$SECTION")
+BULLETS=$(grep '^### ' <<<"$SECTION" | sed 's/^### /- **/; s/$/**/')
 
-> **Pre-1.0: the API is unstable.** k6 parity is actively expanding and the
-> \`tropel-sdk\` surface still changes between minor versions. Pin an exact
-> version if you depend on it.
+cat <<EOF
+$LEAD
+
+$BULLETS
+
+<details>
+<summary><b>Full notes for $V</b></summary>
+$SECTION
+</details>
 
 ## Install
 
-Pick your platform. Linux builds are **static musl** — they run unmodified in
-Alpine, distroless and scratch containers.
+Linux builds are **static musl** — they run unmodified in Alpine, distroless
+and scratch containers.
 
 \`\`\`bash
-# Linux x86_64
 curl -fsSL https://github.com/transithq/tropel/releases/download/v$V/tropel-v$V-x86_64-unknown-linux-musl.tar.gz | tar xz
 sudo install -m755 tropel-v$V-x86_64-unknown-linux-musl/tropel /usr/local/bin/
+\`\`\`
 
+<details>
+<summary><b>Other platforms, checksum verification, building from source</b></summary>
+
+\`\`\`bash
 # Linux arm64
 curl -fsSL https://github.com/transithq/tropel/releases/download/v$V/tropel-v$V-aarch64-unknown-linux-musl.tar.gz | tar xz
-sudo install -m755 tropel-v$V-aarch64-unknown-linux-musl/tropel /usr/local/bin/
 
 # macOS Apple Silicon
 curl -fsSL https://github.com/transithq/tropel/releases/download/v$V/tropel-v$V-aarch64-apple-darwin.tar.gz | tar xz
-sudo install -m755 tropel-v$V-aarch64-apple-darwin/tropel /usr/local/bin/
 
 # macOS Intel
 curl -fsSL https://github.com/transithq/tropel/releases/download/v$V/tropel-v$V-x86_64-apple-darwin.tar.gz | tar xz
-sudo install -m755 tropel-v$V-x86_64-apple-darwin/tropel /usr/local/bin/
 \`\`\`
 
 Windows (PowerShell):
@@ -74,72 +87,27 @@ Invoke-WebRequest -Uri "https://github.com/transithq/tropel/releases/download/v$
 Expand-Archive tropel.zip -DestinationPath .
 \`\`\`
 
-macOS note: binaries are unsigned, so Gatekeeper will quarantine a downloaded
-archive. Clear it with \`xattr -d com.apple.quarantine ./tropel\`.
-
-### Verify your download
+macOS binaries are unsigned, so Gatekeeper quarantines a downloaded archive.
+Clear it with \`xattr -d com.apple.quarantine ./tropel\`.
 
 \`\`\`bash
 curl -fsSLO https://github.com/transithq/tropel/releases/download/v$V/SHA256SUMS
 sha256sum -c SHA256SUMS --ignore-missing      # macOS: shasum -a 256 -c
 \`\`\`
 
-### From source (Rust 1.94+)
+From source (Rust 1.94+): \`cargo build --release\` puts it at
+\`./target/release/tropel\`.
 
-\`\`\`bash
-cargo build --release      # ./target/release/tropel
-\`\`\`
+</details>
 
-## Assets
+Each \`tropel-v$V-<target>\` archive carries \`tropel\`, \`tropel-controller\` and
+\`tropel-agent\`; \`tropel-wasm-v$V.tar.gz\` is the browser tier
+(\`core-wasm\`, \`input-wasm\`, \`runtime-wasm\`, \`shims\`, also on npm at
+\`$V\`); \`SHA256SUMS\` covers every asset.
 
-| asset | contents |
-|---|---|
-| \`tropel-v$V-<target>.tar.gz\` / \`.zip\` | \`tropel\`, \`tropel-controller\`, \`tropel-agent\` + LICENSE, README |
-| \`tropel-wasm-v$V.tar.gz\` | the browser/edge tier — \`core-wasm\`, \`input-wasm\`, \`runtime-wasm\`, \`shims\` |
-| \`SHA256SUMS\` | checksums over every asset above |
-
-Targets: \`x86_64\`/\`aarch64\` Linux (musl), \`x86_64\`/\`aarch64\` macOS,
-\`x86_64\` Windows (MSVC).
-
-## Quick start
-
-\`\`\`bash
-tropel run collection.json --vus 50 --duration 2m   # Postman, HAR, OpenAPI, k6, Bruno, Insomnia
-tropel inspect collection.json                      # preview without sending traffic
-tropel extensions                                   # list the input formats this binary ships
-\`\`\`
-
-Full docs: [docs/](https://github.com/transithq/tropel/tree/v$V/docs) — CLI
-reference, executors, scripting, metrics, extensions, distributed execution.
-
-## What's in it
-
-- **Seven executors** — constant-vus, ramping-vus, shared/per-vu iterations,
-  constant & ramping arrival rate, externally-controlled, with graceful
-  stop/ramp-down, think time and pacing
-- **Postman \`pm.*\` scripting** — tests, assertions, variable scopes,
-  \`setNextRequest\`, \`sendRequest\`, custom metrics
-- **k6-style scripting** — \`http.*\`, \`check()\`, \`group()\`, \`sleep()\`,
-  \`Counter\`/\`Gauge\`/\`Rate\`/\`Trend\`; exported \`options\` honoured
-- **HDR-histogram metrics** — p50/p90/p95/p99, sub-timings, tag-scoped
-  aggregation, thresholds with k6-compatible abort semantics
-- **Streaming outputs** — NDJSON, StatsD, InfluxDB, Prometheus, OTLP
-  (protobuf + gzip), plus stdout/JSON/CSV reporters
-- **Distributed** — k6-style execution segments for multi-node runs
-- **Extensible** — \`tropel-sdk\` + \`tropel build --with <crate>\`, plus a
-  sandboxed WASM plugin tier for third-party input formats
-
-## npm packages
-
-\`\`\`
-@tropel/core-wasm@$V   @tropel/input-wasm@$V   @tropel/runtime-wasm@$V   @tropel/shims@$V
-\`\`\`
-
-## Changes in $V
-$SECTION
 ---
 
-Full changelog: [CHANGELOG.md](https://github.com/transithq/tropel/blob/v$V/CHANGELOG.md) ·
-Issues: [github.com/transithq/tropel/issues](https://github.com/transithq/tropel/issues) ·
-Licence: Apache-2.0
+[Full changelog](https://github.com/transithq/tropel/blob/v$V/CHANGELOG.md) ·
+[Docs](https://github.com/transithq/tropel/tree/v$V/docs) ·
+[Issues](https://github.com/transithq/tropel/issues) · Apache-2.0
 EOF


### PR DESCRIPTION
The shipped binaries were built with the profile tuned for PR wall-clock.

**Fat LTO for release builds.** `[profile.release]` uses `lto = "thin"` because every PR compiles it and fat + `codegen-units = 1` is the slowest configuration cargo offers. None of that applies to `release.yml`, which runs **once per tag** — so it now overrides to fat per build. With `codegen-units = 1` already set, fat is the maximal configuration.

Passed as `--config 'profile.release.lto="fat"'` rather than `CARGO_PROFILE_RELEASE_LTO`, because two of the five targets build through `cross`, which runs cargo in a container and does **not** forward arbitrary `CARGO_*` env vars — the env form would have silently skipped both musl targets while appearing to work.

**The profile comment was backwards.** It read *"thin LTO for size"*. Thin **costs** size, and the `release-wasm` profile directly below measures it: **15,396 B, +2.7%** on core-wasm against fat. Thin is a build-time choice; the comment now says so.

**Release notes lead with what changed.** The generator opened with five curl blocks, a feature list and a quick start before reaching the changelog, then inlined the entire section — so the page restated the README and buried the news.

Now: the section's lead paragraphs, its `###` headings as bullets, one install command. Other platforms, checksum verification, building from source and the full section move behind `<details>`.

The full section is **kept**, not reduced to headings — a breaking change can live in a heading's *body* (0.6.0's `tropel-auth` signature change does), so headings alone would drop precisely what a reader must not miss.

What tropel *is*, its feature list and quick start are dropped: that's the README's job, and duplicating it meant every release page restated and then drifted from it.