### PR TITLE
docs(publish): the runtime-set notes describe a tree that is no longer true

### DIFF
--- a/scripts/publish-runtime.sh
+++ b/scripts/publish-runtime.sh
@@ -11,16 +11,22 @@
 #   variables → js → native → auth → sandbox → runtime
 #
 # Notes:
-#   - tropel-sdk must be live at the workspace version (currently 0.3.0) — the
+#   - tropel-sdk must be live at the workspace version (currently 0.4.0) — the
 #     leaf everything else builds on; publish it before running --execute (the
 #     API-presence gate verifies the exact published artifact).
-#   - tropel-http is NOT in the set (F1, review fix): it was published by
-#     accident because sandbox's `send-request` used `dep:tropel-http`; the
-#     sandbox now routes pm.sendRequest through the SDK `DriverHttpClient`
-#     trait and `publish = false` blocks future publishes. The accidental
-#     0.1.0 has been YANKED on crates.io (cargo yank --version 0.1.0
-#     tropel-http, 2026-08-10), so consumers resolving it get an error instead
-#     of a stale internal crate; no new publish step references it.
+#   - CRATES below is no longer "the published crates". As of 0.6.0 the WHOLE
+#     tree is on crates.io (`chore: 0.6.0, and publish the whole crate tree`),
+#     36 crates including every one this list omits. What survives is the
+#     ordered RUNTIME release: the set whose publish order is load-bearing and
+#     whose API presence the gate below verifies.
+#   - tropel-http therefore is published, at 0.6.0, deliberately. This comment
+#     used to say it was excluded because a 0.1.0 went out by accident (it did,
+#     via sandbox's `dep:tropel-http`, and that version is still YANKED) and
+#     that "`publish = false` blocks future publishes". That guard was never
+#     added — no crate in this workspace carries `publish = false` — so it
+#     blocked nothing, and the 0.6.0 tree publish took tropel-http with it.
+#     Saying so plainly because the old wording would have a reader believe a
+#     live crate is unpublishable.
 #   - Real publishes happen only after the BACKLOG_V2 Phase 0–2 release gate;
 #     this script defaults to --dry-run so the sequence is exercised, not
 #     executed, until you pass --execute.


### PR DESCRIPTION
`publish-runtime.sh`'s header makes three claims about the published tree. Two are false.

**`tropel-sdk` "currently 0.3.0"** — it is **0.4.0**, and live.

**`tropel-http` "is NOT in the set … `publish = false` blocks future publishes"** — that guard was never added. No crate in this workspace carries `publish = false`, so it blocked nothing, and the 0.6.0 tree publish took `tropel-http` with it. It is **live at 0.6.0** right now. The yank of the accidental `0.1.0` is the part still accurate and it stays.

**`CRATES` reads as "the published crates"** — it has not been that since `chore: 0.6.0, and publish the whole crate tree` put all 36 on crates.io. What it still is: the ordered *runtime* release, the set whose publish order is load-bearing and whose API presence the gate verifies. Now says so.

Documentation only. I am deliberately **not** adding the `publish = false` guard the old comment claims exists — publishing the whole tree is the current intent, and the defect is a reader being told a live crate is unpublishable.

### Deliberately not fixed here

`tropel-runtime`, `tropel-sandbox` and `tropel-core-wasm` are live at 0.6.0 carrying `#[cfg(test)]` code that cannot build from their own tarballs (out-of-crate `include_str!`, the same root cause as #593/#595). The source fix is already on master, so their next release carries it. Cutting 0.6.1 for three crates now would burn versions for a defect that reaches nobody depending on the libraries — only someone running `cargo test` against a published tarball.